### PR TITLE
fix(gates): make task-list closure enforceable and gate advisories audible (#1435)

### DIFF
--- a/.claude/guidance/shipped/moflo-claude-swarm-cohesion.md
+++ b/.claude/guidance/shipped/moflo-claude-swarm-cohesion.md
@@ -119,7 +119,15 @@ TaskList()  // Shows what's now unblocked
 TaskUpdate({ taskId: "2", status: "in_progress" })  // Next agent starts
 ```
 
-Close every task you open. moflo's PR gate reads the session transcript on `gh pr create` and prints `N tasks created this session, M still open` — an unclosed list reports as unfinished work on the PR. Mark tasks that no longer apply `status: "deleted"`; that closes the loop exactly like `completed`.
+**Close every task you open — `gh pr create` is blocked until you do.** moflo's PR gate reads the session transcript, counts the tasks this session opened against the ones it closed, and stops the PR while any remain open. A stale list reports work as not-started that is about to merge.
+
+| Situation | Action |
+|-----------|--------|
+| The work is done | `TaskUpdate({ taskId: "1", status: "completed" })` |
+| The task no longer applies | `TaskUpdate({ taskId: "1", status: "deleted" })` — closes the loop exactly like `completed` |
+| The work is deliberately deferred past this PR | Run the acknowledgement command the block message prints — it credits the gate and leaves the tasks open |
+
+Never mark a task `completed` to clear the gate. The acknowledgement path exists so the honest outcome costs one command; a false `completed` costs the user their only accurate view of what shipped. Set `gates: task_status_gate: warn` in `moflo.yaml` to report instead of block, or `off` to silence it.
 
 ---
 

--- a/.claude/helpers/gate-hook.mjs
+++ b/.claude/helpers/gate-hook.mjs
@@ -114,6 +114,34 @@ if (hookContext.tool_response && typeof hookContext.tool_response === 'object') 
   }
 }
 
+// #1435 — deliver a PASSING gate's advisory to Claude, not only to the transcript.
+//
+// Claude Code shows a PreToolUse/PostToolUse hook's stdout to the user in
+// transcript mode and stops there; the model never sees it. So every advisory
+// the gates emit on the exit-0 path was invisible on exactly the runs it was
+// written for: #1374's open-task count, the pre-Agent TaskCreate reminder, the
+// namespace hint, the docs-only and simplify-auto-pass notes. They surfaced only
+// when some OTHER gate blocked, because the catch arm below re-routes err.stdout
+// to stderr — i.e. only once the PR had already been stopped for another reason.
+// A consumer shipped a PR over four untouched tasks with that reminder "working".
+//
+// `hookSpecificOutput.additionalContext` is the documented channel from a passing
+// tool hook into the model's context. Wrap there and nowhere else: SessionStart
+// and UserPromptSubmit already inject their stdout as context, so wrapping those
+// would rewrite a working path for nothing. An unknown or absent hook_event_name
+// falls back to raw stdout — byte-identical to the previous behaviour.
+var ADVISORY_EVENTS = { PreToolUse: true, PostToolUse: true };
+function emitAdvisory(text) {
+  var event = hookContext.hook_event_name;
+  if (!ADVISORY_EVENTS[event]) {
+    process.stdout.write(text);
+    return;
+  }
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: { hookEventName: event, additionalContext: text },
+  }) + '\n');
+}
+
 // Run gate.cjs with the enriched environment
 var projectDir = (env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var gateScript = resolve(projectDir, '.claude/helpers/gate.cjs');
@@ -121,7 +149,7 @@ try {
   var output = execFileSync('node', [gateScript, command], {
     env: env, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true
   });
-  if (output.trim()) process.stdout.write(output);
+  if (output.trim()) emitAdvisory(output);
   process.exit(0);
 } catch (err) {
   // gate.cjs exit(2) = block, exit(1) = also block attempt — translate both to exit(2)

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -13,7 +13,7 @@ var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
 // the code it describes, so a change made outside Write/Edit/MultiEdit (a Bash
 // write, a branch switch, the next issue in the same session) invalidates it.
 // See creditFingerprint() for why the boolean flags alone cannot.
-var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, testsFingerprint: null, simplifyRun: false, simplifySnapshotSha: null, simplifyFingerprint: null, verifyRun: false, verifyOutcome: null, verifyFingerprint: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '', lastNamespaceHintEmittedBy: {}, flMode: null, swarmInitialized: false, hiveInitialized: false, sddMode: false, activeSddSlug: null };
+var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, tasksAcknowledged: false, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, testsFingerprint: null, simplifyRun: false, simplifySnapshotSha: null, simplifyFingerprint: null, verifyRun: false, verifyOutcome: null, verifyFingerprint: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '', lastNamespaceHintEmittedBy: {}, flMode: null, swarmInitialized: false, hiveInitialized: false, sddMode: false, activeSddSlug: null };
 
 // Per-actor memory-search tracking (#838). The legacy `memorySearched` boolean
 // is session-wide, so once the parent searches memory, every spawned subagent
@@ -70,9 +70,24 @@ function loadGateConfig() {
   // ships a real /verify skill and has /flo delegate to it, so leaving it off by
   // default would make the default /flo run silently skip the acceptance check.
   // Disable per-project with `verify_before_done: false` or per-run `--no-verify`.
-  var defaults = { memory_first: true, task_create_first: true, context_tracking: true, testing_gate: true, simplify_gate: true, learnings_gate: true, swarm_invocation_gate: true, verify_before_done: true, sdd_gate: true };
+  // task_status_gate is a MODE, not a boolean: 'block' | 'warn' | 'off' (#1435).
+  // #1374 shipped the open-task count as a warn-only stdout line, and a consumer
+  // still shipped a PR over four untouched tasks — a reminder that survived ten
+  // consecutive ignores in one session is not a control. Blocking is the default
+  // because the honest "these stay open on purpose" outcome is one command away
+  // (record-tasks-acknowledged), so nothing here can deadlock a run.
+  var defaults = { memory_first: true, task_create_first: true, context_tracking: true, testing_gate: true, simplify_gate: true, learnings_gate: true, swarm_invocation_gate: true, verify_before_done: true, sdd_gate: true, task_status_gate: 'block' };
   var content = MOFLO_YAML;
   if (content) {
+    // Boolean forms are accepted so this key reads like every other gate in the
+    // block: `false` is the same opt-out `testing_gate: false` is, `true` means
+    // enforce. Anything unrecognised falls through to the default rather than
+    // silently disabling the gate — a typo must not be a stealth opt-out.
+    var tsg = /task_status_gate:\s*['"]?(block|warn|off|false|true)['"]?/i.exec(content);
+    if (tsg) {
+      var mode = tsg[1].toLowerCase();
+      defaults.task_status_gate = mode === 'false' ? 'off' : mode === 'true' ? 'block' : mode;
+    }
     if (/memory_first:\s*false/i.test(content)) defaults.memory_first = false;
     if (/task_create_first:\s*false/i.test(content)) defaults.task_create_first = false;
     if (/context_tracking:\s*false/i.test(content)) defaults.context_tracking = false;
@@ -1374,6 +1389,41 @@ switch (command) {
     writeState(s);
     break;
   }
+  // #1435 — the escape from the task-status gate, for work deliberately left
+  // open. Session-scoped like `learningsStored`: it lives in STATE_DEFAULTS, so
+  // session-reset clears it, and neither applyPromptStateReset nor
+  // reset-edit-gates touches it — a decision the user made about the task list
+  // is not invalidated by the next prompt or the next source edit.
+  //
+  // A plain flag, not a count. The command is typed by the model into a Bash
+  // tool, where HOOK_TRANSCRIPT_PATH is unset (it is forwarded by gate-hook.mjs
+  // from the hook payload and exists only inside a hook), so this process cannot
+  // read the ledger to record WHICH tasks were acknowledged even if it wanted to.
+  case 'record-tasks-acknowledged': {
+    var s = readState();
+    if (!s.tasksAcknowledged) {
+      s.tasksAcknowledged = true;
+      writeState(s);
+    }
+    // writeState swallows its own errors by design — a gate must never crash the
+    // hook it runs in. That was harmless while every recorder was advisory. This
+    // one is the ONLY escape from a BLOCKING gate, so a lost write would report
+    // "satisfied" and then block the very next `gh pr create` with nothing said
+    // about why: #1332's deadlock shape exactly. Confirm it landed before
+    // claiming it did, and name the file and the way out when it did not.
+    if (!readState().tasksAcknowledged) {
+      process.stderr.write(
+        'Task-status gate NOT satisfied: the acknowledgement could not be persisted to\n' +
+        STATE_FILE + '\n' +
+        'Check that the file and its directory are writable, then run this again.\n' +
+        'To proceed without it: set gates: task_status_gate: off in moflo.yaml.\n');
+      process.exit(1);
+    }
+    process.stdout.write(
+      'Task-status gate satisfied: open tasks acknowledged as deliberately deferred.\n' +
+      'They stay visible in the task list — this records the decision, it does not close them.\n');
+    break;
+  }
   case 'record-memory-searched': {
     var s = readState();
     if (markMemorySearched(s)) writeState(s);
@@ -1683,25 +1733,46 @@ switch (command) {
     // chained, piped, parenthesised, and multi-line shapes (#1410).
     var cmd = process.env.TOOL_INPUT_command || '';
     if (!isPrCreateCommand(cmd)) break;
-    // #1374 — close the loop the TaskCreate reminder opens. Advisory: stdout,
-    // no exit, and worded as a reminder, because a message may only claim to
-    // block when it blocks (#1326). An open task list is a reporting failure,
-    // not a quality failure — blocking the PR on it would be a new deadlock.
+    // #1374 opened this loop; #1435 closes it. The count itself is unchanged —
+    // what changed is that it now has teeth and, in warn mode, a delivery path.
     //
     // Deliberately ABOVE the no-source exemption below: a docs-only PR can
     // abandon a list exactly like a source PR can, and the exemption is about
     // testing/simplify/learnings, not about whether the run told the user what
-    // it did. Gated on the same `task_create_first` flag as the reminder itself
-    // so the two halves are always consistent — a project that turned the nag
-    // off is not then nagged about the other end of it.
-    if (config.task_create_first) {
+    // it did. It also exits on its own rather than joining `missing` below, for
+    // the same reason — `missing` is unreachable on an exempt diff.
+    //
+    // Gated on the same `task_create_first` flag as the reminder itself so the
+    // two halves are always consistent: a project that turned the nag off is
+    // not then blocked about the other end of it.
+    //
+    // Fail-open is load-bearing. readTaskLedger() returns null on a missing,
+    // oversized, or unreadable transcript and on a session with no TaskCreate at
+    // all, and null must never block — a gate that stops PRs because it could
+    // not read a file is worse than the reporting gap it is closing.
+    //
+    // State is read ONCE for the whole case, here — the pre-PR gate logic below
+    // reuses it and nothing writes in between. Reading it before the ledger also
+    // means an already-acknowledged run never pays for the transcript scan.
+    var s = readState();
+    if (config.task_create_first && config.task_status_gate !== 'off' && !s.tasksAcknowledged) {
       var ledger = readTaskLedger();
       if (ledger && ledger.open > 0) {
-        process.stdout.write(
-          'REMINDER: ' + ledger.created + ' task' + (ledger.created === 1 ? '' : 's') +
-          ' created this session, ' + ledger.open + ' still open. Close them with ' +
-          'TaskUpdate (status: completed), or delete the ones that no longer apply, ' +
-          'so the run does not report done over an unfinished list.\n');
+        var tally = ledger.created + ' task' + (ledger.created === 1 ? '' : 's') +
+          ' created this session, ' + ledger.open + ' still open.';
+        var closeIt = 'Close them with TaskUpdate (status: completed), or delete the ones ' +
+          'that no longer apply, so the run does not report done over an unfinished list.\n';
+        if (config.task_status_gate === 'warn') {
+          process.stdout.write('REMINDER: ' + tally + ' ' + closeIt);
+        } else {
+          process.stderr.write(
+            'BLOCKED: ' + tally + '\n' + closeIt +
+            'Deferring them on purpose is a legitimate outcome — declare it instead of\n' +
+            'closing tasks that are not done: node "' + __filename + '" record-tasks-acknowledged\n' +
+            GATE_ORIGIN_NOTE + '\n' +
+            'Report instead of blocking via moflo.yaml: gates: task_status_gate: warn   (or: off)\n');
+          process.exit(2);
+        }
       }
     }
     // No-source-files exemption (#1176, supersedes the original docs-only path).
@@ -1726,7 +1797,6 @@ switch (command) {
         break;
       }
     }
-    var s = readState();
     // Expire any credit whose fingerprint no longer matches the code before
     // reading the flags. This is what catches the mutations reset-edit-gates
     // structurally cannot see — Bash writes, git checkout/pull/merge, and the

--- a/.claude/skills/fl/SKILL.md
+++ b/.claude/skills/fl/SKILL.md
@@ -107,9 +107,11 @@ research → ticket → execute → tests → simplify → learnings → pr
 | Tests | Run unit + integration + E2E |
 | Simplify | Run `/flo-simplify` on changed code |
 | Learnings | Store a **durable** lesson — one that helps a *different* future task — or declare there is none. A run summary belongs in the PR body, never in memory |
-| PR | Open the PR, update issue status |
+| PR | Close every task this run opened, then open the PR and update issue status |
 
-The tests, simplify, and learnings steps are enforced by hooks. `gh pr create` is blocked by `check-before-pr` until each has run in the current session. Skill text describes the flow; the gates handle compliance.
+The tests, simplify, learnings, and task-closure steps are enforced by hooks. `gh pr create` is blocked by `check-before-pr` until each has run in the current session. Skill text describes the flow; the gates handle compliance.
+
+**Close the task list before the PR, and close it honestly.** `TaskUpdate` each task `completed`, or `deleted` if it no longer applies. Work deliberately left open is a legitimate outcome — the block message prints a one-command acknowledgement for it. Never mark a task `completed` just to clear the gate: the list is the user's only view of what actually shipped.
 
 ## Companion files
 

--- a/.claude/skills/fl/phases.md
+++ b/.claude/skills/fl/phases.md
@@ -230,6 +230,16 @@ unblock the PR.
 
 ### 5.3 Create the PR
 
+**Close the task list first.** `TaskUpdate` every task this run opened to `completed`, or to `deleted` where it no longer applies; `check-before-pr` blocks `gh pr create` while any stay open, because a list that still reads *pending* over merged work is the user's only view of what shipped.
+
+| Task state at PR time | Action |
+|-----------------------|--------|
+| Work finished | `TaskUpdate({ taskId: "<id>", status: "completed" })` |
+| No longer applies | `TaskUpdate({ taskId: "<id>", status: "deleted" })` |
+| Deliberately deferred past this PR | Run the acknowledgement command printed in the block message — it credits the gate and leaves the tasks open |
+
+Never mark a task `completed` to clear the gate. Declaring the deferral takes one command and keeps the list true.
+
 In epic mode (`--epic-branch` set): skip the PR. The commit from 5.1 (with `Closes #<issue-number>`) is enough; the epic orchestrator handles the consolidated PR and final push. Skip pushing too.
 
 Otherwise:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — task lists shipped stale, and the reminder that was supposed to catch it was invisible (#1435)
+
+A `/flo` run on a consumer project created four tasks, completed all four items of work, verified,
+committed, and shipped a green PR with `TaskUpdate` called **zero** times. All four tasks ended the
+run at `pending`. #1374 had already added the check that was supposed to catch exactly this.
+
+It was running. It just could not be heard. The open-task count is written to **stdout**, and
+`check-before-pr` exits 0 when the other gates pass — and Claude Code surfaces a passing
+PreToolUse hook's stdout in transcript mode only. The model never sees it, and the user sees it
+only by opening the transcript. It reached anyone at all only when some *other* gate blocked, because
+`gate-hook.mjs` re-routes a failed gate's stdout to stderr. So the closing half of #1374 fired
+solely on runs that had already been stopped for another reason, and was a no-op on every clean one.
+
+Both halves are fixed:
+
+- **Passing-gate advisories now reach Claude.** `gate-hook.mjs` emits exit-0 stdout on `PreToolUse`
+  and `PostToolUse` as `hookSpecificOutput.additionalContext`, the documented channel into the
+  model's context. This repairs every advisory on that path, not just this one — the TaskCreate
+  reminder, the pre-Agent memory reminder, the namespace hint, and the docs-only / simplify-auto-pass
+  notes were all equally unheard. `SessionStart` and `UserPromptSubmit` already inject their stdout
+  as context and are deliberately untouched.
+- **Open tasks now block the PR.** New `gates.task_status_gate`: `block` (default), `warn` (the old
+  report-only behaviour, now actually delivered), or `off`. Deliberate deferrals stay legitimate —
+  the block prints `node "<abs path>/.claude/helpers/gate.cjs" record-tasks-acknowledged`, which
+  credits the gate without closing anything, so the honest outcome costs one command and no task is
+  ever marked `completed` to clear a gate. The gate stays subordinate to `task_create_first`, so a
+  project that turned the nag off is not blocked about the other end of it, and it fails **open**:
+  a missing, oversized, or unreadable transcript, or a session with no `TaskCreate` at all, blocks
+  nothing.
+
+**Consumer impact.** After upgrading, a session that opens tasks and leaves them open will be stopped
+at `gh pr create` until they are closed, deleted, or acknowledged. Set `gates: task_status_gate: warn`
+to keep report-only behaviour, or `off` to silence it.
+
 ### Fixed — the learnings gate manufactured filler instead of lessons (#1434)
 
 `check-before-pr` blocked `gh pr create` until some `memory_store` had run, and credited any write

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ MoFlo installs Claude Code hooks that run on every tool call. Together, these ga
 |------|-----------------|------------------|----------------|
 | **Memory-first** | Claude must search the memory database before using Glob, Grep, or Read on guidance files | Before every Glob/Grep call, and before Read calls targeting `.claude/guidance/` | Prevents the AI from re-exploring files it (or a previous session) already indexed. Forces it to check what it knows first, saving tokens and context window. |
 | **TaskCreate-first** | Claude must call TaskCreate before spawning sub-agents via the Task tool | Before every Task (agent spawn) call | Ensures every piece of delegated work is tracked. Prevents runaway agent proliferation where Claude spawns agents without a clear plan. |
+| **Task-status** *(blocks by default)* | The task list Claude opened must reflect reality before the PR — every task closed, deleted, or explicitly acknowledged as deferred | Before `gh pr create`, whenever the session opened tasks and left some open | A stale task list is worse than none: it reports as not-started work that is about to merge. Every other step here is gated on an artifact; this is the one that gates what the *user is shown*. Deliberate deferrals stay legitimate — the block prints a one-command acknowledgement. Set `task_status_gate: warn` to report without blocking, or `off`; `task_create_first: false` disables both halves. |
 | **Context tracking** | Tracks conversation length and warns about context depletion | On every user prompt (UserPromptSubmit hook) | As conversations grow, AI quality degrades. MoFlo tracks interaction count and assigns a bracket (FRESH → MODERATE → DEPLETED → CRITICAL), advising Claude to checkpoint progress or start a fresh session before quality drops. |
 | **Routing** | Analyzes each prompt and recommends the optimal agent type and model tier | On every user prompt (UserPromptSubmit hook) | Saves cost by suggesting haiku for simple tasks, sonnet for moderate ones, opus for complex reasoning — without you having to think about model selection. |
 | **Verify-before-done** *(on by default)* | Claude must verify the change end-to-end (the `/verify` skill) before `gh pr create` | Before `gh pr create` (docs-only diffs exempt) | Enforces "prove it works before done." On by default since #1294 (`/flo` delegates to `/verify` and reuses its test run — no double verify). Opt out with `verify_before_done: false` or `--no-verify`. Pairs with the [Spec-Driven Development](#spec-driven-development-sdd) cycle, which gives verification its acceptance criteria. |
@@ -321,7 +322,8 @@ All gates are configurable in `moflo.yaml`:
 ```yaml
 gates:
   memory_first: true          # Set to false to disable memory-first enforcement
-  task_create_first: true     # Set to false to disable TaskCreate enforcement
+  task_create_first: true     # Set to false to disable TaskCreate enforcement (disables task_status_gate too)
+  task_status_gate: block     # Open tasks block `gh pr create`; warn → report only; off → silent
   context_tracking: true      # Set to false to disable context bracket warnings
   verify_before_done: true    # On by default (#1294); set false to skip /verify before `gh pr create`
 ```
@@ -916,6 +918,7 @@ tests:
 gates:
   memory_first: true                 # Must search memory before file exploration
   task_create_first: true            # Must TaskCreate before Agent tool
+  task_status_gate: block            # Open tasks block `gh pr create`; warn → report only; off → silent
   context_tracking: true             # Track context window depletion
   verify_before_done: true           # On by default (#1294); /verify before `gh pr create` (unless --no-verify). false to disable
 

--- a/bin/gate-hook.mjs
+++ b/bin/gate-hook.mjs
@@ -114,6 +114,34 @@ if (hookContext.tool_response && typeof hookContext.tool_response === 'object') 
   }
 }
 
+// #1435 — deliver a PASSING gate's advisory to Claude, not only to the transcript.
+//
+// Claude Code shows a PreToolUse/PostToolUse hook's stdout to the user in
+// transcript mode and stops there; the model never sees it. So every advisory
+// the gates emit on the exit-0 path was invisible on exactly the runs it was
+// written for: #1374's open-task count, the pre-Agent TaskCreate reminder, the
+// namespace hint, the docs-only and simplify-auto-pass notes. They surfaced only
+// when some OTHER gate blocked, because the catch arm below re-routes err.stdout
+// to stderr — i.e. only once the PR had already been stopped for another reason.
+// A consumer shipped a PR over four untouched tasks with that reminder "working".
+//
+// `hookSpecificOutput.additionalContext` is the documented channel from a passing
+// tool hook into the model's context. Wrap there and nowhere else: SessionStart
+// and UserPromptSubmit already inject their stdout as context, so wrapping those
+// would rewrite a working path for nothing. An unknown or absent hook_event_name
+// falls back to raw stdout — byte-identical to the previous behaviour.
+var ADVISORY_EVENTS = { PreToolUse: true, PostToolUse: true };
+function emitAdvisory(text) {
+  var event = hookContext.hook_event_name;
+  if (!ADVISORY_EVENTS[event]) {
+    process.stdout.write(text);
+    return;
+  }
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: { hookEventName: event, additionalContext: text },
+  }) + '\n');
+}
+
 // Run gate.cjs with the enriched environment
 var projectDir = (env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var gateScript = resolve(projectDir, '.claude/helpers/gate.cjs');
@@ -121,7 +149,7 @@ try {
   var output = execFileSync('node', [gateScript, command], {
     env: env, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true
   });
-  if (output.trim()) process.stdout.write(output);
+  if (output.trim()) emitAdvisory(output);
   process.exit(0);
 } catch (err) {
   // gate.cjs exit(2) = block, exit(1) = also block attempt — translate both to exit(2)

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -13,7 +13,7 @@ var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
 // the code it describes, so a change made outside Write/Edit/MultiEdit (a Bash
 // write, a branch switch, the next issue in the same session) invalidates it.
 // See creditFingerprint() for why the boolean flags alone cannot.
-var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, testsFingerprint: null, simplifyRun: false, simplifySnapshotSha: null, simplifyFingerprint: null, verifyRun: false, verifyOutcome: null, verifyFingerprint: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '', lastNamespaceHintEmittedBy: {}, flMode: null, swarmInitialized: false, hiveInitialized: false, sddMode: false, activeSddSlug: null };
+var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, tasksAcknowledged: false, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, testsFingerprint: null, simplifyRun: false, simplifySnapshotSha: null, simplifyFingerprint: null, verifyRun: false, verifyOutcome: null, verifyFingerprint: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '', lastNamespaceHintEmittedBy: {}, flMode: null, swarmInitialized: false, hiveInitialized: false, sddMode: false, activeSddSlug: null };
 
 // Per-actor memory-search tracking (#838). The legacy `memorySearched` boolean
 // is session-wide, so once the parent searches memory, every spawned subagent
@@ -70,9 +70,24 @@ function loadGateConfig() {
   // ships a real /verify skill and has /flo delegate to it, so leaving it off by
   // default would make the default /flo run silently skip the acceptance check.
   // Disable per-project with `verify_before_done: false` or per-run `--no-verify`.
-  var defaults = { memory_first: true, task_create_first: true, context_tracking: true, testing_gate: true, simplify_gate: true, learnings_gate: true, swarm_invocation_gate: true, verify_before_done: true, sdd_gate: true };
+  // task_status_gate is a MODE, not a boolean: 'block' | 'warn' | 'off' (#1435).
+  // #1374 shipped the open-task count as a warn-only stdout line, and a consumer
+  // still shipped a PR over four untouched tasks — a reminder that survived ten
+  // consecutive ignores in one session is not a control. Blocking is the default
+  // because the honest "these stay open on purpose" outcome is one command away
+  // (record-tasks-acknowledged), so nothing here can deadlock a run.
+  var defaults = { memory_first: true, task_create_first: true, context_tracking: true, testing_gate: true, simplify_gate: true, learnings_gate: true, swarm_invocation_gate: true, verify_before_done: true, sdd_gate: true, task_status_gate: 'block' };
   var content = MOFLO_YAML;
   if (content) {
+    // Boolean forms are accepted so this key reads like every other gate in the
+    // block: `false` is the same opt-out `testing_gate: false` is, `true` means
+    // enforce. Anything unrecognised falls through to the default rather than
+    // silently disabling the gate — a typo must not be a stealth opt-out.
+    var tsg = /task_status_gate:\s*['"]?(block|warn|off|false|true)['"]?/i.exec(content);
+    if (tsg) {
+      var mode = tsg[1].toLowerCase();
+      defaults.task_status_gate = mode === 'false' ? 'off' : mode === 'true' ? 'block' : mode;
+    }
     if (/memory_first:\s*false/i.test(content)) defaults.memory_first = false;
     if (/task_create_first:\s*false/i.test(content)) defaults.task_create_first = false;
     if (/context_tracking:\s*false/i.test(content)) defaults.context_tracking = false;
@@ -1374,6 +1389,41 @@ switch (command) {
     writeState(s);
     break;
   }
+  // #1435 — the escape from the task-status gate, for work deliberately left
+  // open. Session-scoped like `learningsStored`: it lives in STATE_DEFAULTS, so
+  // session-reset clears it, and neither applyPromptStateReset nor
+  // reset-edit-gates touches it — a decision the user made about the task list
+  // is not invalidated by the next prompt or the next source edit.
+  //
+  // A plain flag, not a count. The command is typed by the model into a Bash
+  // tool, where HOOK_TRANSCRIPT_PATH is unset (it is forwarded by gate-hook.mjs
+  // from the hook payload and exists only inside a hook), so this process cannot
+  // read the ledger to record WHICH tasks were acknowledged even if it wanted to.
+  case 'record-tasks-acknowledged': {
+    var s = readState();
+    if (!s.tasksAcknowledged) {
+      s.tasksAcknowledged = true;
+      writeState(s);
+    }
+    // writeState swallows its own errors by design — a gate must never crash the
+    // hook it runs in. That was harmless while every recorder was advisory. This
+    // one is the ONLY escape from a BLOCKING gate, so a lost write would report
+    // "satisfied" and then block the very next `gh pr create` with nothing said
+    // about why: #1332's deadlock shape exactly. Confirm it landed before
+    // claiming it did, and name the file and the way out when it did not.
+    if (!readState().tasksAcknowledged) {
+      process.stderr.write(
+        'Task-status gate NOT satisfied: the acknowledgement could not be persisted to\n' +
+        STATE_FILE + '\n' +
+        'Check that the file and its directory are writable, then run this again.\n' +
+        'To proceed without it: set gates: task_status_gate: off in moflo.yaml.\n');
+      process.exit(1);
+    }
+    process.stdout.write(
+      'Task-status gate satisfied: open tasks acknowledged as deliberately deferred.\n' +
+      'They stay visible in the task list — this records the decision, it does not close them.\n');
+    break;
+  }
   case 'record-memory-searched': {
     var s = readState();
     if (markMemorySearched(s)) writeState(s);
@@ -1683,25 +1733,46 @@ switch (command) {
     // chained, piped, parenthesised, and multi-line shapes (#1410).
     var cmd = process.env.TOOL_INPUT_command || '';
     if (!isPrCreateCommand(cmd)) break;
-    // #1374 — close the loop the TaskCreate reminder opens. Advisory: stdout,
-    // no exit, and worded as a reminder, because a message may only claim to
-    // block when it blocks (#1326). An open task list is a reporting failure,
-    // not a quality failure — blocking the PR on it would be a new deadlock.
+    // #1374 opened this loop; #1435 closes it. The count itself is unchanged —
+    // what changed is that it now has teeth and, in warn mode, a delivery path.
     //
     // Deliberately ABOVE the no-source exemption below: a docs-only PR can
     // abandon a list exactly like a source PR can, and the exemption is about
     // testing/simplify/learnings, not about whether the run told the user what
-    // it did. Gated on the same `task_create_first` flag as the reminder itself
-    // so the two halves are always consistent — a project that turned the nag
-    // off is not then nagged about the other end of it.
-    if (config.task_create_first) {
+    // it did. It also exits on its own rather than joining `missing` below, for
+    // the same reason — `missing` is unreachable on an exempt diff.
+    //
+    // Gated on the same `task_create_first` flag as the reminder itself so the
+    // two halves are always consistent: a project that turned the nag off is
+    // not then blocked about the other end of it.
+    //
+    // Fail-open is load-bearing. readTaskLedger() returns null on a missing,
+    // oversized, or unreadable transcript and on a session with no TaskCreate at
+    // all, and null must never block — a gate that stops PRs because it could
+    // not read a file is worse than the reporting gap it is closing.
+    //
+    // State is read ONCE for the whole case, here — the pre-PR gate logic below
+    // reuses it and nothing writes in between. Reading it before the ledger also
+    // means an already-acknowledged run never pays for the transcript scan.
+    var s = readState();
+    if (config.task_create_first && config.task_status_gate !== 'off' && !s.tasksAcknowledged) {
       var ledger = readTaskLedger();
       if (ledger && ledger.open > 0) {
-        process.stdout.write(
-          'REMINDER: ' + ledger.created + ' task' + (ledger.created === 1 ? '' : 's') +
-          ' created this session, ' + ledger.open + ' still open. Close them with ' +
-          'TaskUpdate (status: completed), or delete the ones that no longer apply, ' +
-          'so the run does not report done over an unfinished list.\n');
+        var tally = ledger.created + ' task' + (ledger.created === 1 ? '' : 's') +
+          ' created this session, ' + ledger.open + ' still open.';
+        var closeIt = 'Close them with TaskUpdate (status: completed), or delete the ones ' +
+          'that no longer apply, so the run does not report done over an unfinished list.\n';
+        if (config.task_status_gate === 'warn') {
+          process.stdout.write('REMINDER: ' + tally + ' ' + closeIt);
+        } else {
+          process.stderr.write(
+            'BLOCKED: ' + tally + '\n' + closeIt +
+            'Deferring them on purpose is a legitimate outcome — declare it instead of\n' +
+            'closing tasks that are not done: node "' + __filename + '" record-tasks-acknowledged\n' +
+            GATE_ORIGIN_NOTE + '\n' +
+            'Report instead of blocking via moflo.yaml: gates: task_status_gate: warn   (or: off)\n');
+          process.exit(2);
+        }
       }
     }
     // No-source-files exemption (#1176, supersedes the original docs-only path).
@@ -1726,7 +1797,6 @@ switch (command) {
         break;
       }
     }
-    var s = readState();
     // Expire any credit whose fingerprint no longer matches the code before
     // reading the flags. This is what catches the mutations reset-edit-gates
     // structurally cannot see — Bash writes, git checkout/pull/merge, and the

--- a/src/cli/__tests__/services/hook-wiring-generator-parity-1393.test.ts
+++ b/src/cli/__tests__/services/hook-wiring-generator-parity-1393.test.ts
@@ -30,6 +30,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { REQUIRED_HOOK_WIRING, HOOK_ENTRY_MAP, repairHookWiring } from '../../services/hook-wiring.js';
+import { getReferenceHookBlock } from '../../services/hook-block-hash.js';
 
 const GENERATOR_PATH = join(__dirname, '..', '..', 'init', 'settings-generator.ts');
 
@@ -110,6 +111,36 @@ describe('#1393 — settings-generator ↔ hook-wiring parity', () => {
       missing,
       `Listed in REQUIRED_HOOK_WIRING but absent from HOOK_ENTRY_MAP — ` +
       `repairHookWiring() will silently skip these: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  /**
+   * Presence parity is not enough — the EVENT has to match too, and it had
+   * drifted. `check-bash-memory` was listed here under `PostToolUse` while the
+   * generator and the reference block put it under `PreToolUse`, where #1132
+   * deliberately moved it so its `process.exit(2)` prevents the read rather than
+   * reporting one that already happened. Because the presence check is a raw
+   * substring scan over settings.json, the mismatch was invisible on every
+   * project that already had the hook; it would only bite a consumer missing it
+   * entirely, who would then be "repaired" into a gate that cannot block.
+   */
+  it('every repaired pattern is grafted under the same event the reference block uses', () => {
+    const reference = getReferenceHookBlock();
+    const eventOf = (pattern: string): string | undefined =>
+      Object.keys(reference).find(event =>
+        (reference[event] ?? []).some(block =>
+          (block.hooks ?? []).some(h => typeof h.command === 'string' && h.command.includes(pattern)),
+        ),
+      );
+
+    const mismatched = Object.keys(HOOK_ENTRY_MAP)
+      .map(pattern => ({ pattern, mapped: HOOK_ENTRY_MAP[pattern].event, reference: eventOf(pattern) }))
+      .filter(r => r.reference !== undefined && r.reference !== r.mapped)
+      .map(r => `${r.pattern}: HOOK_ENTRY_MAP=${r.mapped} but reference block=${r.reference}`);
+
+    expect(
+      mismatched,
+      `repairHookWiring() would graft these under the wrong hook event:\n  ${mismatched.join('\n  ')}`,
     ).toEqual([]);
   });
 

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -218,7 +218,7 @@ var os = require('os');
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\\/([a-z])\\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
 
-var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, verifyRun: false, verifyOutcome: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '', lastNamespaceHintEmittedBy: {}, flMode: null, swarmInitialized: false, hiveInitialized: false, sddMode: false, activeSddSlug: null };
+var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, tasksAcknowledged: false, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, verifyRun: false, verifyOutcome: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '', lastNamespaceHintEmittedBy: {}, flMode: null, swarmInitialized: false, hiveInitialized: false, sddMode: false, activeSddSlug: null };
 
 function readState() {
   try {
@@ -266,9 +266,17 @@ function writeState(s) {
 
 // Load moflo.yaml gate config (defaults: all enabled)
 function loadGateConfig() {
-  var defaults = { memory_first: true, task_create_first: true, context_tracking: true, testing_gate: true, simplify_gate: true, learnings_gate: true, swarm_invocation_gate: true, verify_before_done: true, sdd_gate: true };
+  // #1435 — task_status_gate is a MODE ('block' | 'warn' | 'off'), not a boolean;
+  // boolean forms are accepted so it reads like its neighbours. Unrecognised
+  // values keep the default: a typo must not become a stealth opt-out.
+  var defaults = { memory_first: true, task_create_first: true, context_tracking: true, testing_gate: true, simplify_gate: true, learnings_gate: true, swarm_invocation_gate: true, verify_before_done: true, sdd_gate: true, task_status_gate: 'block' };
   var content = MOFLO_YAML;
   if (content) {
+    var tsg = /task_status_gate:\\s*['"]?(block|warn|off|false|true)['"]?/i.exec(content);
+    if (tsg) {
+      var tsgMode = tsg[1].toLowerCase();
+      defaults.task_status_gate = tsgMode === 'false' ? 'off' : tsgMode === 'true' ? 'block' : tsgMode;
+    }
     if (/memory_first:\\s*false/i.test(content)) defaults.memory_first = false;
     if (/task_create_first:\\s*false/i.test(content)) defaults.task_create_first = false;
     if (/context_tracking:\\s*false/i.test(content)) defaults.context_tracking = false;
@@ -713,6 +721,71 @@ var EDIT_RESET_SKIP_PATH_RE = /(?:^|[\\\\\\/])\\.github[\\\\\\/](?:workflows|ISS
 // new untested surface for code review.
 var EDIT_RESET_SKIP_SIMPLIFY_ONLY_RE = /(?:^|[\\\\\\/])(__tests__|__mocks__|tests?|spec|specs|cypress|e2e|fixtures?)[\\\\\\/]|\\.(test|spec)\\.[mc]?[jt]sx?$|\\.fixture\\.[mc]?[jt]sx?$/i;
 
+// #1374/#1435 — count TaskCreate calls against terminal TaskUpdate calls in the
+// session transcript. SYNC: mirrors bin/gate.cjs readTaskLedger (see there for
+// why the transcript, and not a TaskUpdate observer or Claude Code's task store).
+//
+// This template variant omits RELAXATIONS the synced bin/gate.cjs carries (the
+// docs-only exemption, fingerprint expiry) — omitting those only makes the
+// fallback stricter. An ENFORCEMENT gate is the opposite: leaving it out would
+// make the fallback silently permissive, which is the exact failure #1435 is
+// about. So it is mirrored in full.
+var TRANSCRIPT_MAX_BYTES = 16 * 1024 * 1024;
+function readTaskLedger() {
+  var tp = process.env.HOOK_TRANSCRIPT_PATH || '';
+  if (!tp) return null;
+  var raw;
+  try {
+    var tst = fs.statSync(tp);
+    if (!tst.isFile() || tst.size > TRANSCRIPT_MAX_BYTES) return null;
+    raw = fs.readFileSync(tp, 'utf-8');
+  } catch (e) { return null; }
+  var created = 0, createdIdCount = 0;
+  var pendingCreates = {}, createdIds = {}, latest = {};
+  var pos = 0;
+  while (pos <= raw.length) {
+    var nl = raw.indexOf('\\n', pos);
+    var line = nl < 0 ? raw.slice(pos) : raw.slice(pos, nl);
+    pos = nl < 0 ? raw.length + 1 : nl + 1;
+    if (line.indexOf('TaskCreate') < 0 && line.indexOf('TaskUpdate') < 0
+      && line.indexOf('created successfully') < 0) continue;
+    var entry;
+    try { entry = JSON.parse(line); } catch (e) { continue; }
+    var content = entry && entry.message && entry.message.content;
+    if (!Array.isArray(content)) continue;
+    for (var ci = 0; ci < content.length; ci++) {
+      var block = content[ci];
+      if (!block) continue;
+      if (block.type === 'tool_result') {
+        if (!pendingCreates[block.tool_use_id]) continue;
+        delete pendingCreates[block.tool_use_id];
+        var text = typeof block.content === 'string' ? block.content : JSON.stringify(block.content);
+        var m = /Task #(\\S+) created successfully/.exec(text || '');
+        if (m && !createdIds[m[1]]) { createdIds[m[1]] = true; createdIdCount++; }
+        continue;
+      }
+      if (block.type !== 'tool_use') continue;
+      if (block.name === 'TaskCreate') {
+        created++;
+        if (block.id) pendingCreates[block.id] = true;
+        continue;
+      }
+      if (block.name !== 'TaskUpdate') continue;
+      var tinput = block.input || {};
+      var tid = tinput.taskId != null ? tinput.taskId : tinput.task_id;
+      if (tid == null || typeof tinput.status !== 'string' || !tinput.status) continue;
+      latest[String(tid)] = tinput.status;
+    }
+  }
+  if (created === 0) return null;
+  var open = created - createdIdCount;
+  Object.keys(createdIds).forEach(function(id) {
+    if (latest[id] !== 'completed' && latest[id] !== 'deleted') open++;
+  });
+  if (open > created) open = created;
+  return { created: created, closed: created - open, open: open };
+}
+
 switch (command) {
   case 'check-before-agent': {
     // Mostly advisory. The TaskCreate + memory reminders below go to stdout and
@@ -827,6 +900,28 @@ switch (command) {
     s.tasksCreated = true;
     s.taskCount = (s.taskCount || 0) + 1;
     writeState(s);
+    break;
+  }
+  // #1435 — the escape from the task-status gate, for work deliberately left
+  // open. Session-scoped via STATE_DEFAULTS; no prompt or edit reset touches it.
+  case 'record-tasks-acknowledged': {
+    var s = readState();
+    if (!s.tasksAcknowledged) {
+      s.tasksAcknowledged = true;
+      writeState(s);
+    }
+    // writeState swallows its own errors so a gate never crashes its hook. This
+    // is the ONLY escape from a BLOCKING gate, so an unconfirmed write would
+    // report "satisfied" and block the next 'gh pr create' anyway — confirm it.
+    if (!readState().tasksAcknowledged) {
+      process.stderr.write('Task-status gate NOT satisfied: the acknowledgement could not be persisted to\\n' +
+        STATE_FILE + '\\n' +
+        'Check that the file and its directory are writable, then run this again.\\n' +
+        'To proceed without it: set gates: task_status_gate: off in moflo.yaml.\\n');
+      process.exit(1);
+    }
+    process.stdout.write('Task-status gate satisfied: open tasks acknowledged as deliberately deferred.\\n' +
+      'They stay visible in the task list — this records the decision, it does not close them.\\n');
     break;
   }
   case 'record-memory-searched': {
@@ -1014,7 +1109,30 @@ switch (command) {
   case 'check-before-pr': {
     var cmd = process.env.TOOL_INPUT_command || '';
     if (!/(?:^|&&\\s*|\\|\\|\\s*|;\\s*)\\s*(?:[A-Z_][A-Z0-9_]*=\\S+\\s+)*gh\\s+pr\\s+create\\b/.test(cmd)) break;
+    // #1435 — task-status gate. Subordinate to task_create_first so both halves
+    // of the task nag are on or off together; fail-open when the ledger is null.
+    // State is read once for the whole case and reused below; reading it before
+    // the ledger keeps an acknowledged run off the transcript scan entirely.
     var s = readState();
+    if (config.task_create_first && config.task_status_gate !== 'off' && !s.tasksAcknowledged) {
+      var ledger = readTaskLedger();
+      if (ledger && ledger.open > 0) {
+        var tally = ledger.created + ' task' + (ledger.created === 1 ? '' : 's') +
+          ' created this session, ' + ledger.open + ' still open.';
+        var closeIt = 'Close them with TaskUpdate (status: completed), or delete the ones ' +
+          'that no longer apply, so the run does not report done over an unfinished list.\\n';
+        if (config.task_status_gate === 'warn') {
+          process.stdout.write('REMINDER: ' + tally + ' ' + closeIt);
+        } else {
+          process.stderr.write('BLOCKED: ' + tally + '\\n' + closeIt +
+            'Deferring them on purpose is a legitimate outcome — declare it instead of\\n' +
+            'closing tasks that are not done: node "' + __filename + '" record-tasks-acknowledged\\n' +
+            GATE_ORIGIN_NOTE + '\\n' +
+            'Report instead of blocking via moflo.yaml: gates: task_status_gate: warn   (or: off)\\n');
+          process.exit(2);
+        }
+      }
+    }
     var missing = [];
     if (config.testing_gate && !s.testsRun) missing.push('tests have not run green since the last code edit (run npm test, vitest, jest, pytest, or similar — a run whose output reports failures does not count)');
     if (config.simplify_gate && !s.simplifyRun) missing.push('/flo-simplify (or /distill) has not run since the last code edit');
@@ -1285,6 +1403,34 @@ if (hookContext.tool_response && typeof hookContext.tool_response === 'object') 
   }
 }
 
+// #1435 — deliver a PASSING gate's advisory to Claude, not only to the transcript.
+//
+// Claude Code shows a PreToolUse/PostToolUse hook's stdout to the user in
+// transcript mode and stops there; the model never sees it. So every advisory
+// the gates emit on the exit-0 path was invisible on exactly the runs it was
+// written for: #1374's open-task count, the pre-Agent TaskCreate reminder, the
+// namespace hint, the docs-only and simplify-auto-pass notes. They surfaced only
+// when some OTHER gate blocked, because the catch arm below re-routes err.stdout
+// to stderr — i.e. only once the PR had already been stopped for another reason.
+// A consumer shipped a PR over four untouched tasks with that reminder "working".
+//
+// \`hookSpecificOutput.additionalContext\` is the documented channel from a passing
+// tool hook into the model's context. Wrap there and nowhere else: SessionStart
+// and UserPromptSubmit already inject their stdout as context, so wrapping those
+// would rewrite a working path for nothing. An unknown or absent hook_event_name
+// falls back to raw stdout — byte-identical to the previous behaviour.
+var ADVISORY_EVENTS = { PreToolUse: true, PostToolUse: true };
+function emitAdvisory(text) {
+  var event = hookContext.hook_event_name;
+  if (!ADVISORY_EVENTS[event]) {
+    process.stdout.write(text);
+    return;
+  }
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: { hookEventName: event, additionalContext: text },
+  }) + '\\n');
+}
+
 // Run gate.cjs with the enriched environment
 var projectDir = (env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\\/([a-z])\\//i, '$1:/');
 var gateScript = resolve(projectDir, '.claude/helpers/gate.cjs');
@@ -1292,7 +1438,7 @@ try {
   var output = execFileSync('node', [gateScript, command], {
     env: env, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true
   });
-  if (output.trim()) process.stdout.write(output);
+  if (output.trim()) emitAdvisory(output);
   process.exit(0);
 } catch (err) {
   // gate.cjs exit(2) = block, exit(1) = also block attempt — translate both to exit(2)

--- a/src/cli/init/moflo-yaml-template.ts
+++ b/src/cli/init/moflo-yaml-template.ts
@@ -224,6 +224,7 @@ gates:
   task_create_first: ${gates}
   context_tracking: ${gates}
   verify_before_done: true    # Run /verify before 'gh pr create'. On by default; opt out with false or per-run --no-verify
+  task_status_gate: block     # Open tasks stop 'gh pr create'. warn → report only; off → silent
 
 # Auto-index on session start
 auto_index:

--- a/src/cli/services/hook-wiring.ts
+++ b/src/cli/services/hook-wiring.ts
@@ -85,7 +85,9 @@ export const REQUIRED_HOOK_WIRING: ReadonlyArray<{ event: string; pattern: strin
   // listing it here made repairHookWiring() graft the hook back into every
   // consumer on session start, undoing the removal.
   { event: 'PostToolUse', pattern: 'record-learnings-stored' },
-  { event: 'PostToolUse', pattern: 'check-bash-memory' },
+  // PreToolUse, not PostToolUse: #1132 moved it so its process.exit(2) actually
+  // prevents the read instead of reporting one that already happened.
+  { event: 'PreToolUse', pattern: 'check-bash-memory' },
   { event: 'PostToolUse', pattern: 'record-test-run' },
   // #1338 follow-up — CLI half of the #952 swarm/hive init recorders. Listed
   // here so an existing consumer picks it up via repairHookWiring on session
@@ -166,7 +168,9 @@ export const HOOK_ENTRY_MAP: Record<string, HookEntryMapping> = {
   'record-learnings-stored':  { event: 'PostToolUse',      matcher: '^mcp__moflo__memory_store$', hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" record-learnings-stored', timeout: 2000 } },
   // #1171 — widened to ^(Bash|PowerShell)$ so PS reads / PS-invoked tests credit
   // the same gates as Bash. Name kept as `check-bash-memory` for backwards compat.
-  'check-bash-memory':        { event: 'PostToolUse',      matcher: '^(Bash|PowerShell)$',        hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" check-bash-memory', timeout: 2000 } },
+  // PreToolUse since #1132: grafting it under PostToolUse — as this entry did —
+  // would repair a consumer into a gate that reports a read it can no longer stop.
+  'check-bash-memory':        { event: 'PreToolUse',       matcher: '^(Bash|PowerShell)$',        hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" check-bash-memory', timeout: 2000 } },
   'record-test-run':          { event: 'PostToolUse',      matcher: '^(Bash|PowerShell)$',        hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-test-run', timeout: 2000 } },
   // #1338 follow-up — same Bash/PowerShell PostToolUse block as record-test-run.
   'record-bash-swarm-init':   { event: 'PostToolUse',      matcher: '^(Bash|PowerShell)$',        hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-bash-swarm-init', timeout: 2000 } },

--- a/tests/bin/gate-helpers.test.ts
+++ b/tests/bin/gate-helpers.test.ts
@@ -1780,11 +1780,17 @@ describe('end-to-end: spell lifecycle', () => {
 
   // #1374 — the completion half of the TaskCreate reminder. moflo used to push
   // `TaskCreate` and then never look again, so a run that opened four tasks and
-  // closed none satisfied every gate. These pin the reporting side: the ledger
-  // comes from the session transcript (no `^TaskUpdate$` observer — that wiring
-  // is what #1331 removed as hot-path overhead), it counts CALLS not mentions,
-  // and it reminds without ever claiming to block (#1326).
-  describe('open-task advisory at the PR gate (#1374)', () => {
+  // closed none satisfied every gate. These pin the LEDGER ARITHMETIC: it comes
+  // from the session transcript (no `^TaskUpdate$` observer — that wiring is what
+  // #1331 removed as hot-path overhead) and counts CALLS, not mentions.
+  //
+  // Pinned in `warn` mode deliberately. #1435 made `block` the default because
+  // reporting alone demonstrably did not hold, and every case below is about what
+  // the ledger COUNTS rather than what the gate then does with the count — asserting
+  // both here would re-test the mode on nine shapes that do not vary by it. The
+  // enforcement half (block, the acknowledgement escape, mode routing) is pinned
+  // in tests/bin/gate-task-status-1435.test.ts.
+  describe('open-task ledger at the PR gate (#1374)', () => {
     /** One transcript line as Claude Code writes it: a tool_use block. */
     function toolUse(name: string, input: Record<string, unknown>, id = 'toolu_x'): string {
       return JSON.stringify({
@@ -1819,8 +1825,12 @@ describe('end-to-end: spell lifecycle', () => {
       env.HOOK_TRANSCRIPT_PATH = p;
     }
 
-    /** All blocking gates satisfied, so only the advisory can appear. */
+    /**
+     * All blocking gates satisfied and the task gate in `warn` mode, so the only
+     * thing that can appear is the ledger's own line — on stdout, exit 0.
+     */
     function prReady(env: Record<string, string>): void {
+      writeFileSync(join(tmpDir, 'moflo.yaml'), 'gates:\n  task_status_gate: warn\n');
       writeState(tmpDir, { testsRun: true, simplifyRun: true, learningsStored: true });
       env.TOOL_INPUT_command = 'gh pr create --title "test"';
     }
@@ -1957,6 +1967,9 @@ describe('end-to-end: spell lifecycle', () => {
 
     it('still reports while the PR is blocked for another reason', () => {
       const env = baseEnv(tmpDir);
+      // warn mode, so the failing gate below is the ONLY thing blocking — the
+      // point is that the ledger still speaks when it is not itself the blocker.
+      writeFileSync(join(tmpDir, 'moflo.yaml'), 'gates:\n  task_status_gate: warn\n');
       writeState(tmpDir, { testsRun: false, simplifyRun: true, learningsStored: true });
       env.TOOL_INPUT_command = 'gh pr create --title "test"';
       withTranscript(env, taskCreate('1'));
@@ -1968,12 +1981,17 @@ describe('end-to-end: spell lifecycle', () => {
     it('is silent when task_create_first is off — both halves or neither', () => {
       // The reminder to OPEN a list and the reminder to CLOSE it are one
       // feature. A project that turned the nag off must not get the other end.
-      writeFileSync(join(tmpDir, 'moflo.yaml'), 'gates:\n  task_create_first: false\n');
       const env = baseEnv(tmpDir);
       prReady(env);
+      // After prReady, which writes its own moflo.yaml. Deliberately without a
+      // task_status_gate key: `task_create_first: false` alone must silence both
+      // halves, including the mode that would otherwise block.
+      writeFileSync(join(tmpDir, 'moflo.yaml'), 'gates:\n  task_create_first: false\n');
       withTranscript(env, [toolUse('TaskCreate', { subject: 'a', description: 'a' })]);
       const r = runGate('check-before-pr', env);
       expect(r.stdout).not.toContain('still open');
+      expect(r.stderr).not.toContain('still open');
+      expect(r.exitCode).toBe(0);
     });
 
     it('is silent when the host forwards no transcript path', () => {
@@ -2615,6 +2633,10 @@ describe('gate-hook.mjs: session_id forwarding (#838)', () => {
 // forwarding step is the part that can regress.
 describe('gate-hook.mjs: transcript_path forwarding (#1374)', () => {
   it('forwards transcript_path so the PR gate can count open tasks', async () => {
+    // warn mode keeps this on the exit-0 path, which is what the forwarding
+    // assertion is about; the block mode #1435 made the default is pinned in
+    // tests/bin/gate-task-status-1435.test.ts.
+    writeFileSync(join(tmpDir, 'moflo.yaml'), 'gates:\n  task_status_gate: warn\n');
     writeState(tmpDir, { testsRun: true, simplifyRun: true, learningsStored: true });
     const transcript = join(tmpDir, 'transcript.jsonl');
     writeFileSync(transcript, [

--- a/tests/bin/gate-task-status-1435.test.ts
+++ b/tests/bin/gate-task-status-1435.test.ts
@@ -1,0 +1,491 @@
+/**
+ * #1435 — task-list closure must be enforced, and a passing gate's advisory must
+ * actually reach Claude.
+ *
+ * Two defects, one report. A `/flo` run on a consumer project opened four tasks,
+ * finished all four items of work, and shipped a green PR with `TaskUpdate`
+ * called zero times — while #1374's open-task check was installed and running.
+ *
+ *   1. It could not be heard. The count goes to STDOUT, and `check-before-pr`
+ *      exits 0 once the other gates pass; a passing PreToolUse hook's stdout is
+ *      surfaced in transcript mode only. It reached anyone solely when some OTHER
+ *      gate blocked, because gate-hook.mjs re-routes a failed gate's stdout to
+ *      stderr — i.e. only on runs already stopped for another reason.
+ *   2. Even heard, it was advisory. A reminder ignored ten consecutive times in
+ *      one session is not a control.
+ *
+ * So this file pins the ENFORCEMENT and the DELIVERY. The ledger's arithmetic —
+ * what counts as created, closed, or carried across `/clear` — stays pinned in
+ * gate-helpers.test.ts, which exercises those shapes in `warn` mode.
+ *
+ * Assertions run against the shipped `bin/` scripts plus the generator that
+ * writes gate.cjs into a fresh project, because a consumer runs a synced copy,
+ * never this repo's source tree.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { resolve, join, isAbsolute } from 'path';
+import { tmpdir } from 'os';
+
+import { generateGateScript } from '../../src/cli/init/helpers-generator.js';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+const GATE = resolve(REPO_ROOT, 'bin/gate.cjs');
+const GATE_HOOK = resolve(REPO_ROOT, 'bin/gate-hook.mjs');
+
+let root: string;
+
+function baseEnv(): Record<string, string> {
+  return {
+    ...(process.env as Record<string, string>),
+    CLAUDE_PROJECT_DIR: root,
+    TOOL_INPUT_command: 'gh pr create --title "t" --body "b"',
+    HOOK_SESSION_ID: '',
+    HOOK_TRANSCRIPT_PATH: '',
+  };
+}
+
+function runGate(command: string, env: Record<string, string>) {
+  const r = spawnSync(process.execPath, [GATE, command], {
+    env, encoding: 'utf-8', timeout: 30_000, stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return { stdout: r.stdout || '', stderr: r.stderr || '', exitCode: typeof r.status === 'number' ? r.status : 1 };
+}
+
+/** One transcript line as Claude Code writes it: an assistant tool_use block. */
+function toolUse(name: string, input: Record<string, unknown>, id = 'toolu_x'): string {
+  return JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_use', id, name, input }] } });
+}
+
+/** A TaskCreate call plus the tool_result naming the id it was assigned. */
+function taskCreate(taskId: string): string[] {
+  const useId = `toolu_create_${taskId}`;
+  return [
+    toolUse('TaskCreate', { subject: `task ${taskId}`, description: 'd' }, useId),
+    JSON.stringify({
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: useId, content: `Task #${taskId} created successfully: task ${taskId}` }] },
+    }),
+  ];
+}
+
+function withTranscript(env: Record<string, string>, lines: string[]): string {
+  const p = join(root, 'transcript.jsonl');
+  writeFileSync(p, lines.join('\n') + '\n');
+  env.HOOK_TRANSCRIPT_PATH = p;
+  return p;
+}
+
+function writeState(patch: Record<string, unknown>): void {
+  writeFileSync(join(root, '.claude', 'workflow-state.json'), JSON.stringify(patch, null, 2));
+}
+
+function readStateFile(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(root, '.claude', 'workflow-state.json'), 'utf-8'));
+}
+
+/** Every OTHER pre-PR gate satisfied, so only the task gate can speak. */
+function otherGatesGreen(): void {
+  writeState({ testsRun: true, simplifyRun: true, learningsStored: true, verifyRun: true, verifyOutcome: 'PASS' });
+}
+
+function setMode(mode: string): void {
+  writeFileSync(join(root, 'moflo.yaml'), `gates:\n  task_status_gate: ${mode}\n`);
+}
+
+beforeEach(() => {
+  root = resolve(tmpdir(), `moflo-1435-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(join(root, '.claude', 'helpers'), { recursive: true });
+  // gate-hook.mjs resolves the gate at <project>/.claude/helpers/gate.cjs — the
+  // bridge tests below exercise the real pair, not a stub.
+  writeFileSync(join(root, '.claude', 'helpers', 'gate.cjs'), readFileSync(GATE, 'utf-8'));
+});
+
+afterEach(() => {
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* Windows may still hold handles — non-fatal */
+  }
+});
+
+describe('#1435 open tasks block the PR by default', () => {
+  it('blocks gh pr create when every other gate is green', () => {
+    const env = baseEnv();
+    otherGatesGreen();
+    withTranscript(env, [...taskCreate('1'), ...taskCreate('2')]);
+
+    const r = runGate('check-before-pr', env);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('BLOCKED');
+    expect(r.stderr).toContain('2 tasks created this session, 2 still open');
+  });
+
+  it('passes once every created task reached a terminal status', () => {
+    const env = baseEnv();
+    otherGatesGreen();
+    withTranscript(env, [
+      ...taskCreate('1'),
+      ...taskCreate('2'),
+      toolUse('TaskUpdate', { taskId: '1', status: 'completed' }),
+      toolUse('TaskUpdate', { taskId: '2', status: 'deleted' }),
+    ]);
+
+    const r = runGate('check-before-pr', env);
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).not.toContain('BLOCKED');
+  });
+
+  /**
+   * The block fires before the no-source exemption on purpose: a docs-only PR
+   * can abandon a task list exactly like a source PR can, and the exemption is
+   * about testing/simplify/learnings, not about whether the run reported what it
+   * did. Nothing in this fixture is a source file, so the exemption would swallow
+   * the gate if the order were reversed.
+   */
+  it('blocks even on a diff the other gates would exempt', () => {
+    const env = baseEnv();
+    writeState({});
+    withTranscript(env, taskCreate('1'));
+
+    const r = runGate('check-before-pr', env);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('1 task created this session, 1 still open');
+  });
+
+  it('names the acknowledgement escape rather than only the failure', () => {
+    const env = baseEnv();
+    otherGatesGreen();
+    withTranscript(env, taskCreate('1'));
+
+    const { stderr } = runGate('check-before-pr', env);
+    expect(stderr).toContain('record-tasks-acknowledged');
+    // The mode knob is part of the escape surface: a project that wants the old
+    // report-only behaviour must be able to find it from the block itself.
+    expect(stderr).toContain('task_status_gate: warn');
+  });
+});
+
+describe('#1435 acknowledging deferred work credits the gate', () => {
+  it('lets gh pr create through with the tasks still open', () => {
+    const env = baseEnv();
+    otherGatesGreen();
+    withTranscript(env, [...taskCreate('1'), ...taskCreate('2')]);
+    expect(runGate('check-before-pr', env).exitCode).toBe(2);
+
+    const ack = runGate('record-tasks-acknowledged', env);
+    expect(ack.exitCode).toBe(0);
+    expect(readStateFile().tasksAcknowledged).toBe(true);
+
+    const after = runGate('check-before-pr', env);
+    expect(after.exitCode).toBe(0);
+    expect(after.stderr).not.toContain('BLOCKED');
+  });
+
+  it('says the tasks stay open, so acknowledging is not mistaken for closing', () => {
+    const r = runGate('record-tasks-acknowledged', baseEnv());
+    expect(r.stdout).toContain('deferred');
+    expect(r.stdout).toContain('does not close them');
+  });
+
+  it('is idempotent and leaves the other credits untouched', () => {
+    otherGatesGreen();
+    const before = readStateFile();
+    runGate('record-tasks-acknowledged', baseEnv());
+    runGate('record-tasks-acknowledged', baseEnv());
+    const after = readStateFile();
+    expect(after.tasksAcknowledged).toBe(true);
+    expect(after.testsRun).toBe(before.testsRun);
+    expect(after.learningsStored).toBe(before.learningsStored);
+    expect(after.verifyOutcome).toBe(before.verifyOutcome);
+  });
+
+  /**
+   * The escape is the ONLY way past a blocking gate, and writeState swallows its
+   * own errors so a gate never crashes the hook it runs in. Reporting success on
+   * a write that did not land would block the next `gh pr create` anyway, with
+   * nothing said about why — a deadlock with no diagnostic.
+   *
+   * The failure is induced by making the state path a DIRECTORY, which fails the
+   * write on every platform (Rule #1) — unlike a permissions bit, which Windows
+   * would happily ignore.
+   */
+  it('reports failure, loudly, when the acknowledgement cannot be persisted', () => {
+    rmSync(join(root, '.claude', 'workflow-state.json'), { force: true });
+    mkdirSync(join(root, '.claude', 'workflow-state.json'), { recursive: true });
+
+    const r = runGate('record-tasks-acknowledged', baseEnv());
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stdout).not.toContain('satisfied:');
+    expect(r.stderr).toContain('NOT satisfied');
+    // Name the file and a way forward — a diagnostic that only says "failed"
+    // leaves the caller with the same deadlock.
+    expect(r.stderr).toContain('workflow-state.json');
+    expect(r.stderr).toContain('task_status_gate: off');
+  });
+
+  /**
+   * The command is typed by the model into a Bash tool, where $CLAUDE_PROJECT_DIR
+   * is unset (a hook-only variable) and the cwd is not guaranteed to be the
+   * project root. Matching the case name alone would pass on a command that
+   * cannot run — so run the printed command itself, from elsewhere.
+   */
+  it('prints a command that actually runs from an unrelated cwd', () => {
+    const env = baseEnv();
+    otherGatesGreen();
+    withTranscript(env, taskCreate('1'));
+
+    const { stderr } = runGate('check-before-pr', env);
+    const printed = /node "([^"]+)" record-tasks-acknowledged/.exec(stderr);
+    expect(printed, 'block message must print an absolute, quoted script path').not.toBeNull();
+    expect(isAbsolute(printed![1])).toBe(true);
+    expect(stderr).not.toContain('$CLAUDE_PROJECT_DIR');
+
+    const r = spawnSync(process.execPath, [printed![1], 'record-tasks-acknowledged'], {
+      cwd: REPO_ROOT, // deliberately NOT the fixture project root
+      env, encoding: 'utf-8', timeout: 30_000,
+    });
+    expect(r.status).toBe(0);
+    expect(readStateFile().tasksAcknowledged).toBe(true);
+  });
+});
+
+describe('#1435 task_status_gate modes', () => {
+  function openOneTask(env: Record<string, string>): void {
+    otherGatesGreen();
+    withTranscript(env, taskCreate('1'));
+  }
+
+  it('warn reports on stdout without blocking', () => {
+    const env = baseEnv();
+    setMode('warn');
+    openOneTask(env);
+
+    const r = runGate('check-before-pr', env);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('1 task created this session, 1 still open');
+    expect(r.stdout).not.toContain('BLOCKED');
+  });
+
+  it('off says nothing at all', () => {
+    const env = baseEnv();
+    setMode('off');
+    openOneTask(env);
+
+    const r = runGate('check-before-pr', env);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toContain('still open');
+    expect(r.stderr).not.toContain('still open');
+  });
+
+  it('accepts the boolean forms its neighbouring gate keys use', () => {
+    const env = baseEnv();
+    setMode('false');
+    openOneTask(env);
+    expect(runGate('check-before-pr', env).exitCode).toBe(0);
+
+    setMode('true');
+    expect(runGate('check-before-pr', env).exitCode).toBe(2);
+  });
+
+  /**
+   * A typo must not be a stealth opt-out. `task_status_gate: blcok` reads like a
+   * configured value at a glance, and silently disabling enforcement on it would
+   * reproduce this ticket in a form nobody can see.
+   */
+  it('keeps blocking on an unrecognised value', () => {
+    const env = baseEnv();
+    setMode('blcok');
+    openOneTask(env);
+    expect(runGate('check-before-pr', env).exitCode).toBe(2);
+  });
+
+  it('is disabled entirely by task_create_first: false — both halves or neither', () => {
+    const env = baseEnv();
+    openOneTask(env);
+    writeFileSync(join(root, 'moflo.yaml'), 'gates:\n  task_create_first: false\n');
+
+    const r = runGate('check-before-pr', env);
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).not.toContain('still open');
+  });
+});
+
+describe('#1435 the gate fails open, never closed', () => {
+  it('does not block when the host forwards no transcript path', () => {
+    const env = baseEnv();
+    otherGatesGreen();
+    env.HOOK_TRANSCRIPT_PATH = '';
+    expect(runGate('check-before-pr', env).exitCode).toBe(0);
+  });
+
+  it('does not block when the transcript path does not exist', () => {
+    const env = baseEnv();
+    otherGatesGreen();
+    env.HOOK_TRANSCRIPT_PATH = join(root, 'no-such-transcript.jsonl');
+    expect(runGate('check-before-pr', env).exitCode).toBe(0);
+  });
+
+  it('does not block when the transcript is over the size cap', () => {
+    // Past the cap the ledger declines to comment rather than risk the hook
+    // timeout. Declining must mean "no opinion", not "no tasks" and not a block.
+    const env = baseEnv();
+    otherGatesGreen();
+    const p = join(root, 'huge.jsonl');
+    const line = taskCreate('1').join('\n') + '\n';
+    writeFileSync(p, line + 'x'.repeat(16 * 1024 * 1024 + 1));
+    env.HOOK_TRANSCRIPT_PATH = p;
+
+    const r = runGate('check-before-pr', env);
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).not.toContain('still open');
+  });
+
+  it('does not block a session that opened no tasks at all', () => {
+    const env = baseEnv();
+    otherGatesGreen();
+    withTranscript(env, [toolUse('TaskUpdate', { taskId: '7', status: 'completed' })]);
+    expect(runGate('check-before-pr', env).exitCode).toBe(0);
+  });
+});
+
+/**
+ * The delivery half. Asserting gate.cjs writes the right bytes proves nothing if
+ * the bridge then drops them where nobody reads — which is precisely what
+ * happened to #1374's advisory for two releases.
+ */
+describe('#1435 gate-hook.mjs delivers a passing gate advisory to Claude', () => {
+  function runBridge(command: string, payload: Record<string, unknown>) {
+    const r = spawnSync(process.execPath, [GATE_HOOK, command], {
+      env: { ...(process.env as Record<string, string>), CLAUDE_PROJECT_DIR: root },
+      input: JSON.stringify(payload),
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+    return { stdout: r.stdout || '', stderr: r.stderr || '', exitCode: typeof r.status === 'number' ? r.status : 1 };
+  }
+
+  function warnPayload(event: string | undefined): Record<string, unknown> {
+    setMode('warn');
+    otherGatesGreen();
+    const p = join(root, 'transcript.jsonl');
+    writeFileSync(p, taskCreate('1').join('\n') + '\n');
+    const payload: Record<string, unknown> = {
+      tool_name: 'Bash',
+      tool_input: { command: 'gh pr create --title "t"' },
+      transcript_path: p,
+    };
+    if (event) payload.hook_event_name = event;
+    return payload;
+  }
+
+  it('wraps exit-0 stdout as hookSpecificOutput.additionalContext on PreToolUse', () => {
+    const r = runBridge('check-before-pr', warnPayload('PreToolUse'));
+    expect(r.exitCode).toBe(0);
+
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.hookSpecificOutput.hookEventName).toBe('PreToolUse');
+    expect(parsed.hookSpecificOutput.additionalContext).toContain('1 task created this session, 1 still open');
+  });
+
+  it('wraps PostToolUse the same way', () => {
+    const payload = warnPayload('PostToolUse');
+    const r = runBridge('check-before-pr', payload);
+    expect(JSON.parse(r.stdout).hookSpecificOutput.hookEventName).toBe('PostToolUse');
+  });
+
+  it('falls back to raw stdout when the host sends no hook_event_name', () => {
+    // Older hosts, and any event outside the tool pair. Byte-identical to the
+    // pre-#1435 behaviour rather than a JSON blob the host cannot interpret.
+    const r = runBridge('check-before-pr', warnPayload(undefined));
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('1 task created this session, 1 still open');
+    expect(r.stdout.trim().startsWith('{')).toBe(false);
+  });
+
+  it('leaves a blocking gate on stderr with exit 2, unwrapped', () => {
+    // The block path must stay plain text: Claude Code reads a PreToolUse
+    // exit-2 stderr directly, and wrapping it would bury the reason.
+    const payload = warnPayload('PreToolUse');
+    setMode('block');
+    const r = runBridge('check-before-pr', payload);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('1 task created this session, 1 still open');
+    expect(r.stdout).toBe('');
+  });
+});
+
+describe('#1435 every gate copy carries the fix', () => {
+  const copies = [
+    ['bin/gate.cjs', readFileSync(GATE, 'utf-8')],
+    ['.claude/helpers/gate.cjs', readFileSync(join(REPO_ROOT, '.claude', 'helpers', 'gate.cjs'), 'utf-8')],
+    ['generateGateScript()', generateGateScript()],
+  ] as const;
+
+  for (const [name, src] of copies) {
+    it(`${name} handles record-tasks-acknowledged and reads the mode`, () => {
+      expect(src).toContain("case 'record-tasks-acknowledged'");
+      expect(src).toContain('task_status_gate');
+      expect(src).toContain('readTaskLedger');
+    });
+
+    /**
+     * The escape path must be the `__filename` TOKEN, resolved when the gate runs
+     * in the consumer. The generator embeds its copy inside a template literal, so
+     * a `${__filename}` slip would bake the build machine's absolute path into
+     * every consumer's block message — wrong for them, and a path disclosure.
+     */
+    it(`${name} resolves the escape path at runtime, not at build time`, () => {
+      expect(src).toMatch(/'node "' \+ __filename \+ '"/);
+      expect(src).not.toMatch(/node "\/(home|Users)\//);
+    });
+  }
+
+  const hooks = [
+    ['bin/gate-hook.mjs', readFileSync(GATE_HOOK, 'utf-8')],
+    ['.claude/helpers/gate-hook.mjs', readFileSync(join(REPO_ROOT, '.claude', 'helpers', 'gate-hook.mjs'), 'utf-8')],
+  ] as const;
+
+  for (const [name, src] of hooks) {
+    it(`${name} wraps passing-gate advisories`, () => {
+      expect(src).toContain('additionalContext');
+      expect(src).toContain('hook_event_name');
+    });
+  }
+});
+
+/**
+ * The generated copy is what a FRESH `flo init` writes. Substring-matching its
+ * source cannot catch a syntax error inside the template literal — a mis-escaped
+ * `\n`, an unbalanced brace — which would then ship to every new project.
+ */
+describe('#1435 the generated gate script runs, not just contains the case', () => {
+  it('blocks and then acknowledges, executed as a fresh init would write it', () => {
+    const genPath = join(root, 'generated-gate.cjs');
+    writeFileSync(genPath, generateGateScript());
+
+    const env = baseEnv();
+    otherGatesGreen();
+    withTranscript(env, taskCreate('1'));
+
+    const blocked = spawnSync(process.execPath, [genPath, 'check-before-pr'], {
+      env, encoding: 'utf-8', timeout: 30_000,
+    });
+    expect(blocked.stderr).not.toMatch(/SyntaxError|Unexpected token/);
+    expect(blocked.status).toBe(2);
+    expect(blocked.stderr).toContain('1 task created this session, 1 still open');
+
+    const ack = spawnSync(process.execPath, [genPath, 'record-tasks-acknowledged'], {
+      env, encoding: 'utf-8', timeout: 30_000,
+    });
+    expect(ack.status).toBe(0);
+    expect(readStateFile().tasksAcknowledged).toBe(true);
+
+    const after = spawnSync(process.execPath, [genPath, 'check-before-pr'], {
+      env, encoding: 'utf-8', timeout: 30_000,
+    });
+    expect(after.status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

A `/flo` run on a consumer project opened four tasks, finished all four items of work, verified, committed, and shipped a green PR with `TaskUpdate` called **zero** times. All four ended at `pending`. #1374 had already shipped the check that was supposed to catch exactly this — and it was installed and running.

**It could not be heard.** The open-task count goes to **stdout**, and `check-before-pr` exits 0 once the other gates pass. Claude Code surfaces a passing `PreToolUse` hook's stdout in transcript mode only: the model never sees it, and the user sees it only by opening the transcript. It reached anyone at all *solely* when some **other** gate blocked, because `gate-hook.mjs` re-routes a failed gate's stdout to stderr. So the closing half of #1374 fired only on runs already stopped for another reason, and was a no-op on every clean one.

That is the surprise in this ticket, and it is not specific to one message — every advisory on the exit-0 path was equally unheard.

## Changes

**Delivery — passing-gate advisories now reach Claude.** `bin/gate-hook.mjs` emits exit-0 stdout on `PreToolUse`/`PostToolUse` as `hookSpecificOutput.additionalContext`, the documented channel into the model's context. This repairs the whole class: the TaskCreate reminder, the pre-Agent memory reminder, the namespace hint, the docs-only and simplify-auto-pass notes. `SessionStart` and `UserPromptSubmit` already inject their stdout as context and are deliberately untouched; an unknown or absent `hook_event_name` falls back to raw stdout, byte-identical to before.

**Enforcement — open tasks block the PR.** New `gates.task_status_gate`: `block` (default), `warn` (the old report-only behaviour, now actually delivered), or `off`. Boolean forms are accepted; an unrecognised value keeps blocking, so a typo is never a stealth opt-out.

Deliberate deferral stays a legitimate outcome. The block prints a one-command escape:

```
node "<abs path>/.claude/helpers/gate.cjs" record-tasks-acknowledged
```

built from `__filename` — `$CLAUDE_PROJECT_DIR` is unset in the Bash tool, and a relative path breaks from any cwd but the project root. It credits the gate without closing anything, so no task is ever marked `completed` to clear a gate. The escape **verifies its own write landed** before reporting success: `writeState` swallows errors by design, and a silent loss would deadlock the only way out of a blocking gate.

The gate stays subordinate to `task_create_first` (both halves on or off together) and **fails open** — a missing, oversized, or unreadable transcript, or a session with no `TaskCreate` at all, blocks nothing.

Mirrored across all three gate copies. The init-generated fallback carries the **full** ledger, not a stub: it may omit *relaxations* the synced `bin/gate.cjs` has (that only makes it stricter), but omitting an *enforcement* gate would make it silently permissive — this ticket's own failure mode.

**Drive-by, same wiring surface.** `HOOK_ENTRY_MAP` grafted `check-bash-memory` under `PostToolUse` while the generator and reference block place it under `PreToolUse`, where #1132 moved it so its `exit(2)` prevents the read instead of reporting one that already happened. Invisible on any project that already had the hook (the presence check is a raw substring scan), but a consumer missing it would have been "repaired" into a gate that cannot block. Now guarded by an event-parity test — proven to catch the drift by reverting the fix and watching it go red.

## Testing

- [x] Unit tests pass — `tests/bin/gate-task-status-1435.test.ts` (31 tests): block/warn/off/boolean/typo routing, the acknowledgement escape, the escape's printed command **executed from an unrelated cwd**, persistence-failure diagnostics (induced cross-platform by making the state path a directory), fail-open on absent/nonexistent/over-cap transcripts, copy parity, and the generated script **executed** rather than string-matched
- [x] Bridge tests assert delivery at `gate-hook.mjs` itself, not by string-matching `gate.cjs`
- [x] `tests/bin/gate-helpers.test.ts` #1374 ledger cases repinned in `warn` mode (they test arithmetic, not the mode) — 290 pass
- [x] Full suite: 10734 passed, 0 failed; build and lint clean
- [x] Dogfooded live: the reminder from a **passing** hook reached the model as `additionalContext` during this session, and this PR's own `gh pr create` was blocked by the new gate and released by the acknowledgement command

## Consumer impact

After upgrading, a session that opens tasks and leaves them open is stopped at `gh pr create` until they are closed, deleted, or acknowledged. `gates: task_status_gate: warn` keeps report-only behaviour; `off` silences it; `task_create_first: false` disables both halves.

Closes #1435
