### PR TITLE
chore: install moflo@4.12.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^10.8.0",
         "glob": "^11.1.0",
-        "moflo": "^4.12.6",
+        "moflo": "^4.12.7",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.0"
@@ -3412,9 +3412,9 @@
       }
     },
     "node_modules/moflo": {
-      "version": "4.12.6",
-      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.12.6.tgz",
-      "integrity": "sha512-aDyngFVg0prp/UxnmHbibgTCkz9MIFElP/0YV+NtYKaH+Zq8ddILtpgbmGQKlErvQK8b3RR4YZJzJwm1I+lATA==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.12.7.tgz",
+      "integrity": "sha512-XYkXOe3hhOLWOxUYmzsDSnntg7WKJ6d1kjBagBmTt+66yKBT1Bcz4qFJ708s+ZOLCBRjYa8gJee0VPKboqzR/A==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@typescript-eslint/parser": "^8.65.0",
     "eslint": "^10.8.0",
     "glob": "^11.1.0",
-    "moflo": "^4.12.6",
+    "moflo": "^4.12.7",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.0"


### PR DESCRIPTION
Dogfood install of the just-published `moflo@4.12.7`. Follows #1439 (the version bump) and completes the release cycle.

Two files, both mechanical:
- `package.json` — self-dogfood devDependency `^4.12.6` → `^4.12.7` (written by `npm install moflo@4.12.7 --save-dev`; deliberately deferred out of #1439 because 4.12.7 did not exist on npm yet and bumping it there would have desynced the lockfile)
- `package-lock.json` — matching resolution, plus `npm install --package-lock-only --force` to backfill cross-platform optional-dependency entries

Verified locally:
- `npm ci --dry-run --legacy-peer-deps` — up to date, lockfile in sync with `package.json`
- `node_modules/moflo` resolves to 4.12.7
- `npm view moflo version` → `4.12.7`, `dist-tags.latest` → `4.12.7`

The `chore: install moflo@<version>` message prefix is exact — it is the anchor `.claude/skills/publish/fingerprint.sh` uses to bound the next release's diff.