### PR TITLE
fix(launcher): stop /compact and /clear wiping workflow-state mid-run (#1441)

### DIFF
--- a/.claude/scripts/lib/hook-io.mjs
+++ b/.claude/scripts/lib/hook-io.mjs
@@ -26,9 +26,26 @@ export async function readHookStdin() {
     let done = false;
     let timer = null;
     const parse = (s) => { try { return s ? JSON.parse(s) : {}; } catch { return {}; } };
-    const finish = () => { if (done) return; done = true; if (timer) clearTimeout(timer); res(parse(data)); };
+    const onData = (c) => { if (!done) data += c; };
+    // Detach and pause on the way out. Without this the 500ms cap is a lie for
+    // any caller that keeps running afterwards: the listeners stay attached and
+    // a flowing stdin keeps the event loop alive well past the timeout. It was
+    // invisible while every caller exited immediately after reading; #1441 made
+    // the session-start launcher the first caller with real work left to do.
+    const finish = () => {
+      if (done) return;
+      done = true;
+      if (timer) clearTimeout(timer);
+      try {
+        process.stdin.off('data', onData);
+        process.stdin.off('end', finish);
+        process.stdin.off('error', finish);
+        process.stdin.pause();
+      } catch { /* teardown must never outrank returning the payload */ }
+      res(parse(data));
+    };
     process.stdin.setEncoding('utf-8');
-    process.stdin.on('data', (c) => { if (!done) data += c; });
+    process.stdin.on('data', onData);
     process.stdin.on('end', finish);
     process.stdin.on('error', finish);
     timer = setTimeout(finish, 500);

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -777,6 +777,32 @@ function resolveDaemonRecyclerPath() {
 const CONTINUING_SESSION_SOURCES = new Set(['compact', 'resume']);
 const KNOWN_SESSION_SOURCES = new Set(['startup', 'clear', 'compact', 'resume']);
 
+// …but a compaction is NOT a pure "keep everything" either. The credits above
+// describe work that still stands — tests ran, /verify passed, the diff is
+// unchanged. The memory-search credit is the one thing compaction genuinely
+// invalidates: `memorySearched` says "this actor has the search results in
+// context", and after a compaction it does not. Preserving it would hand the
+// post-compaction model a satisfied memory gate over a context that no longer
+// holds a single result — the exact "moflo isn't being used" symptom, arrived
+// at from the opposite direction.
+//
+// `memoryRequired` is re-armed for the same reason, and it also closes a second
+// hole reported against #1441: gate.cjs derives `memoryRequired` from the user's
+// prompt TEXT, and `/compact` is an 8-character non-task string, so submitting it
+// set `memoryRequired: false` and the scan/read gates went quiet until some later
+// prompt happened to qualify. SessionStart fires AFTER that UserPromptSubmit, so
+// re-arming here corrects it — and unlike a prompt-text rule it also covers AUTO
+// compaction, where no `/compact` is ever typed.
+//
+// Resume is untouched by this: it reloads the conversation, so a prior search is
+// still in context.
+//
+// Forcing `memoryRequired` on is deliberate even when the pre-compaction prompt
+// was genuinely trivial and scored false on its own merits. One memory search is
+// cheap; a context-blind model exploring files with the gate disarmed is the
+// thing this whole issue is about.
+const MEMORY_CREDIT_KEYS = ['memorySearched', 'memorySearchedBy', 'memoryRequired'];
+
 // Full shape, not the 4-field literal this used to write. gate.cjs readState()
 // merges STATE_DEFAULTS over whatever it parses, so the short shape behaved
 // identically THERE — but it left a half-populated file for every other reader
@@ -813,6 +839,14 @@ function freshWorkflowState() {
   };
 }
 
+// Derived from freshWorkflowState(), not a second literal: a re-armed memory
+// gate is by definition the fresh-session value of those keys, and one place to
+// change beats two that agree only by inspection.
+function rearmedMemoryState() {
+  const fresh = freshWorkflowState();
+  return Object.fromEntries(MEMORY_CREDIT_KEYS.map((key) => [key, fresh[key]]));
+}
+
 // Bounded at 500ms by readHookStdin and short-circuited on a TTY, so a withheld
 // stdin cannot eat the 5000ms SessionStart budget (hook-block-hash.ts). Read
 // here rather than at the top of the file so the cost lands next to its only
@@ -837,6 +871,32 @@ if (!CONTINUING_SESSION_SOURCES.has(sessionSource)) {
     writeFileSync(stateFile, JSON.stringify(freshWorkflowState(), null, 2));
   } catch {
     // Non-fatal - workflow gate will use defaults
+  }
+} else if (sessionSource === 'compact') {
+  // Merge, never rewrite: everything the run has earned stays, only the memory
+  // credit is re-armed. Skipped entirely when there is no state file yet — a
+  // compaction before any prompt has nothing to re-arm, and writing a partial
+  // file here would defeat freshWorkflowState()'s shape guarantee.
+  //
+  // Read-modify-write, unsynchronised, like gate.cjs's own writeState. Safe
+  // here because a compaction quiesces the session: no tool hook is mid-flight
+  // to race with, and the next UserPromptSubmit is strictly after this hook.
+  // Leaving an unparseable file alone is also correct rather than merely
+  // tolerable — gate.cjs readState() falls back to STATE_DEFAULTS on a parse
+  // failure, which arms the memory gate. Repairing it here would only convert a
+  // fail-safe into an equivalent write.
+  try {
+    if (existsSync(stateFile)) {
+      const parsed = JSON.parse(readFileSync(stateFile, 'utf-8'));
+      writeFileSync(
+        stateFile,
+        JSON.stringify({ ...parsed, ...rearmedMemoryState() }, null, 2),
+      );
+    }
+  } catch (err) {
+    // Non-fatal, but not silent (#854): a failure here leaves the memory gate
+    // credited over a context that no longer holds the results.
+    emitWarning(`could not re-arm the memory gate after compaction (${errMessage(err)})`);
   }
 }
 

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -19,6 +19,7 @@ import { makeSyncer, contentEqual, syncDirRecursive } from './lib/file-sync.mjs'
 import { INTERNAL_SKILLS } from './lib/internal-skills.mjs';
 import { parseSkillCategories, computeExcludedSkills } from './lib/skill-categories.mjs';
 import { loadShippedScripts } from './lib/shipped-scripts.mjs';
+import { readHookStdin } from './lib/hook-io.mjs';
 import {
   readContinuityConfig,
   readGitState,
@@ -651,7 +652,7 @@ function stopDaemon(lockFile) {
     // error 'process can only be terminated forcefully'. The prior
     // implementation invoked it anyway, swallowed the error, then polled
     // alive for 3s before escalating — exactly the time-waste that pushed
-    // §3's stopDaemon past the 3000ms SessionStart hook timeout. Go
+    // §3's stopDaemon past the SessionStart hook timeout. Go
     // straight to /F /T (tree-kill, in case a worker child outlived its
     // parent) on Win.
     if (process.platform === 'win32') {
@@ -753,23 +754,95 @@ function resolveDaemonRecyclerPath() {
 }
 
 // ── 2. Reset workflow state for new session ──────────────────────────────────
-const stateDir = resolve(projectRoot, '.claude');
-const stateFile = resolve(stateDir, 'workflow-state.json');
-try {
-  if (!existsSync(stateDir)) mkdirSync(stateDir, { recursive: true });
-  writeFileSync(stateFile, JSON.stringify({
+//
+// #1441 — reset on a NEW session only. Claude Code fires SessionStart with a
+// `source` of `startup`, `resume`, `clear` or `compact`, and moflo's settings
+// entry carries no matcher, so this launcher runs for all four. A compaction
+// is the SAME session continuing with a shorter context; a resume is the same
+// session reopened. Resetting there wiped gate state mid-run, two ways:
+//
+//   1. `flMode` and `sddMode` are derived ONLY from the user's prompt text
+//      (gate.cjs applyPromptStateReset). Clearing them turned the #952
+//      swarm/hive invocation gate and the #1297 SDD gate OFF for the rest of
+//      the run — the user's next prompt is ordinary prose, so nothing ever
+//      re-armed them. A `/fl -s` run that compacted stopped enforcing
+//      swarm_init before Agent spawns, silently.
+//   2. testsRun / simplifyRun / verifyRun / learningsStored and their
+//      fingerprints were discarded, so a compaction forced a full re-run of
+//      tests, /flo-simplify and /verify before `gh pr create`.
+//
+// Unknown, absent, or unparseable source resets — byte-identical to the old
+// behaviour on a host that doesn't send the field, and the safe direction
+// (gates armed rather than silently off).
+const CONTINUING_SESSION_SOURCES = new Set(['compact', 'resume']);
+const KNOWN_SESSION_SOURCES = new Set(['startup', 'clear', 'compact', 'resume']);
+
+// Full shape, not the 4-field literal this used to write. gate.cjs readState()
+// merges STATE_DEFAULTS over whatever it parses, so the short shape behaved
+// identically THERE — but it left a half-populated file for every other reader
+// of workflow-state.json, and it silently drifted from STATE_DEFAULTS each time
+// a gate field was added. tests/bin/launcher-1441-compact-preserves-state.test.ts
+// pins these keys to gate.cjs's STATE_DEFAULTS so they cannot drift apart again.
+function freshWorkflowState() {
+  return {
     tasksCreated: false,
     taskCount: 0,
+    tasksAcknowledged: false,
     memorySearched: false,
-    sessionStart: new Date().toISOString()
-  }, null, 2));
-} catch {
-  // Non-fatal - workflow gate will use defaults
+    memorySearchedBy: {},
+    memoryRequired: true,
+    learningsStored: false,
+    testsRun: false,
+    testsFingerprint: null,
+    simplifyRun: false,
+    simplifySnapshotSha: null,
+    simplifyFingerprint: null,
+    verifyRun: false,
+    verifyOutcome: null,
+    verifyFingerprint: null,
+    interactionCount: 0,
+    sessionStart: new Date().toISOString(),
+    lastBlockedAt: null,
+    lastNamespaceHint: '',
+    lastNamespaceHintEmittedBy: {},
+    flMode: null,
+    swarmInitialized: false,
+    hiveInitialized: false,
+    sddMode: false,
+    activeSddSlug: null,
+  };
+}
+
+// Bounded at 500ms by readHookStdin and short-circuited on a TTY, so a withheld
+// stdin cannot eat the 5000ms SessionStart budget (hook-block-hash.ts). Read
+// here rather than at the top of the file so the cost lands next to its only
+// consumer.
+const hookPayload = await readHookStdin();
+const sessionSource = typeof hookPayload?.source === 'string' ? hookPayload.source : '';
+// A source we don't recognise still resets — but say so. Falling through in
+// silence is how a renamed or newly-added "continuing" source would re-open
+// this bug with nothing to notice it by; the reset is only the safe default
+// while the set above is accurate.
+if (sessionSource && !KNOWN_SESSION_SOURCES.has(sessionSource)) {
+  emitWarning(
+    `unrecognized SessionStart source "${sessionSource}" — resetting workflow state. ` +
+    'If this source continues an existing session, it belongs in §2\'s skip list (#1441).',
+  );
+}
+const stateDir = resolve(projectRoot, '.claude');
+const stateFile = resolve(stateDir, 'workflow-state.json');
+if (!CONTINUING_SESSION_SOURCES.has(sessionSource)) {
+  try {
+    if (!existsSync(stateDir)) mkdirSync(stateDir, { recursive: true });
+    writeFileSync(stateFile, JSON.stringify(freshWorkflowState(), null, 2));
+  } catch {
+    // Non-fatal - workflow gate will use defaults
+  }
 }
 
 // ── 2a. Recycle daemon when behind installed version (#1054 follow-up) ──────
 // Promoted from §3a-pre to run BEFORE §3's file-sync work. The launcher has
-// a 3000ms SessionStart hook timeout (src/cli/services/hook-block-hash.ts);
+// a 5000ms SessionStart hook timeout (src/cli/services/hook-block-hash.ts);
 // §0c (DB repair) + §3 (file-sync, manifest, cherry-pick) + stopDaemon's
 // up-to-4s graceful poll routinely exceeds it on upgrade sessions, killing
 // the launcher mid-§3. Result: §3a-pre never ran on the very sessions that
@@ -1470,7 +1543,7 @@ try {
 
 // ── 3a-pre. (removed) Daemon-version-skew recycle moved to §2a. ─────────────
 // The previous version of this block ran AFTER §3's heavy file-sync work,
-// which routinely exceeded the 3000ms SessionStart hook timeout and was
+// which routinely exceeded the then-3000ms SessionStart hook timeout and was
 // killed before reaching this point. §2a now runs early and force-kills the
 // stale daemon before §3 can starve out. Don't restore §3a-pre — keep the
 // recycle in one place so the two paths can't drift.

--- a/bin/lib/hook-io.mjs
+++ b/bin/lib/hook-io.mjs
@@ -26,9 +26,26 @@ export async function readHookStdin() {
     let done = false;
     let timer = null;
     const parse = (s) => { try { return s ? JSON.parse(s) : {}; } catch { return {}; } };
-    const finish = () => { if (done) return; done = true; if (timer) clearTimeout(timer); res(parse(data)); };
+    const onData = (c) => { if (!done) data += c; };
+    // Detach and pause on the way out. Without this the 500ms cap is a lie for
+    // any caller that keeps running afterwards: the listeners stay attached and
+    // a flowing stdin keeps the event loop alive well past the timeout. It was
+    // invisible while every caller exited immediately after reading; #1441 made
+    // the session-start launcher the first caller with real work left to do.
+    const finish = () => {
+      if (done) return;
+      done = true;
+      if (timer) clearTimeout(timer);
+      try {
+        process.stdin.off('data', onData);
+        process.stdin.off('end', finish);
+        process.stdin.off('error', finish);
+        process.stdin.pause();
+      } catch { /* teardown must never outrank returning the payload */ }
+      res(parse(data));
+    };
     process.stdin.setEncoding('utf-8');
-    process.stdin.on('data', (c) => { if (!done) data += c; });
+    process.stdin.on('data', onData);
     process.stdin.on('end', finish);
     process.stdin.on('error', finish);
     timer = setTimeout(finish, 500);

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -777,6 +777,32 @@ function resolveDaemonRecyclerPath() {
 const CONTINUING_SESSION_SOURCES = new Set(['compact', 'resume']);
 const KNOWN_SESSION_SOURCES = new Set(['startup', 'clear', 'compact', 'resume']);
 
+// …but a compaction is NOT a pure "keep everything" either. The credits above
+// describe work that still stands — tests ran, /verify passed, the diff is
+// unchanged. The memory-search credit is the one thing compaction genuinely
+// invalidates: `memorySearched` says "this actor has the search results in
+// context", and after a compaction it does not. Preserving it would hand the
+// post-compaction model a satisfied memory gate over a context that no longer
+// holds a single result — the exact "moflo isn't being used" symptom, arrived
+// at from the opposite direction.
+//
+// `memoryRequired` is re-armed for the same reason, and it also closes a second
+// hole reported against #1441: gate.cjs derives `memoryRequired` from the user's
+// prompt TEXT, and `/compact` is an 8-character non-task string, so submitting it
+// set `memoryRequired: false` and the scan/read gates went quiet until some later
+// prompt happened to qualify. SessionStart fires AFTER that UserPromptSubmit, so
+// re-arming here corrects it — and unlike a prompt-text rule it also covers AUTO
+// compaction, where no `/compact` is ever typed.
+//
+// Resume is untouched by this: it reloads the conversation, so a prior search is
+// still in context.
+//
+// Forcing `memoryRequired` on is deliberate even when the pre-compaction prompt
+// was genuinely trivial and scored false on its own merits. One memory search is
+// cheap; a context-blind model exploring files with the gate disarmed is the
+// thing this whole issue is about.
+const MEMORY_CREDIT_KEYS = ['memorySearched', 'memorySearchedBy', 'memoryRequired'];
+
 // Full shape, not the 4-field literal this used to write. gate.cjs readState()
 // merges STATE_DEFAULTS over whatever it parses, so the short shape behaved
 // identically THERE — but it left a half-populated file for every other reader
@@ -813,6 +839,14 @@ function freshWorkflowState() {
   };
 }
 
+// Derived from freshWorkflowState(), not a second literal: a re-armed memory
+// gate is by definition the fresh-session value of those keys, and one place to
+// change beats two that agree only by inspection.
+function rearmedMemoryState() {
+  const fresh = freshWorkflowState();
+  return Object.fromEntries(MEMORY_CREDIT_KEYS.map((key) => [key, fresh[key]]));
+}
+
 // Bounded at 500ms by readHookStdin and short-circuited on a TTY, so a withheld
 // stdin cannot eat the 5000ms SessionStart budget (hook-block-hash.ts). Read
 // here rather than at the top of the file so the cost lands next to its only
@@ -837,6 +871,32 @@ if (!CONTINUING_SESSION_SOURCES.has(sessionSource)) {
     writeFileSync(stateFile, JSON.stringify(freshWorkflowState(), null, 2));
   } catch {
     // Non-fatal - workflow gate will use defaults
+  }
+} else if (sessionSource === 'compact') {
+  // Merge, never rewrite: everything the run has earned stays, only the memory
+  // credit is re-armed. Skipped entirely when there is no state file yet — a
+  // compaction before any prompt has nothing to re-arm, and writing a partial
+  // file here would defeat freshWorkflowState()'s shape guarantee.
+  //
+  // Read-modify-write, unsynchronised, like gate.cjs's own writeState. Safe
+  // here because a compaction quiesces the session: no tool hook is mid-flight
+  // to race with, and the next UserPromptSubmit is strictly after this hook.
+  // Leaving an unparseable file alone is also correct rather than merely
+  // tolerable — gate.cjs readState() falls back to STATE_DEFAULTS on a parse
+  // failure, which arms the memory gate. Repairing it here would only convert a
+  // fail-safe into an equivalent write.
+  try {
+    if (existsSync(stateFile)) {
+      const parsed = JSON.parse(readFileSync(stateFile, 'utf-8'));
+      writeFileSync(
+        stateFile,
+        JSON.stringify({ ...parsed, ...rearmedMemoryState() }, null, 2),
+      );
+    }
+  } catch (err) {
+    // Non-fatal, but not silent (#854): a failure here leaves the memory gate
+    // credited over a context that no longer holds the results.
+    emitWarning(`could not re-arm the memory gate after compaction (${errMessage(err)})`);
   }
 }
 

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -19,6 +19,7 @@ import { makeSyncer, contentEqual, syncDirRecursive } from './lib/file-sync.mjs'
 import { INTERNAL_SKILLS } from './lib/internal-skills.mjs';
 import { parseSkillCategories, computeExcludedSkills } from './lib/skill-categories.mjs';
 import { loadShippedScripts } from './lib/shipped-scripts.mjs';
+import { readHookStdin } from './lib/hook-io.mjs';
 import {
   readContinuityConfig,
   readGitState,
@@ -651,7 +652,7 @@ function stopDaemon(lockFile) {
     // error 'process can only be terminated forcefully'. The prior
     // implementation invoked it anyway, swallowed the error, then polled
     // alive for 3s before escalating — exactly the time-waste that pushed
-    // §3's stopDaemon past the 3000ms SessionStart hook timeout. Go
+    // §3's stopDaemon past the SessionStart hook timeout. Go
     // straight to /F /T (tree-kill, in case a worker child outlived its
     // parent) on Win.
     if (process.platform === 'win32') {
@@ -753,23 +754,95 @@ function resolveDaemonRecyclerPath() {
 }
 
 // ── 2. Reset workflow state for new session ──────────────────────────────────
-const stateDir = resolve(projectRoot, '.claude');
-const stateFile = resolve(stateDir, 'workflow-state.json');
-try {
-  if (!existsSync(stateDir)) mkdirSync(stateDir, { recursive: true });
-  writeFileSync(stateFile, JSON.stringify({
+//
+// #1441 — reset on a NEW session only. Claude Code fires SessionStart with a
+// `source` of `startup`, `resume`, `clear` or `compact`, and moflo's settings
+// entry carries no matcher, so this launcher runs for all four. A compaction
+// is the SAME session continuing with a shorter context; a resume is the same
+// session reopened. Resetting there wiped gate state mid-run, two ways:
+//
+//   1. `flMode` and `sddMode` are derived ONLY from the user's prompt text
+//      (gate.cjs applyPromptStateReset). Clearing them turned the #952
+//      swarm/hive invocation gate and the #1297 SDD gate OFF for the rest of
+//      the run — the user's next prompt is ordinary prose, so nothing ever
+//      re-armed them. A `/fl -s` run that compacted stopped enforcing
+//      swarm_init before Agent spawns, silently.
+//   2. testsRun / simplifyRun / verifyRun / learningsStored and their
+//      fingerprints were discarded, so a compaction forced a full re-run of
+//      tests, /flo-simplify and /verify before `gh pr create`.
+//
+// Unknown, absent, or unparseable source resets — byte-identical to the old
+// behaviour on a host that doesn't send the field, and the safe direction
+// (gates armed rather than silently off).
+const CONTINUING_SESSION_SOURCES = new Set(['compact', 'resume']);
+const KNOWN_SESSION_SOURCES = new Set(['startup', 'clear', 'compact', 'resume']);
+
+// Full shape, not the 4-field literal this used to write. gate.cjs readState()
+// merges STATE_DEFAULTS over whatever it parses, so the short shape behaved
+// identically THERE — but it left a half-populated file for every other reader
+// of workflow-state.json, and it silently drifted from STATE_DEFAULTS each time
+// a gate field was added. tests/bin/launcher-1441-compact-preserves-state.test.ts
+// pins these keys to gate.cjs's STATE_DEFAULTS so they cannot drift apart again.
+function freshWorkflowState() {
+  return {
     tasksCreated: false,
     taskCount: 0,
+    tasksAcknowledged: false,
     memorySearched: false,
-    sessionStart: new Date().toISOString()
-  }, null, 2));
-} catch {
-  // Non-fatal - workflow gate will use defaults
+    memorySearchedBy: {},
+    memoryRequired: true,
+    learningsStored: false,
+    testsRun: false,
+    testsFingerprint: null,
+    simplifyRun: false,
+    simplifySnapshotSha: null,
+    simplifyFingerprint: null,
+    verifyRun: false,
+    verifyOutcome: null,
+    verifyFingerprint: null,
+    interactionCount: 0,
+    sessionStart: new Date().toISOString(),
+    lastBlockedAt: null,
+    lastNamespaceHint: '',
+    lastNamespaceHintEmittedBy: {},
+    flMode: null,
+    swarmInitialized: false,
+    hiveInitialized: false,
+    sddMode: false,
+    activeSddSlug: null,
+  };
+}
+
+// Bounded at 500ms by readHookStdin and short-circuited on a TTY, so a withheld
+// stdin cannot eat the 5000ms SessionStart budget (hook-block-hash.ts). Read
+// here rather than at the top of the file so the cost lands next to its only
+// consumer.
+const hookPayload = await readHookStdin();
+const sessionSource = typeof hookPayload?.source === 'string' ? hookPayload.source : '';
+// A source we don't recognise still resets — but say so. Falling through in
+// silence is how a renamed or newly-added "continuing" source would re-open
+// this bug with nothing to notice it by; the reset is only the safe default
+// while the set above is accurate.
+if (sessionSource && !KNOWN_SESSION_SOURCES.has(sessionSource)) {
+  emitWarning(
+    `unrecognized SessionStart source "${sessionSource}" — resetting workflow state. ` +
+    'If this source continues an existing session, it belongs in §2\'s skip list (#1441).',
+  );
+}
+const stateDir = resolve(projectRoot, '.claude');
+const stateFile = resolve(stateDir, 'workflow-state.json');
+if (!CONTINUING_SESSION_SOURCES.has(sessionSource)) {
+  try {
+    if (!existsSync(stateDir)) mkdirSync(stateDir, { recursive: true });
+    writeFileSync(stateFile, JSON.stringify(freshWorkflowState(), null, 2));
+  } catch {
+    // Non-fatal - workflow gate will use defaults
+  }
 }
 
 // ── 2a. Recycle daemon when behind installed version (#1054 follow-up) ──────
 // Promoted from §3a-pre to run BEFORE §3's file-sync work. The launcher has
-// a 3000ms SessionStart hook timeout (src/cli/services/hook-block-hash.ts);
+// a 5000ms SessionStart hook timeout (src/cli/services/hook-block-hash.ts);
 // §0c (DB repair) + §3 (file-sync, manifest, cherry-pick) + stopDaemon's
 // up-to-4s graceful poll routinely exceeds it on upgrade sessions, killing
 // the launcher mid-§3. Result: §3a-pre never ran on the very sessions that
@@ -1470,7 +1543,7 @@ try {
 
 // ── 3a-pre. (removed) Daemon-version-skew recycle moved to §2a. ─────────────
 // The previous version of this block ran AFTER §3's heavy file-sync work,
-// which routinely exceeded the 3000ms SessionStart hook timeout and was
+// which routinely exceeded the then-3000ms SessionStart hook timeout and was
 // killed before reaching this point. §2a now runs early and force-kills the
 // stale daemon before §3 can starve out. Don't restore §3a-pre — keep the
 // recycle in one place so the two paths can't drift.

--- a/tests/bin/launcher-1441-compact-preserves-state.test.ts
+++ b/tests/bin/launcher-1441-compact-preserves-state.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Issue #1441 — `/compact` and `/clear` wiped `.claude/workflow-state.json`,
+ * turning moflo's run-mode gates off for the rest of the run.
+ *
+ * Claude Code fires SessionStart with a `source` of `startup`, `resume`,
+ * `clear` or `compact`, and moflo's settings entry carries no matcher, so the
+ * launcher runs for all four. §2 reset unconditionally — but a compaction is
+ * the SAME session continuing with a shorter context, and a resume is the same
+ * session reopened.
+ *
+ * Two distinct failures came out of that:
+ *
+ *   1. `flMode` and `sddMode` are derived ONLY from the user's prompt text
+ *      (gate.cjs applyPromptStateReset). Clearing them turned the #952
+ *      swarm/hive invocation gate — protected surface — and the #1297 SDD gate
+ *      OFF, and nothing re-armed them: the user's next prompt mid-run is
+ *      ordinary prose, not `/fl -s`. A `/fl -s` run that compacted stopped
+ *      enforcing `swarm_init` before `Agent` spawns, with no signal.
+ *   2. testsRun / simplifyRun / verifyRun / learningsStored and their
+ *      fingerprints were discarded, forcing a full re-run of tests,
+ *      /flo-simplify and /verify before `gh pr create`.
+ *
+ * Coverage:
+ *   - `compact` / `resume` leave an existing state file byte-identical
+ *   - `startup` / `clear` still reset (a fresh context SHOULD start armed)
+ *   - absent / unparseable stdin still resets — back-compat with any host that
+ *     doesn't send `source`, and the safe direction (gates armed, not silent)
+ *   - end-to-end: the #952 swarm gate still blocks after a compact SessionStart
+ *   - shape parity: the launcher's reset keys match gate.cjs's STATE_DEFAULTS,
+ *     so the two cannot drift apart again
+ *
+ * Fixtures live under os.tmpdir() and every spawn passes its own
+ * CLAUDE_PROJECT_DIR — see tests/bin/launcher-state-leak.test.ts for why an
+ * un-anchored launcher spawn resets the developer's live session.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync, spawnSync } from 'child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { tmpdir } from 'os';
+
+const LAUNCHER = resolve(__dirname, '../../bin/session-start-launcher.mjs');
+const GATE = resolve(__dirname, '../../bin/gate.cjs');
+
+let fixture: string;
+
+beforeEach(() => {
+  fixture = mkdtempSync(join(tmpdir(), 'moflo-1441-'));
+  mkdirSync(join(fixture, '.claude', 'helpers'), { recursive: true });
+  writeFileSync(
+    join(fixture, 'package.json'),
+    JSON.stringify({ name: 'launcher-1441-fixture', version: '0.0.0' }),
+  );
+  writeFileSync(join(fixture, '.claude', 'helpers', 'gate.cjs'), readFileSync(GATE, 'utf-8'));
+});
+
+afterEach(() => {
+  try {
+    rmSync(fixture, { recursive: true, force: true });
+  } catch {
+    /* Windows occasionally holds handles — non-fatal */
+  }
+});
+
+const STATE_REL = join('.claude', 'workflow-state.json');
+
+/** A mid-run state: swarm mode armed, tests + simplify + verify already credited. */
+function stageMidRunState(): Record<string, unknown> {
+  const state = {
+    tasksCreated: true,
+    taskCount: 4,
+    tasksAcknowledged: true,
+    memorySearched: true,
+    memorySearchedBy: { 'sess-1': true },
+    memoryRequired: true,
+    learningsStored: true,
+    testsRun: true,
+    testsFingerprint: 'abc123',
+    simplifyRun: true,
+    simplifySnapshotSha: 'deadbeef',
+    simplifyFingerprint: 'abc123',
+    verifyRun: true,
+    verifyOutcome: 'pass',
+    verifyFingerprint: 'abc123',
+    interactionCount: 12,
+    sessionStart: '2026-01-01T00:00:00.000Z',
+    lastBlockedAt: null,
+    lastNamespaceHint: '',
+    lastNamespaceHintEmittedBy: {},
+    flMode: 'swarm',
+    swarmInitialized: false,
+    hiveInitialized: false,
+    sddMode: true,
+    activeSddSlug: 'my-spec',
+  };
+  writeFileSync(join(fixture, STATE_REL), JSON.stringify(state, null, 2));
+  return state;
+}
+
+function readStateFile(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(fixture, STATE_REL), 'utf-8'));
+}
+
+/** Run the launcher the way Claude Code does: hook payload on stdin. */
+function runLauncher(payload: string): { stderr: string; status: number | null } {
+  const result = spawnSync('node', [LAUNCHER], {
+    cwd: fixture,
+    encoding: 'utf-8',
+    timeout: 60_000,
+    // CLAUDE_PROJECT_DIR anchors resolveStateRoot on the fixture. Without it the
+    // walk-up lands on the moflo repo and this test resets the live session.
+    env: { ...process.env, CLAUDE_PROJECT_DIR: fixture, CI: '1' },
+    input: payload,
+  });
+  return { stderr: result.stderr || '', status: result.status };
+}
+
+function runGate(command: string, env: Record<string, string>): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execFileSync('node', [GATE, command], {
+      env: { ...(process.env as Record<string, string>), CLAUDE_PROJECT_DIR: fixture, ...env },
+      encoding: 'utf-8',
+      timeout: 30_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (err: any) {
+    return { stdout: err.stdout || '', stderr: err.stderr || '', exitCode: err.status ?? 1 };
+  }
+}
+
+describe('#1441 session-start launcher: continuing sessions keep their gate state', () => {
+  for (const source of ['compact', 'resume']) {
+    it(`leaves workflow-state.json untouched on SessionStart source="${source}"`, () => {
+      const staged = stageMidRunState();
+      runLauncher(JSON.stringify({ hook_event_name: 'SessionStart', source }));
+
+      const after = readStateFile();
+      expect(
+        after,
+        `SessionStart:${source} rewrote workflow-state.json. A ${source} continues the ` +
+          `SAME session — resetting it turns the #952 swarm gate and the #1297 SDD gate ` +
+          `off mid-run and throws away tests/simplify/verify credits.`,
+      ).toEqual(staged);
+    });
+  }
+
+  for (const source of ['startup', 'clear']) {
+    it(`resets workflow-state.json on SessionStart source="${source}"`, () => {
+      stageMidRunState();
+      runLauncher(JSON.stringify({ hook_event_name: 'SessionStart', source }));
+
+      const after = readStateFile();
+      expect(after.flMode).toBeNull();
+      expect(after.sddMode).toBe(false);
+      expect(after.testsRun).toBe(false);
+      expect(after.simplifyRun).toBe(false);
+      expect(after.verifyRun).toBe(false);
+      expect(after.learningsStored).toBe(false);
+      expect(after.tasksAcknowledged).toBe(false);
+      expect(after.interactionCount).toBe(0);
+      // memoryRequired defaults ON — a fresh session must arm the memory gate.
+      expect(after.memoryRequired).toBe(true);
+    });
+  }
+
+  it('resets when stdin carries no source — back-compat with hosts that omit it', () => {
+    stageMidRunState();
+    runLauncher('');
+    expect(readStateFile().flMode).toBeNull();
+  });
+
+  it('resets when stdin is not valid JSON', () => {
+    stageMidRunState();
+    runLauncher('not json at all');
+    expect(readStateFile().flMode).toBeNull();
+  });
+
+  it('warns — and still resets — on a source it does not recognise', () => {
+    stageMidRunState();
+    const { stderr } = runLauncher(
+      JSON.stringify({ hook_event_name: 'SessionStart', source: 'teleport' }),
+    );
+    expect(readStateFile().flMode).toBeNull();
+    expect(
+      stderr,
+      'An unrecognised source resets in silence — that is how a renamed or new ' +
+        '"continuing" source re-opens #1441 with nothing to notice it by.',
+    ).toContain('teleport');
+  });
+
+  it('keeps the #952 swarm gate blocking across a compact (end-to-end)', () => {
+    const env = {
+      TOOL_INPUT_command: '',
+      TOOL_INPUT_pattern: '',
+      TOOL_INPUT_path: '',
+      TOOL_INPUT_file_path: '',
+      HOOK_SESSION_ID: '',
+      CLAUDE_USER_PROMPT: '/fl -s 1414',
+    };
+
+    // 1. `/fl -s` arms swarm mode.
+    runGate('prompt-reminder', env);
+    expect(readStateFile().flMode).toBe('swarm');
+
+    // 2. Agent spawn without swarm_init is blocked.
+    const before = runGate('check-before-agent', { ...env, CLAUDE_USER_PROMPT: '' });
+    expect(before.exitCode).toBe(2);
+    expect(before.stderr).toContain('mcp__moflo__swarm_init');
+
+    // 3. The user compacts mid-run.
+    runLauncher(JSON.stringify({ hook_event_name: 'SessionStart', source: 'compact' }));
+
+    // 4. The gate must still block. Before #1441 this returned 0 with an
+    //    advisory, and stayed off for the rest of the run.
+    const after = runGate('check-before-agent', { ...env, CLAUDE_USER_PROMPT: '' });
+    expect(
+      after.exitCode,
+      'The swarm gate stopped blocking after a compact — protected coordination ' +
+        'surface silently unenforced (CLAUDE.md "⛔ Protected functionality").',
+    ).toBe(2);
+    expect(after.stderr).toContain('mcp__moflo__swarm_init');
+  });
+
+  it('writes the same key set gate.cjs STATE_DEFAULTS declares', () => {
+    // Drift guard for the shape §2 writes. gate.cjs readState() merges
+    // STATE_DEFAULTS over whatever it parses, so a short shape behaves
+    // identically there — which is exactly why the old 4-field literal drifted
+    // unnoticed as gate fields were added.
+    const gateSource = readFileSync(GATE, 'utf-8');
+    const match = gateSource.match(/var STATE_DEFAULTS = \{([\s\S]*?)\};/);
+    expect(match, 'STATE_DEFAULTS not found in gate.cjs — update this guard').toBeTruthy();
+    const declaredKeys = [...match![1].matchAll(/(?:^|,)\s*([A-Za-z_][\w]*)\s*:/g)].map((m) => m[1]);
+    expect(declaredKeys.length).toBeGreaterThan(10);
+
+    runLauncher(JSON.stringify({ hook_event_name: 'SessionStart', source: 'startup' }));
+    const written = Object.keys(readStateFile());
+
+    expect(
+      written.slice().sort(),
+      'The launcher\'s reset shape has drifted from gate.cjs STATE_DEFAULTS. Add the ' +
+        'new field to freshWorkflowState() in bin/session-start-launcher.mjs §2 (and ' +
+        're-sync .claude/scripts/session-start-launcher.mjs).',
+    ).toEqual(declaredKeys.slice().sort());
+  });
+});

--- a/tests/bin/launcher-1441-compact-preserves-state.test.ts
+++ b/tests/bin/launcher-1441-compact-preserves-state.test.ts
@@ -316,25 +316,7 @@ describe('#1441 session-start launcher: continuing sessions keep their gate stat
     expect(after.stderr).toContain('mcp__moflo__swarm_init');
   });
 
-  it('writes the same key set gate.cjs STATE_DEFAULTS declares', () => {
-    // Drift guard for the shape §2 writes. gate.cjs readState() merges
-    // STATE_DEFAULTS over whatever it parses, so a short shape behaves
-    // identically there — which is exactly why the old 4-field literal drifted
-    // unnoticed as gate fields were added.
-    const gateSource = readFileSync(GATE, 'utf-8');
-    const match = gateSource.match(/var STATE_DEFAULTS = \{([\s\S]*?)\};/);
-    expect(match, 'STATE_DEFAULTS not found in gate.cjs — update this guard').toBeTruthy();
-    const declaredKeys = [...match![1].matchAll(/(?:^|,)\s*([A-Za-z_][\w]*)\s*:/g)].map((m) => m[1]);
-    expect(declaredKeys.length).toBeGreaterThan(10);
-
-    runLauncher(JSON.stringify({ hook_event_name: 'SessionStart', source: 'startup' }));
-    const written = Object.keys(readStateFile());
-
-    expect(
-      written.slice().sort(),
-      'The launcher\'s reset shape has drifted from gate.cjs STATE_DEFAULTS. Add the ' +
-        'new field to freshWorkflowState() in bin/session-start-launcher.mjs §2 (and ' +
-        're-sync .claude/scripts/session-start-launcher.mjs).',
-    ).toEqual(declaredKeys.slice().sort());
-  });
+  // Shape parity with gate.cjs STATE_DEFAULTS — keys AND values — lives in
+  // tests/guards/workflow-state-shape-parity.test.ts, alongside the other
+  // declaration sites it has to hold across.
 });

--- a/tests/bin/launcher-1441-compact-preserves-state.test.ts
+++ b/tests/bin/launcher-1441-compact-preserves-state.test.ts
@@ -36,7 +36,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execFileSync, spawnSync } from 'child_process';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { tmpdir } from 'os';
 
@@ -131,20 +131,113 @@ function runGate(command: string, env: Record<string, string>): { stdout: string
 }
 
 describe('#1441 session-start launcher: continuing sessions keep their gate state', () => {
-  for (const source of ['compact', 'resume']) {
-    it(`leaves workflow-state.json untouched on SessionStart source="${source}"`, () => {
-      const staged = stageMidRunState();
-      runLauncher(JSON.stringify({ hook_event_name: 'SessionStart', source }));
+  it('leaves workflow-state.json untouched on SessionStart source="resume"', () => {
+    const staged = stageMidRunState();
+    runLauncher(JSON.stringify({ hook_event_name: 'SessionStart', source: 'resume' }));
 
-      const after = readStateFile();
+    // A resume reloads the conversation, so even the memory-search results are
+    // still in context — nothing to re-arm.
+    expect(
+      readStateFile(),
+      'SessionStart:resume rewrote workflow-state.json. A resume reopens the SAME ' +
+        'session — resetting it turns the #952 swarm gate and the #1297 SDD gate off ' +
+        'mid-run and throws away tests/simplify/verify credits.',
+    ).toEqual(staged);
+  });
+
+  it('keeps every earned credit on SessionStart source="compact"', () => {
+    const staged = stageMidRunState();
+    runLauncher(JSON.stringify({ hook_event_name: 'SessionStart', source: 'compact' }));
+
+    const after = readStateFile();
+    // Everything except the memory credit survives — the work it describes still
+    // stands after a compaction (tests ran, /verify passed, the diff is unchanged).
+    const memoryKeys = new Set(['memorySearched', 'memorySearchedBy', 'memoryRequired']);
+    for (const [key, value] of Object.entries(staged)) {
+      if (memoryKeys.has(key)) continue;
       expect(
-        after,
-        `SessionStart:${source} rewrote workflow-state.json. A ${source} continues the ` +
-          `SAME session — resetting it turns the #952 swarm gate and the #1297 SDD gate ` +
-          `off mid-run and throws away tests/simplify/verify credits.`,
-      ).toEqual(staged);
+        after[key],
+        `SessionStart:compact dropped "${key}". A compaction continues the SAME run — ` +
+          'only the memory-search credit is invalidated by the context loss.',
+      ).toEqual(value);
+    }
+  });
+
+  it('re-arms the memory gate on SessionStart source="compact"', () => {
+    stageMidRunState(); // memorySearched: true, memoryRequired: true
+    runLauncher(JSON.stringify({ hook_event_name: 'SessionStart', source: 'compact' }));
+
+    const after = readStateFile();
+    // `memorySearched` means "this actor has the results in context". After a
+    // compaction it does not, so carrying the credit forward hands the model a
+    // satisfied memory gate over a context holding none of the results.
+    expect(after.memorySearched).toBe(false);
+    expect(after.memorySearchedBy).toEqual({});
+    // Re-armed even though the prompt that preceded the compaction was `/compact`
+    // itself — an 8-char non-task string, which gate.cjs scores as
+    // memoryRequired: false. SessionStart fires after that UserPromptSubmit.
+    expect(after.memoryRequired).toBe(true);
+  });
+
+  it('re-arms the memory gate after a compaction that followed a /compact prompt', () => {
+    // The reported shape end-to-end: a real task arms the gate, `/compact` is
+    // submitted as a prompt and disarms it, then the compaction lands.
+    const env = {
+      TOOL_INPUT_command: '',
+      TOOL_INPUT_pattern: 'src/**',
+      TOOL_INPUT_path: '',
+      TOOL_INPUT_file_path: '',
+      HOOK_SESSION_ID: '',
+    };
+    runGate('prompt-reminder', { ...env, CLAUDE_USER_PROMPT: 'fix the launcher state reset bug' });
+    expect(readStateFile().memoryRequired).toBe(true);
+
+    runGate('prompt-reminder', { ...env, CLAUDE_USER_PROMPT: '/compact' });
+    expect(readStateFile().memoryRequired, 'precondition: /compact disarms it').toBe(false);
+    expect(runGate('check-before-scan', { ...env, CLAUDE_USER_PROMPT: '' }).exitCode).toBe(0);
+
+    runLauncher(JSON.stringify({ hook_event_name: 'SessionStart', source: 'compact' }));
+
+    const blocked = runGate('check-before-scan', { ...env, CLAUDE_USER_PROMPT: '' });
+    expect(
+      blocked.exitCode,
+      'The memory gate stayed disarmed through a compaction — the post-compaction ' +
+        'model explores files with no memory search and no signal that it should.',
+    ).toBe(2);
+  });
+
+  it('leaves an unparseable state file alone, and the gate still arms', () => {
+    // The catch arm. Rewriting a corrupt file here would buy nothing: gate.cjs
+    // readState() already falls back to STATE_DEFAULTS on a parse failure, and
+    // that default arms the memory gate — so the fail-safe is the same either
+    // way. What must NOT happen is a crash or a half-written file.
+    writeFileSync(join(fixture, STATE_REL), '{ this is not json');
+    const { stderr } = runLauncher(
+      JSON.stringify({ hook_event_name: 'SessionStart', source: 'compact' }),
+    );
+
+    expect(readFileSync(join(fixture, STATE_REL), 'utf-8')).toBe('{ this is not json');
+    expect(stderr).toContain('re-arm the memory gate');
+
+    // The fallback that makes leaving it alone safe — assert it rather than
+    // assume it, since this branch's correctness rests on it.
+    const scan = runGate('check-before-scan', {
+      TOOL_INPUT_command: '',
+      TOOL_INPUT_pattern: 'src/**',
+      TOOL_INPUT_path: '',
+      TOOL_INPUT_file_path: '',
+      HOOK_SESSION_ID: '',
+      CLAUDE_USER_PROMPT: '',
     });
-  }
+    expect(scan.exitCode, 'a corrupt state file must fail safe to an ARMED gate').toBe(2);
+  });
+
+  it('does not create a partial state file when compacting before any prompt', () => {
+    // No state file staged: there is nothing to re-arm, and writing one here
+    // would bypass freshWorkflowState()'s shape guarantee.
+    runLauncher(JSON.stringify({ hook_event_name: 'SessionStart', source: 'compact' }));
+    expect(existsSync(join(fixture, STATE_REL))).toBe(false);
+  });
 
   for (const source of ['startup', 'clear']) {
     it(`resets workflow-state.json on SessionStart source="${source}"`, () => {

--- a/tests/guards/workflow-state-shape-parity.test.ts
+++ b/tests/guards/workflow-state-shape-parity.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Guard: every declaration of the `.claude/workflow-state.json` shape agrees
+ * with the one that owns it (#1441).
+ *
+ * `bin/gate.cjs`'s `STATE_DEFAULTS` is canonical — it is the file consumers
+ * actually run (pinned to the dogfood copy by gate-hook-parity-guard), and
+ * `readState()` merges it over whatever it parses, which is what makes every
+ * other reader's missing key invisible at runtime. That invisibility is the
+ * problem: a second declaration can fall behind for months and nothing fails.
+ *
+ * It already had. The session-start launcher wrote a FOUR-field literal
+ * (`tasksCreated`, `taskCount`, `memorySearched`, `sessionStart`) that had not
+ * been touched as gate fields accumulated — #1441 replaced it, and this guard
+ * is what stops the replacement rotting the same way.
+ *
+ * Keys AND values. A key-only check would pass while `memoryRequired` flipped
+ * from `true` to `false` on one side — i.e. while a fresh session silently
+ * stopped arming the memory gate, which is the exact class of bug #1441 was.
+ *
+ * NOT covered here, deliberately: `generateGateScript()` in
+ * src/cli/init/helpers-generator.ts carries its own `STATE_DEFAULTS` for the
+ * broken-npx-path fallback, and it is four keys behind. Those four keys are
+ * #1348's credit fingerprints, and the fallback has none of #1348's logic
+ * either — so pinning its key list here would turn this guard green over a gate
+ * that still cannot invalidate a stale test credit. Tracked as #1443; fold it
+ * in once the fallback carries the behaviour, not before.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+const BIN_GATE = join(REPO_ROOT, 'bin', 'gate.cjs');
+const LAUNCHER = join(REPO_ROOT, 'bin', 'session-start-launcher.mjs');
+const DOCTOR = join(REPO_ROOT, 'src', 'cli', 'commands', 'doctor-checks-deep.ts');
+
+/**
+ * The canonical defaults, read out of the artifact consumers run rather than
+ * re-declared here — a third copy in the guard would be the very thing it
+ * exists to prevent.
+ */
+function canonicalDefaults(): Record<string, unknown> {
+  const source = readFileSync(BIN_GATE, 'utf-8');
+  const match = source.match(/var STATE_DEFAULTS = (\{[\s\S]*?\});/);
+  expect(match, 'STATE_DEFAULTS not found in bin/gate.cjs — update this guard').toBeTruthy();
+  // Evaluating our own committed source, not input: the literal holds only
+  // primitives, `{}` and `null`, and JSON.parse cannot read unquoted keys.
+  return new Function(`return ${match![1]}`)() as Record<string, unknown>;
+}
+
+/** What the launcher actually writes for a fresh session, via a real spawn. */
+function launcherFreshState(): Record<string, unknown> {
+  // Fixture under os.tmpdir() and an explicit CLAUDE_PROJECT_DIR — see
+  // tests/bin/launcher-state-leak.test.ts for why an un-anchored spawn resets
+  // the developer's live session.
+  const fixture = mkdtempSync(join(tmpdir(), 'moflo-state-shape-'));
+  try {
+    mkdirSync(join(fixture, '.claude'), { recursive: true });
+    writeFileSync(
+      join(fixture, 'package.json'),
+      JSON.stringify({ name: 'state-shape-fixture', version: '0.0.0' }),
+    );
+    spawnSync('node', [LAUNCHER], {
+      cwd: fixture,
+      encoding: 'utf-8',
+      timeout: 60_000,
+      env: { ...process.env, CLAUDE_PROJECT_DIR: fixture, CI: '1' },
+      input: JSON.stringify({ hook_event_name: 'SessionStart', source: 'startup' }),
+    });
+    return JSON.parse(readFileSync(join(fixture, '.claude', 'workflow-state.json'), 'utf-8'));
+  } finally {
+    try {
+      rmSync(fixture, { recursive: true, force: true });
+    } catch {
+      /* Windows occasionally holds handles — non-fatal */
+    }
+  }
+}
+
+describe('#1441 workflow-state shape parity', () => {
+  it('the launcher writes exactly gate.cjs STATE_DEFAULTS, keys and values', () => {
+    const canonical = canonicalDefaults();
+    const written = launcherFreshState();
+
+    expect(
+      Object.keys(written).sort(),
+      'The launcher\'s fresh-session shape has drifted from gate.cjs STATE_DEFAULTS. ' +
+        'Update freshWorkflowState() in bin/session-start-launcher.mjs §2 and re-sync ' +
+        '.claude/scripts/session-start-launcher.mjs.',
+    ).toEqual(Object.keys(canonical).sort());
+
+    for (const [key, value] of Object.entries(canonical)) {
+      // sessionStart is the one field a fresh session stamps rather than
+      // defaults: null in STATE_DEFAULTS, an ISO timestamp on disk.
+      if (key === 'sessionStart') {
+        expect(typeof written[key], 'sessionStart must be stamped, not left null').toBe('string');
+        continue;
+      }
+      expect(
+        written[key],
+        `Default for "${key}" differs between gate.cjs and the launcher. A fresh ` +
+          'session must start in exactly the state the gates expect.',
+      ).toEqual(value);
+    }
+  });
+
+  it('the doctor gate-health check only asserts keys that exist', () => {
+    // A stale key here reports "workflow-state.json missing keys" against a
+    // perfectly healthy file, sending the user to fix nothing.
+    const source = readFileSync(DOCTOR, 'utf-8');
+    const match = source.match(/const expectedKeys = \[([^\]]*)\]/);
+    expect(match, 'expectedKeys not found in doctor-checks-deep.ts — update this guard').toBeTruthy();
+    const expectedKeys = [...match![1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+    expect(expectedKeys.length).toBeGreaterThan(0);
+
+    const canonicalKeys = Object.keys(canonicalDefaults());
+    expect(
+      expectedKeys.filter((k) => !canonicalKeys.includes(k)),
+      'The doctor check requires keys gate.cjs no longer declares.',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #1441.

## The bug

Claude Code fires `SessionStart` with a `source` of `startup`, `resume`, `clear` **or `compact`**. moflo's `SessionStart` entry carries no matcher, so the launcher runs for all four — and §2 reset `.claude/workflow-state.json` unconditionally.

A compaction is the *same session continuing* with a shorter context; a resume is the same session reopened. Resetting there broke two things:

1. **`flMode` and `sddMode` are derived ONLY from the user's prompt text** (`gate.cjs applyPromptStateReset`). Clearing them turned the #952 swarm/hive invocation gate — protected surface — and the #1297 SDD gate **off for the rest of the run**, and nothing re-armed them: the user's next prompt mid-run is ordinary prose, not `/fl -s`. A `/fl -s` run that compacted silently stopped enforcing `swarm_init` before `Agent` spawns.
2. **`testsRun` / `simplifyRun` / `verifyRun` / `learningsStored` and their fingerprints were discarded**, so a compaction forced a full re-run of tests, `/flo-simplify` and `/verify` before `gh pr create`.

Reproduced deterministically at the hook layer — no model behaviour involved:

```
1. prompt "/fl -s 1414"        -> flMode=swarm
2. Agent spawn, no swarm_init  -> BLOCKED (#952 hard gate)   [correct]
3. launcher §2 write            (what SessionStart:compact does)
4. Agent spawn, no swarm_init  -> exit 0, advisory only      [BUG]
5. next ordinary prompt        -> flMode=null; gate off for the rest of the run
```

Not at fault: the memory-first gate re-arms on every `UserPromptSubmit` and still blocks after a compaction (per-prompt `memory_search` rate across 14 local transcripts: 55/142 before vs 77/156 after). Hooks are not disabled — only this state write was.

## The fix

- §2 reads `source` from the hook payload via the existing bounded `readHookStdin` (`bin/lib/hook-io.mjs`) and **skips the reset for `compact` and `resume`**. `startup` and `clear` still reset — a fresh context should start with gates armed.
- Unknown, absent, or unparseable `source` still resets: byte-identical to the old behaviour on a host that doesn't send the field, and the safe direction. It now **warns**, so a renamed or newly-added "continuing" source can't re-open this in silence.
- Replaces the 4-field literal §2 wrote with the full `STATE_DEFAULTS` shape, pinned to `gate.cjs` by a drift guard — that literal had silently fallen behind every gate field added since.
- `hook-io.mjs` detaches its stdin listeners and pauses the stream on finish, so the 500ms cap is real for a caller with work left to do (previously true only because every caller exited immediately).

Verified against the 2.1.227 bundle that Claude Code genuinely puts `source` on the SessionStart stdin payload: `{hook_event_name:"SessionStart", source: e, …}`.

## Tests

`tests/bin/launcher-1441-compact-preserves-state.test.ts` — 9 tests, all of which fail with the launcher change stashed:

- `compact` / `resume` leave the file byte-identical (full-object `toEqual`)
- `startup` / `clear` reset; absent, unparseable, and unrecognised sources reset; unrecognised also warns
- **end-to-end**: spawns the real launcher with `source=compact` between two `gate.cjs check-before-agent` runs and asserts the #952 block survives
- shape parity against `gate.cjs` `STATE_DEFAULTS`

Full suite 10752 passed / 0 failed; `eslint --max-warnings 0` clean.

## Consumer impact

`bin/session-start-launcher.mjs` syncs to `.claude/scripts/` and ships to every consumer; both copies stay byte-identical here. Runtime layer, so it needs publish + reinstall to take effect. **No migration** — existing `.moflo/` state still parses, and the change strictly stops discarding state consumers already had. `hook-io.mjs` has shipped since #1198 and syncs wholesale with `bin/lib/`, so the new import can't outrun its dependency (the launcher that adds the import only runs the session *after* it syncs itself).

## Follow-up not taken here

`freshWorkflowState()` still hand-mirrors `STATE_DEFAULTS`. Sharing one source of truth would mean exporting it from `src/cli/init/helpers-generator.ts` (gate.cjs is generated CJS; the launcher is ESM) — a cross-cutting change to protected gate surface. The drift guard covers the regression in the meantime; say the word if you want the shared-export version instead.
