### PR TITLE
fix(tests,gates): stop the suite resetting live workflow state; verify the no-durable-lesson write

### DIFF
--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -1506,6 +1506,23 @@ switch (command) {
       writeState(s);
     }
     if (command === 'record-no-durable-lesson') {
+      // Same reasoning as record-tasks-acknowledged above: writeState swallows
+      // its own errors so a gate never crashes the hook it runs in, and this is
+      // the ONLY escape from the BLOCKING learnings gate that does not require a
+      // memory_store. A lost write here would print "satisfied" and then block
+      // the next `gh pr create` with nothing said about why — #1332's deadlock.
+      // Verified only on this arm: record-learnings-stored is fired
+      // automatically by the PostToolUse hook on every memory_store, where a
+      // failed write leaves the gate closed but the run still has the ordinary
+      // way through, and a diagnostic on every store would be noise.
+      if (!readState().learningsStored) {
+        process.stderr.write(
+          'Learnings gate NOT satisfied: the declaration could not be persisted to\n' +
+          STATE_FILE + '\n' +
+          'Check that the file and its directory are writable, then run this again.\n' +
+          'To proceed without it: set gates: learnings_gate: false in moflo.yaml.\n');
+        process.exit(1);
+      }
       process.stdout.write(
         'Learnings gate satisfied: no durable lesson declared for this run.\n' +
         'What this run did belongs in the PR body, not in memory.\n',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — the no-durable-lesson escape could report success on a write that never landed
+
+`writeState` swallows its own errors so a gate never crashes the hook it runs in. That is right for
+an advisory recorder and wrong for the one command that releases a *blocking* gate without doing the
+work the gate asks for: `record-no-durable-lesson` printed "Learnings gate satisfied", and if the
+write had failed the very next `gh pr create` was blocked again with nothing said about why. #1435
+hardened `record-tasks-acknowledged` against exactly this; this is the only other command with the
+shape. It now re-reads the state, and on a lost write exits non-zero naming the state file and
+`gates: learnings_gate: false`. `record-learnings-stored` shares the case body and stays silent —
+it fires automatically on every `memory_store`, where a failed write leaves the ordinary route
+through the gate intact.
+
+**Consumer impact.** None on a healthy project; the command behaves as before. On a project whose
+`.claude/workflow-state.json` is not writable, a run that would previously have looped between a
+false "satisfied" and a blocked PR now says so on the first attempt.
+
+### Fixed — running the test suite reset the developer's own workflow state
+
+A launcher spawn in `tests/bin/launcher-visibility.test.ts` passed a `cwd` but no environment, so it
+inherited the `CLAUDE_PROJECT_DIR` that Claude Code sets to the real project root. The launcher's
+session-reset then rewrote *that* project's `.claude/workflow-state.json` with its four-field
+starting shape — wiping `memorySearched`, `sessionId`, and every earned gate credit out from under
+the live session. Two test files were enough. It never showed up in CI, which does not set the
+variable: the divergence was the bug. `vitest.setup.ts` now drops the inherited value so local runs
+match CI, the spawn carries its own anchor, and a regression test spawns the launcher un-anchored
+and asserts the repo's state file is untouched.
+
+Repairing the anchor also exposed a test that had been passing for the wrong reason: with the
+launcher pointed at the real repo it never touched its own fixture, so "aborted launcher leaves the
+version stamp unchanged" was true no matter what the launcher did. Pointed at the fixture, the abort
+has to land before the manifest write the stamp commit is gated on — the test now hangs the
+cherry-pick rather than the embeddings migration, and a second test pins the other half of that
+contract: an abort *after* the sync keeps the new stamp, so the next session does not re-detect the
+upgrade.
+
+**Consumer impact.** None — test and dev-config only, nothing in this entry ships.
+
 ### Fixed — task lists shipped stale, and the reminder that was supposed to catch it was invisible (#1435)
 
 A `/flo` run on a consumer project created four tasks, completed all four items of work, verified,

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -1506,6 +1506,23 @@ switch (command) {
       writeState(s);
     }
     if (command === 'record-no-durable-lesson') {
+      // Same reasoning as record-tasks-acknowledged above: writeState swallows
+      // its own errors so a gate never crashes the hook it runs in, and this is
+      // the ONLY escape from the BLOCKING learnings gate that does not require a
+      // memory_store. A lost write here would print "satisfied" and then block
+      // the next `gh pr create` with nothing said about why — #1332's deadlock.
+      // Verified only on this arm: record-learnings-stored is fired
+      // automatically by the PostToolUse hook on every memory_store, where a
+      // failed write leaves the gate closed but the run still has the ordinary
+      // way through, and a diagnostic on every store would be noise.
+      if (!readState().learningsStored) {
+        process.stderr.write(
+          'Learnings gate NOT satisfied: the declaration could not be persisted to\n' +
+          STATE_FILE + '\n' +
+          'Check that the file and its directory are writable, then run this again.\n' +
+          'To proceed without it: set gates: learnings_gate: false in moflo.yaml.\n');
+        process.exit(1);
+      }
       process.stdout.write(
         'Learnings gate satisfied: no durable lesson declared for this run.\n' +
         'What this run did belongs in the PR body, not in memory.\n',

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -976,6 +976,18 @@ switch (command) {
       writeState(s);
     }
     if (command === 'record-no-durable-lesson') {
+      // Same reasoning as record-tasks-acknowledged: this is the ONLY escape
+      // from the BLOCKING learnings gate that needs no memory_store, so an
+      // unconfirmed write would report "satisfied" and block anyway. Verified
+      // only on this arm — record-learnings-stored fires automatically on every
+      // memory_store, where a lost write still leaves the ordinary way through.
+      if (!readState().learningsStored) {
+        process.stderr.write('Learnings gate NOT satisfied: the declaration could not be persisted to\\n' +
+          STATE_FILE + '\\n' +
+          'Check that the file and its directory are writable, then run this again.\\n' +
+          'To proceed without it: set gates: learnings_gate: false in moflo.yaml.\\n');
+        process.exit(1);
+      }
       process.stdout.write(
         'Learnings gate satisfied: no durable lesson declared for this run.\\n' +
         'What this run did belongs in the PR body, not in memory.\\n',

--- a/tests/bin/gate-no-durable-lesson-1434.test.ts
+++ b/tests/bin/gate-no-durable-lesson-1434.test.ts
@@ -183,6 +183,58 @@ describe('#1434 the block message teaches the bar, not just the mechanism', () =
 });
 
 /**
+ * `writeState` swallows its own errors so a gate never crashes the hook it runs
+ * in — correct while every recorder was advisory, wrong for the ONE command that
+ * releases a blocking gate without doing the work the gate asks for. Reporting
+ * success on a write that never landed leaves the next `gh pr create` blocked
+ * with nothing said about why: the deadlock #1332 already paid for once, and the
+ * same shape `record-tasks-acknowledged` was hardened against in #1435.
+ *
+ * The failure is induced by making the state path a DIRECTORY, which fails the
+ * write on every platform (Rule #1) — unlike a permissions bit, which Windows
+ * would happily ignore.
+ */
+describe('#1434 the escape hatch never claims a write it did not make', () => {
+  it('reports failure, loudly, when the declaration cannot be persisted', () => {
+    rmSync(join(root, '.claude', 'workflow-state.json'), { force: true });
+    mkdirSync(join(root, '.claude', 'workflow-state.json'), { recursive: true });
+
+    const r = gate('record-no-durable-lesson');
+    expect(r.status).not.toBe(0);
+    expect(r.stdout).not.toContain('gate satisfied');
+    expect(r.stderr).toContain('NOT satisfied');
+    // Name the file and a way forward — a diagnostic that only says "failed"
+    // leaves the caller in the same deadlock.
+    expect(r.stderr).toContain('workflow-state.json');
+    expect(r.stderr).toContain('learnings_gate: false');
+  });
+
+  /**
+   * `record-learnings-stored` shares this case body but is fired automatically
+   * by the PostToolUse hook on every `memory_store`. A failed write there leaves
+   * the gate closed while the ordinary path through it still exists, so it must
+   * stay quiet rather than print a diagnostic on every store.
+   */
+  it('stays silent on the automatic credit, which has an ordinary way through', () => {
+    rmSync(join(root, '.claude', 'workflow-state.json'), { force: true });
+    mkdirSync(join(root, '.claude', 'workflow-state.json'), { recursive: true });
+
+    const r = gate('record-learnings-stored');
+    expect(r.status).toBe(0);
+    expect(r.stderr).not.toContain('NOT satisfied');
+  });
+
+  it('names the disable knob that actually controls this gate', () => {
+    // `learnings_gate: false` is the key `check-before-pr` reads; pointing at any
+    // other gate name would send the caller to a setting that changes nothing.
+    writeFileSync(join(root, 'moflo.yaml'), 'gates:\n  learnings_gate: false\n');
+    earnCreditsExceptLearnings();
+    const { stderr } = gate('check-before-pr', PR_CMD);
+    expect(stderr).not.toContain('durable lesson');
+  });
+});
+
+/**
  * The generated copy is the one a FRESH `flo init` writes, and every existing
  * test of it only string-matches the source. A syntax error inside the template
  * literal — a mis-escaped `\n`, an unbalanced brace — would therefore ship to
@@ -206,6 +258,25 @@ describe('#1434 the generated gate script runs, not just contains the case', () 
     expect(r.status).toBe(0);
     expect(r.stdout).toContain('no durable lesson');
     expect(readStateFile().learningsStored).toBe(true);
+  });
+
+  it('emits the persistence diagnostic, so its escaping survives the template', () => {
+    const genPath = join(root, 'generated-gate.cjs');
+    writeFileSync(genPath, generateGateScript());
+    rmSync(join(root, '.claude', 'workflow-state.json'), { force: true });
+    mkdirSync(join(root, '.claude', 'workflow-state.json'), { recursive: true });
+
+    const r = spawnSync(process.execPath, [genPath, 'record-no-durable-lesson'], {
+      cwd: root,
+      encoding: 'utf-8',
+      timeout: 30_000,
+      env: { ...process.env, CLAUDE_PROJECT_DIR: root },
+    });
+
+    expect(r.stderr).not.toMatch(/SyntaxError|Unexpected token/);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain('NOT satisfied');
+    expect(r.stderr).toContain('learnings_gate: false');
   });
 });
 
@@ -239,6 +310,14 @@ describe('#1434 all three gate copies carry the fix', () => {
     it(`${name} resolves the escape path at runtime, not at build time`, () => {
       expect(src).toMatch(/'node "' \+ __filename \+ '"/);
       expect(src).not.toMatch(/node "\/(home|Users)\//);
+    });
+
+    /**
+     * Cheap to lose in a merge, and the loss is invisible: the command still
+     * exits 0 and still prints "satisfied", it just stops being true.
+     */
+    it(`${name} re-reads state before claiming the gate is satisfied`, () => {
+      expect(src).toContain('if (!readState().learningsStored)');
     });
   }
 });

--- a/tests/bin/launcher-state-leak.test.ts
+++ b/tests/bin/launcher-state-leak.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Guard: running the test suite must not rewrite the developer's own
+ * `.claude/workflow-state.json`.
+ *
+ * `bin/session-start-launcher.mjs` §2 resets workflow state on every start,
+ * writing the 4-field session-reset shape over whatever `resolveStateRoot()`
+ * picks. That resolver treats an inherited `CLAUDE_PROJECT_DIR` as
+ * authoritative, and Claude Code sets that variable to the developer's real
+ * project root — which every `spawnSync(..., { env: { ...process.env } })` in
+ * this suite then hands to the child. A launcher spawn that forgets its own
+ * anchor therefore resets the LIVE session: `memorySearched`, `sessionId`,
+ * `testsRun`, `simplifyRun` and the rest all revert mid-run, and the gates
+ * start blocking work that was already credited.
+ *
+ * Reproduced before the fix: `launcher-visibility` + `launcher-854-fixes` were
+ * enough to truncate this repo's state file to `{tasksCreated, taskCount,
+ * memorySearched, sessionStart}`.
+ *
+ * Two things keep it shut, and this file proves the pair end to end:
+ *   1. `vitest.setup.ts` deletes the ambient `CLAUDE_PROJECT_DIR`, so an
+ *      un-anchored child cannot inherit a pointer to the real repo (CI never
+ *      sets the variable, so this makes local runs match CI).
+ *   2. Fixtures live under `os.tmpdir()`, so the fallback walk-up from the
+ *      child's cwd cannot climb into the repo either. A fixture staged inside
+ *      the repo (e.g. under `.testoutput/`) defeats (1) on its own — the walk
+ *      finds the repo's `.moflo/moflo.db` above it.
+ *
+ * If this goes red, do NOT relax the assertion: find the spawn that lost its
+ * anchor. The failure mode it catches is silent, and it corrupts state the
+ * developer is actively relying on.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+const LAUNCHER = join(REPO_ROOT, 'bin', 'session-start-launcher.mjs');
+const REPO_STATE = join(REPO_ROOT, '.claude', 'workflow-state.json');
+
+/** Contents of the repo's own state file, or null when it has none. */
+function snapshotRepoState(): string | null {
+  try {
+    return readFileSync(REPO_STATE, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+function restoreRepoState(snapshot: string | null): void {
+  try {
+    if (snapshot === null) {
+      rmSync(REPO_STATE, { force: true });
+    } else {
+      mkdirSync(join(REPO_ROOT, '.claude'), { recursive: true });
+      writeFileSync(REPO_STATE, snapshot);
+    }
+  } catch {
+    /* best effort — the assertion below is what reports the leak */
+  }
+}
+
+describe('session-start launcher: test spawns stay inside their fixture', () => {
+  it('leaves the repo workflow-state.json untouched when spawned with no CLAUDE_PROJECT_DIR', () => {
+    // Outside the repo on purpose — see (2) in the header.
+    const fixture = mkdtempSync(join(tmpdir(), 'moflo-launcher-leak-'));
+    writeFileSync(
+      join(fixture, 'package.json'),
+      JSON.stringify({ name: 'launcher-leak-fixture', version: '0.0.0' }),
+    );
+
+    const before = snapshotRepoState();
+    let after: string | null;
+    let fixtureWroteState: boolean;
+    let stderr: string;
+
+    try {
+      // Deliberately un-anchored: `{ ...process.env }` and a cwd, exactly what
+      // a call site that forgot its override looks like. The env must NOT gain
+      // a CLAUDE_PROJECT_DIR here — that is the condition under test.
+      const result = spawnSync(process.execPath, [LAUNCHER], {
+        cwd: fixture,
+        encoding: 'utf-8',
+        timeout: 30_000,
+        env: { ...process.env, CI: '1' },
+        input: '',
+      });
+      after = snapshotRepoState();
+      fixtureWroteState = existsSync(join(fixture, '.claude', 'workflow-state.json'));
+      stderr = result.stderr || '';
+    } finally {
+      // Runs before either assertion below, so a red result still hands the
+      // developer their session state back.
+      restoreRepoState(before);
+      rmSync(fixture, { recursive: true, force: true });
+    }
+
+    // The leak assertion comes FIRST. When the anchor is lost the launcher
+    // resets the repo AND writes nothing to the fixture, so a vacuity check
+    // ahead of it would fire first and blame an early exit for a leak.
+    expect(
+      after,
+      `The launcher reset THIS repo's ${REPO_STATE} instead of its fixture. Some ` +
+        `spawn is inheriting a CLAUDE_PROJECT_DIR that points at the real project — ` +
+        `check that vitest.setup.ts still deletes it and that the spawn passes its ` +
+        `own anchor. (The original contents have been restored.)`,
+    ).toBe(before);
+
+    // Not vacuous: the launcher has to have actually reached §2 and written a
+    // state file somewhere, or "the repo file is unchanged" proves nothing.
+    expect(
+      fixtureWroteState,
+      `Launcher wrote no state file in its fixture and left the repo alone — it ` +
+        `probably exited early, which makes the leak assertion above vacuous. ` +
+        `stderr: ${stderr}`,
+    ).toBe(true);
+  });
+});

--- a/tests/bin/launcher-visibility.test.ts
+++ b/tests/bin/launcher-visibility.test.ts
@@ -435,24 +435,36 @@ describe('session-start-launcher — visible mutation reporter (#716)', () => {
     const stampPath = join(root, '.moflo', 'moflo-version');
     writeFileSync(stampPath, '9.9.8');
 
-    // Stage a hanging embeddings-migration so the launcher gets stuck on the
-    // `await mod.runEmbeddingsMigrationIfNeeded(...)` call. The setInterval
-    // keeps the event loop busy so Node won't bail out via "unsettled top-level
-    // await" — we want to verify the SIGKILL path that mirrors a libuv-style
-    // crash mid-upgrade (the original failure shape from #726 task G).
+    // Stage a hanging cherry-pick so the launcher gets stuck on the
+    // `await mod.cherryPickLearningsFromLegacy(...)` call — which sits BEFORE
+    // the manifest write, and the stamp is committed immediately after that
+    // write. Hanging anything later (the embeddings migration, say) aborts the
+    // launcher on the far side of the commit and the stamp legitimately reads
+    // 9.9.9; that half of the contract is pinned by the next test. The
+    // setInterval keeps the event loop busy so Node won't bail out via
+    // "unsettled top-level await" — we want the SIGKILL path that mirrors a
+    // libuv-style crash mid-upgrade (the original failure shape from #726 task G).
     const servicesDir = join(root, 'node_modules', 'moflo', 'dist', 'src', 'cli', 'services');
     mkdirSync(servicesDir, { recursive: true });
-    const migrationFile = join(servicesDir, 'embeddings-migration.js');
+    const cherryPickFile = join(servicesDir, 'cherry-pick-learnings.js');
     writeFileSync(
-      migrationFile,
-      'export const runEmbeddingsMigrationIfNeeded = () => new Promise(() => { setInterval(() => {}, 1000); });\n',
+      cherryPickFile,
+      'export const cherryPickLearningsFromLegacy = () => new Promise(() => { setInterval(() => {}, 1000); });\n',
     );
 
     // Spawn + SIGKILL after enough time for ESM imports + the synchronous
-    // upgrade-work blocks to reach the hanging migration. Cross-platform:
+    // upgrade-work blocks to reach the hanging cherry-pick. Cross-platform:
     // Node maps SIGKILL → TerminateProcess on Windows.
+    //
+    // Anchor CLAUDE_PROJECT_DIR like `runLauncher` above does — `cwd` alone is
+    // not enough. `resolveStateRoot()` treats an inherited value as
+    // authoritative, so without this the launcher resets whatever project the
+    // ambient env points at rather than this fixture.
     await new Promise<void>((resolveExit) => {
-      const child = spawn('node', [LAUNCHER], { cwd: root });
+      const child = spawn('node', [LAUNCHER], {
+        cwd: root,
+        env: { ...process.env, CLAUDE_PROJECT_DIR: root },
+      });
       const killTimer = setTimeout(() => child.kill('SIGKILL'), 800);
       child.on('exit', () => {
         clearTimeout(killTimer);
@@ -460,14 +472,16 @@ describe('session-start-launcher — visible mutation reporter (#716)', () => {
       });
     });
 
-    // Stamp must STILL be the old version — the launcher never reached the
-    // post-notice-clear commit point because it was killed mid-flight.
+    // Stamp must STILL be the old version — the launcher was killed before it
+    // reached the manifest write the stamp commit is gated on. (A launcher too
+    // slow to even reach the cherry-pick lands here too, which is the same
+    // verdict, so there is no timing race in this assertion.)
     expect(readFileSync(stampPath, 'utf-8').trim()).toBe('9.9.8');
 
     // Drop the hanging fixture so the second run can complete.
     writeFileSync(
-      migrationFile,
-      'export const runEmbeddingsMigrationIfNeeded = () => Promise.resolve();\n',
+      cherryPickFile,
+      'export const cherryPickLearningsFromLegacy = () => Promise.resolve({ copied: 0 });\n',
     );
 
     // Next launcher detects the same upgrade and completes it cleanly: stamp
@@ -482,6 +496,77 @@ describe('session-start-launcher — visible mutation reporter (#716)', () => {
     const notice = JSON.parse(readFileSync(noticePath, 'utf-8'));
     expect(notice.status).toBe('completed');
   });
+
+  it('aborted launcher AFTER the sync keeps the new stamp so the next run does not re-detect (#730)', async () => {
+    // The other half of the contract the previous test pins. `session-start-
+    // launcher.mjs` commits the version stamp immediately after the manifest
+    // write, on purpose: "an abort BEFORE sync still re-runs upgrade detection,
+    // while an abort AFTER sync no longer strands the stamp in a re-detect
+    // loop." Without this test only the first half is covered, and a change
+    // that moved the commit back to the end of the launcher would look green.
+    mkdirSync(join(root, 'node_modules', 'moflo'), { recursive: true });
+    writeFileSync(
+      join(root, 'node_modules', 'moflo', 'package.json'),
+      JSON.stringify({ name: 'moflo', version: '9.9.9' }),
+    );
+    mkdirSync(join(root, '.moflo'), { recursive: true });
+    const stampPath = join(root, '.moflo', 'moflo-version');
+    writeFileSync(stampPath, '9.9.8');
+
+    // Hang the embeddings migration — section 3e, well past the manifest write.
+    const servicesDir = join(root, 'node_modules', 'moflo', 'dist', 'src', 'cli', 'services');
+    mkdirSync(servicesDir, { recursive: true });
+    writeFileSync(
+      join(servicesDir, 'embeddings-migration.js'),
+      'export const runEmbeddingsMigrationIfNeeded = () => new Promise(() => { setInterval(() => {}, 1000); });\n',
+    );
+
+    // Poll for the stamp rather than sleeping a fixed interval: the kill has to
+    // land after the commit, and how long the sync takes varies with runner
+    // load. A fixed delay would be a flake on a slow CI box.
+    await new Promise<void>((resolveExit, rejectExit) => {
+      const child = spawn('node', [LAUNCHER], {
+        cwd: root,
+        env: { ...process.env, CLAUDE_PROJECT_DIR: root },
+      });
+      // Bounded well inside the `it` timeout below: the second launcher spawn
+      // still has to run to completion after this, and a deadline that ate most
+      // of the budget would turn a slow runner into a timeout that reads like a
+      // regression. The stamp lands in well under a second in practice — this
+      // ceiling only matters when something is already broken.
+      const deadline = Date.now() + 10_000;
+      const poll = setInterval(() => {
+        let stamped = false;
+        try {
+          stamped = readFileSync(stampPath, 'utf-8').trim() === '9.9.9';
+        } catch { /* mid-write — try again next tick */ }
+        if (stamped || Date.now() > deadline) {
+          clearInterval(poll);
+          child.kill('SIGKILL');
+        }
+      }, 25);
+      child.on('exit', () => {
+        clearInterval(poll);
+        resolveExit();
+      });
+      child.on('error', (err) => {
+        clearInterval(poll);
+        rejectExit(err);
+      });
+    });
+
+    expect(readFileSync(stampPath, 'utf-8').trim()).toBe('9.9.9');
+
+    // Drop the hang so the second run completes, and assert it treats the
+    // project as already upgraded — no re-detect loop.
+    writeFileSync(
+      join(servicesDir, 'embeddings-migration.js'),
+      'export const runEmbeddingsMigrationIfNeeded = () => Promise.resolve();\n',
+    );
+    const second = runLauncher(root);
+    expect(second.stdout).not.toContain('moflo: upgraded');
+    expect(readFileSync(stampPath, 'utf-8').trim()).toBe('9.9.9');
+  }, 40_000);
 
   it('replaces a stale upgrade-notice.json with a fresh completed notice on a subsequent upgrade (#738)', () => {
     // Pre-seed with a stale notice from a prior upgrade. Section 0-pre wipes

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -142,6 +142,7 @@ export const isolationTests = [
   'tests/bin/launcher-854-fixes.test.ts',
   'tests/bin/launcher-928-dogfood-skip.test.ts',
   'tests/bin/launcher-headless-skip.test.ts',
+  'tests/bin/launcher-state-leak.test.ts',
   'tests/bin/launcher-visibility.test.ts',
   'tests/bin/prompt-hook-restart-notice.test.ts',
   'tests/system/launcher-version-skew-upgrade-boundary.test.ts',

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -38,6 +38,28 @@ import './src/cli/memory/suppress-sqlite-warning.js';
 // beforeEach, which runs *after* this one.
 const INITIAL_CWD = process.cwd();
 
+// Drop the ambient CLAUDE_PROJECT_DIR the runner inherited. Claude Code sets it
+// to the developer's real project root, and every `spawnSync('node', [LAUNCHER])`
+// / `[GATE]` in the suite passes `{ ...process.env }` through — so a call site
+// that forgets its own override anchors the child at the REAL repo instead of
+// its tmp fixture. `bin/session-start-launcher.mjs` §2 then rewrites
+// `.claude/workflow-state.json` with the 4-field session-reset shape, wiping the
+// live session's memorySearched/sessionId and every gate flag mid-run. Measured:
+// two launcher test files were enough (`tests/bin/launcher-visibility.test.ts`
+// spawned the launcher with `{ cwd: root }` and no env at all).
+//
+// CI never sets the var, so unsetting it here makes local runs match CI rather
+// than diverge from it — the divergence is precisely why this only ever bit a
+// developer. Nothing in the suite reads it expecting the real repo: every test
+// that needs an anchor assigns its own (and restores to `undefined`, i.e. this
+// state). With it unset, `findProjectRoot` walks up from the child's cwd, which
+// for a tmp fixture stays in the tmp fixture.
+//
+// Deleted once at module load, NOT in the beforeEach below: test files that set
+// the anchor outside a hook (module scope, `beforeAll`, a fixture helper) would
+// have it stripped out from under them by a per-test delete.
+delete process.env.CLAUDE_PROJECT_DIR;
+
 // Set once at module load (every test file imports this setup).
 process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
 


### PR DESCRIPTION
Two follow-ups from #1435, both found while shipping it and reported at the time rather than folded in silently.

## 1. Running the test suite reset the developer's own workflow state

A launcher spawn in `tests/bin/launcher-visibility.test.ts` passed a `cwd` but no `env`, so it inherited the `CLAUDE_PROJECT_DIR` that Claude Code sets to the real project root. `resolveStateRoot()` treats an inherited value as authoritative, so the launcher's session-reset rewrote **that** project's `.claude/workflow-state.json` with its four-field starting shape — wiping `memorySearched`, `sessionId`, and every earned gate credit out from under the live session. Two test files were enough to do it.

CI never sets the variable, so it never showed up there. That divergence *was* the bug.

- `vitest.setup.ts` drops the inherited value at module load, so local runs match CI. Deleted once at load rather than per-test, so files that anchor in module scope or `beforeAll` keep their own value.
- The spawn carries its own anchor, like every other spawn in that file.
- `tests/bin/launcher-state-leak.test.ts` spawns the launcher deliberately un-anchored and asserts the repo's state file is untouched — restoring it in a `finally`, so a red run does not cost the developer their session.

Repairing the anchor unmasked a test that had been passing for the wrong reason. Pointed at the real repo it never touched its own fixture, so *"aborted launcher leaves the version stamp unchanged (#730)"* held no matter what the launcher did. The stamp is committed immediately after the manifest write, so the abort has to land before that point: the test now hangs the cherry-pick rather than the embeddings migration, and a second test pins the other half of the contract the launcher actually guarantees — an abort **after** the sync keeps the new stamp, so the next session does not re-detect the upgrade.

## 2. `record-no-durable-lesson` could report a write that never landed

`writeState` swallows its own errors so a gate never crashes the hook it runs in. Right for an advisory recorder; wrong for the one command that releases a **blocking** gate without doing the work the gate asks for. #1435 hardened `record-tasks-acknowledged` against exactly this — this is the only other command with the shape.

It now re-reads state and, on a lost write, exits non-zero naming the state file and `gates: learnings_gate: false`. The shared `record-learnings-stored` arm stays silent: it fires automatically on every `memory_store`, where a failed write still leaves the ordinary route through the gate intact, and a diagnostic on every store would be noise.

Mirrored across all three gate copies — `bin/gate.cjs`, `.claude/helpers/gate.cjs`, and the `generateGateScript()` template — with a test that executes the generated copy's failure path so the template escaping cannot rot.

## Consumer impact

Section 1 is test and dev-config only; nothing in it ships. Section 2 is inert on a healthy project. On one whose `.claude/workflow-state.json` is not writable, a run that previously looped between a false "satisfied" and a blocked PR now says so on the first attempt.

## Verification

- Full suite: **10,743 passed, 0 failed** (re-run after the review fix). Lint (`--max-warnings 0`) and `tsc --noEmit` clean.
- Both fixes proven red-before-green: the leak test fails naming the repo's own state file when the setup fix is disabled; the persistence diagnostic is induced by making the state path a directory, which fails the write on every platform (Rule #1) unlike a permissions bit.
- `/flo-simplify` NORMAL tier (3 agents) + validation pass. Quality review confirmed `exit(1)` is safe here — the command is invoked as a plain Bash call, never registered as a `gate-hook.mjs` matcher, so it surfaces as a failed command rather than an exit-2 block. Its one actionable finding (the poll deadline left too little of the `it` budget for the second launcher spawn) is fixed.