### PR TITLE
feat(skills): add /flfl — /fl with moflo's standing considerations preloaded

### DIFF
--- a/.claude/scripts/lib/internal-skills.mjs
+++ b/.claude/scripts/lib/internal-skills.mjs
@@ -2,8 +2,10 @@
  * Skills that ship in the npm tarball (under `node_modules/moflo/.claude/skills/`)
  * but must NEVER be installed into consumer projects — strictly moflo-internal
  * dev tooling. `/publish` bumps moflo's own version and publishes to npm;
- * `/reset-epic` torches epic test data. Both are meaningless or harmful in a
- * consumer repo.
+ * `/reset-epic` torches epic test data; `/flfl` runs `/fl` preloaded with the
+ * rules that govern developing MOFLO (cross-platform, consumer blast radius,
+ * dogfooding), which are not constraints on a consumer's own project. All three
+ * are meaningless, noisy, or harmful in a consumer repo.
  *
  * The session-start launcher's recursive skills sync (`syncDirRecursive` in
  * `file-sync.mjs`) copies every shipped skill into the consumer on each run, so
@@ -13,4 +15,4 @@
  * so this leaf mirrors it. `tests/bin/internal-skills-parity.test.ts` asserts
  * the two lists never drift.
  */
-export const INTERNAL_SKILLS = ['publish', 'reset-epic'];
+export const INTERNAL_SKILLS = ['publish', 'reset-epic', 'flfl'];

--- a/.claude/skills/flfl/SKILL.md
+++ b/.claude/skills/flfl/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: flfl
+description: Run /fl on a ticket with moflo's three standing considerations loaded first — cross-platform (Rule #1), consumer blast radius, and dogfooding. Use in the moflo repo itself instead of bare /fl. moflo-internal; never installed into consumer projects.
+arguments: "[options] <issue-number | title>"
+---
+
+```text
+$ARGUMENTS
+```
+
+# /flfl — /fl with moflo's standing considerations loaded first
+
+Purpose: run the normal `/fl` ticket workflow, but seat the three things that break moflo changes **before** any research, code, or review happens — not after a reviewer catches them.
+
+These are not a preamble to acknowledge and move past. Hold all three for the **whole** run: research, implementation, tests, `/flo-simplify`, `/verify`, and the PR body.
+
+## The three considerations
+
+| # | Consideration | What it changes about the work you are about to do |
+|---|---------------|----------------------------------------------------|
+| 1 | **Rule #1 — everything ships cross-platform** | Linux, macOS **and** Windows, identically. Audit every edit for: `path.join`/`path.sep` over hardcoded separators; `fs.realpathSync` on **both** sides of any path comparison; no `Foo.ts` beside `foo.ts`; platform EOL; no `bash`/`grep`/`sed`/`cat`/`find` shell-outs (use Node `fs`/`spawn`); `tasklist` vs `/proc` for process checks; `shell: true` on Windows vs `detached` on POSIX when spawning; `os.tmpdir()` and test ports in 40000–44999. Verify against CI's macOS **and** Ubuntu runs, not just your own OS. |
+| 2 | **moflo is installed into a destination project** | This is a library, not an app. Before writing code, name (a) the **consumer surface** touched — `bin/`, `src/cli/`, `.claude/scripts/`, hooks, `init/`, settings/CLAUDE.md generators, anything synced into `node_modules/moflo/`; (b) the **failure mode** for someone already on the current version who upgrades — does their `.moflo/` state still parse, do their hooks still wire, is a migration needed; (c) the **round-trip cost** — does this need publish-then-reinstall to take effect. If you cannot name all three, re-scope before writing code. |
+| 3 | **moflo dogfoods itself** | The daemon, hooks, statusline, MCP server and indexer all run from `node_modules/moflo/…`, **not** the source tree. A source edit changes nothing for those layers until publish + reinstall + Claude Code restart. Before diagnosing any "X is broken" symptom, establish **which copy is actually running** — diff `bin/` against `.claude/` against `node_modules/moflo/` first. Expect local flapping: the session-start launcher re-syncs `.claude/helpers/` from the **installed** package, so a local fix to a synced file reverts until published. |
+
+## How to run
+
+1. Restate the three considerations in one line each, mapped to **this specific ticket** — which surface it touches, which platform risks it carries, whether it needs a publish round-trip. Generic restatement is worthless; if a consideration genuinely does not apply, say so and why.
+2. Invoke the real workflow with the arguments above, unchanged and in full — including every flag (`-sd`, `-s`, `-w`, `-m`, …):
+
+   ```
+   Skill({ skill: "fl", args: "<the $ARGUMENTS block above, verbatim>" })
+   ```
+
+3. Follow `/fl` from there. `/flfl` adds nothing to the workflow itself — same phases, same gates, same run-mode resolution. Re-check the three at each gate: they most often fail at `/flo-simplify` (a cross-platform miss) and at the PR body (an unnamed consumer failure mode).
+
+## Anti-patterns
+
+| Don't | Do |
+|-------|-----|
+| Acknowledge the three, then run `/fl` and never revisit them | Re-check them at implementation, simplify, and PR |
+| Restate them verbatim from this file | Map each to the ticket's actual surface and risk |
+| Drop or reorder `$ARGUMENTS` when calling `/fl` | Pass the argument string through untouched |
+| Verify only on your own OS | Read the macOS and Ubuntu CI runs before claiming green |
+| Debug a runtime symptom against the source tree | Confirm which copy is running first |
+
+## See Also
+
+- `.claude/skills/fl/SKILL.md` — the workflow this wraps
+- `CLAUDE.md` — Rule #1, Rule #2, and the dogfooding section these three condense
+- `.claude/guidance/internal/dogfooding.md` — required reading before diagnosing runtime symptoms or adding files under `bin/`

--- a/bin/lib/internal-skills.mjs
+++ b/bin/lib/internal-skills.mjs
@@ -2,8 +2,10 @@
  * Skills that ship in the npm tarball (under `node_modules/moflo/.claude/skills/`)
  * but must NEVER be installed into consumer projects — strictly moflo-internal
  * dev tooling. `/publish` bumps moflo's own version and publishes to npm;
- * `/reset-epic` torches epic test data. Both are meaningless or harmful in a
- * consumer repo.
+ * `/reset-epic` torches epic test data; `/flfl` runs `/fl` preloaded with the
+ * rules that govern developing MOFLO (cross-platform, consumer blast radius,
+ * dogfooding), which are not constraints on a consumer's own project. All three
+ * are meaningless, noisy, or harmful in a consumer repo.
  *
  * The session-start launcher's recursive skills sync (`syncDirRecursive` in
  * `file-sync.mjs`) copies every shipped skill into the consumer on each run, so
@@ -13,4 +15,4 @@
  * so this leaf mirrors it. `tests/bin/internal-skills-parity.test.ts` asserts
  * the two lists never drift.
  */
-export const INTERNAL_SKILLS = ['publish', 'reset-epic'];
+export const INTERNAL_SKILLS = ['publish', 'reset-epic', 'flfl'];

--- a/src/cli/init/executor.ts
+++ b/src/cli/init/executor.ts
@@ -85,6 +85,9 @@ export const SKILLS_MAP: Record<SkillCategory, string[]> = {
 export const INTERNAL_SKILLS: string[] = [
   'publish',    // moflo's own /publish workflow — not consumer-relevant
   'reset-epic', // moflo's own epic test-data reset — would torch a consumer's repo
+  'flfl',       // /fl preloaded with moflo's OWN rules (cross-platform, consumer
+                // blast radius, dogfooding) — those are constraints on developing
+                // moflo, not on a consumer's project, where they read as noise
 ];
 
 /**

--- a/tests/bin/internal-skills-parity.test.ts
+++ b/tests/bin/internal-skills-parity.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { INTERNAL_SKILLS as BIN_INTERNAL_SKILLS } from '../../bin/lib/internal-skills.mjs';
 
@@ -27,6 +27,18 @@ function parseExecutorInternalSkills(): string[] {
   return [...body.matchAll(/'([^']+)'|"([^"]+)"/g)].map((m) => m[1] ?? m[2]);
 }
 
+/** Skill names inside executor.ts's SKILLS_MAP — i.e. the ones that DO ship. */
+function parseExecutorSkillsMap(): string[] {
+  const src = readFileSync(resolve(__dirname, '../../src/cli/init/executor.ts'), 'utf-8');
+  // Anchor on the closing `\n};` at column 0 so a nested `}` inside the literal
+  // cannot truncate the captured body early.
+  const block = src.match(/SKILLS_MAP[^=]*=\s*\{([\s\S]*?)\n\};/);
+  expect(block, 'SKILLS_MAP declaration not found in executor.ts').not.toBeNull();
+  // Category keys are unquoted, so every quoted token in here is a skill name.
+  const body = block![1].replace(/\/\/[^\n]*/g, '');
+  return [...body.matchAll(/'([^']+)'|"([^"]+)"/g)].map((m) => m[1] ?? m[2]);
+}
+
 describe('internal-skills list parity (launcher vs executor)', () => {
   it('bin/lib/internal-skills.mjs matches executor.ts INTERNAL_SKILLS', () => {
     const tsList = parseExecutorInternalSkills();
@@ -37,5 +49,33 @@ describe('internal-skills list parity (launcher vs executor)', () => {
   it('includes the known moflo-internal skills', () => {
     expect(BIN_INTERNAL_SKILLS).toContain('publish');
     expect(BIN_INTERNAL_SKILLS).toContain('reset-epic');
+    // `/flfl` wraps `/fl` with the rules for developing MOFLO — cross-platform,
+    // consumer blast radius, dogfooding. Correct in this repo, noise in a
+    // consumer's, where none of the three describe their project.
+    expect(BIN_INTERNAL_SKILLS).toContain('flfl');
+  });
+
+  it('classifies every skill directory, so a new one cannot default to shipping', () => {
+    // The failure this guards is silent: `flo init` and the launcher both copy
+    // what they are not told to skip, so an unclassified skill ships to every
+    // consumer without anything failing.
+    const skillDirs = readdirSync(resolve(__dirname, '../../.claude/skills'), { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+    // Membership must be checked inside the SKILLS_MAP literal, not anywhere in
+    // executor.ts: a whole-file grep passes as soon as the directory name shows
+    // up in ANY quoted string or comment, so a genuinely unclassified skill
+    // whose name collides with unrelated text would satisfy this vacuously —
+    // and still leak through the launcher's blanket sync.
+    const shipped = parseExecutorSkillsMap();
+    const unclassified = skillDirs.filter(
+      (name) =>
+        !BIN_INTERNAL_SKILLS.includes(name) &&
+        !shipped.includes(name) &&
+        // `flo`/`fl` take a dedicated install path in moflo-init.ts rather than
+        // appearing in either list.
+        name !== 'flo' && name !== 'fl',
+    );
+    expect(unclassified, 'unclassified skills would ship to consumers by default').toEqual([]);
   });
 });


### PR DESCRIPTION
## What

`/flfl` runs the normal `/fl` ticket workflow, but seats the three things that break moflo changes **before** any research, code, or review happens — rather than after a reviewer catches them:

| # | Consideration | What it changes about the work |
|---|---|---|
| 1 | **Rule #1 — everything ships cross-platform** | `path.join` over separators, `realpathSync` both sides of a comparison, no `bash`/`grep`/`sed` shell-outs, `tasklist` vs `/proc`, Windows spawn shape, tmpdir + 40000–44999 ports. Check macOS **and** Ubuntu CI, not just your own OS. |
| 2 | **moflo installs into a destination project** | Name the consumer surface, the failure mode for someone upgrading from the current version, and the round-trip cost — before writing code. |
| 3 | **moflo dogfoods itself** | The runtime layers execute from `node_modules/moflo/…`. Establish which copy is actually running before diagnosing, and expect local flapping on launcher-synced files. |

Each is written as what it *changes about the work*, not as a slogan, and the skill requires restating them **mapped to the specific ticket** — generic restatement is worthless. It also says to re-check at each gate: they most often fail at `/flo-simplify` (a cross-platform miss) and in the PR body (an unnamed consumer failure mode), not at first read.

`$ARGUMENTS` passes through to `/fl` verbatim, flags included. `/flfl` adds nothing to the workflow itself — same phases, gates, and run-mode resolution.

## Internal-only

Those three constrain developing **moflo**, not a consumer's project, where they'd read as noise. Registered in **all three** copies of `INTERNAL_SKILLS`:

- `src/cli/init/executor.ts` — used by `flo init`
- `bin/lib/internal-skills.mjs` — used by the launcher's skills sync
- `.claude/scripts/lib/internal-skills.mjs` — the fourth copy, which the `dogfood-copy-parity` guard caught me missing

It is also absent from `SKILLS_MAP`, so both consumer paths exclude it independently.

**Verified behaviourally**, not just structurally: `flo init` into a fresh temp git project installed 25 skills with `flfl` absent, alongside `publish` and `reset-epic`.

## New guard

Every `.claude/skills/*` directory must now be classified as either shipped or internal.

Testing the list only proves the entry you just added. The failure that actually ships is the **next** directory — classified nowhere, copied by default, nothing red. Two details that matter:

- It parses the `SKILLS_MAP` literal rather than grepping `executor.ts` wholesale. A whole-file grep passes as soon as the directory name appears in any unrelated string or comment, so a genuinely unclassified skill could satisfy it vacuously (review finding).
- It was **mutation-tested** with a throwaway directory to confirm it discriminates rather than always passing.

Full suite **10,856 passed / 0 failed**, `tsc` clean.

## Found while working, filed separately

#1449 — `check-dangerous-command` substring-matches `rm -rf /`, so it blocks *every* absolute-path deletion (`rm -rf /tmp/scratch`, `rm -rf /var/cache/x`). Not fixed here: it's a different surface with its own blast radius, and mixing a safety-gate change into a skill-registration PR would couple two independent risks.
