### PR TITLE
fix(statusline): source context % from the stdin context window, not session count (#1453)

### DIFF
--- a/.claude/guidance/shipped/moflo-yaml-reference.md
+++ b/.claude/guidance/shipped/moflo-yaml-reference.md
@@ -103,6 +103,7 @@ status_line:
   show_model: true                # Current model name
   show_session: true              # Session duration
   show_intelligence: true         # Intelligence % indicator
+  show_context: true              # Context-window % used; hides until Claude Code reports it
   show_swarm: true                # Active swarm agents count
   show_hooks: true                # Enabled hooks count
   show_mcp: true                  # MCP server count

--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -45,6 +45,7 @@ function loadStatusLineConfig() {
     show_model: true,
     show_session: true,
     show_intelligence: true,
+    show_context: true,
     show_swarm: true,
     show_hooks: true,
     show_mcp: true,
@@ -151,6 +152,23 @@ function readJSON(filePath) {
     }
   } catch { /* ignore */ }
   return null;
+}
+
+// Normalize Claude Code's `context_window.used_percentage` into a 0-100 integer.
+// Returns null (never a stand-in number) for anything that isn't a finite number,
+// so every renderer can self-hide rather than publish a value it can't stand
+// behind (#1453).
+function normalizeContextPct(raw) {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return null;
+  return Math.max(0, Math.min(100, Math.round(raw)));
+}
+
+// Colour for a context gauge; lower is better. Matches the thresholds already
+// used by the TypeScript statusline generator (src/cli/hooks/statusline/index.ts).
+function contextColor(pct) {
+  if (pct >= 75) return c.brightRed;
+  if (pct >= 50) return c.brightYellow;
+  return c.brightGreen;
 }
 
 // Safe file stat (returns null on failure)
@@ -386,7 +404,6 @@ function getSystemMetrics() {
   // Intelligence from learning.json
   const learningData = readJSON(path.join(CWD, '.moflo', 'metrics', 'learning.json'));
   let intelligencePct = 0;
-  let contextPct = 0;
 
   if (learningData?.intelligence?.score !== undefined) {
     intelligencePct = Math.min(100, Math.floor(learningData.intelligence.score));
@@ -409,11 +426,20 @@ function getSystemMetrics() {
     intelligencePct = Math.min(100, score);
   }
 
-  if (learningData?.sessions?.total !== undefined) {
-    contextPct = Math.min(100, learningData.sessions.total * 5);
-  } else {
-    contextPct = Math.min(100, Math.floor(learning.sessions * 5));
-  }
+  // Context %: the real value, piped in by Claude Code on stdin (#1453).
+  //
+  // `context_window.used_percentage` is pre-calculated by Claude Code from INPUT
+  // tokens only (input_tokens + cache_creation_input_tokens + cache_read_input_tokens);
+  // it deliberately excludes output_tokens. It already accounts for
+  // `context_window_size`, so it stays correct on a 1M-context model. Do NOT
+  // "correct" this to `exceeds_200k_tokens`, which is a fixed 200k threshold and
+  // is meaningless on anything larger.
+  //
+  // It is null early in a session (before the first API response). Report null,
+  // never a substitute: this field used to be derived from the stored session
+  // count (`sessions * 5`), which pinned at 100% after 20 sessions and had nothing
+  // to do with the window. A blank beats a wrong number.
+  const contextPct = normalizeContextPct(STDIN_PAYLOAD?.context_window?.used_percentage);
 
   // Sub-agents from file metrics (no ps aux)
   let subAgents = 0;
@@ -797,6 +823,12 @@ function generateStatusline() {
     parts.push(`${c.cyan}\u23F1 ${session.duration}${c.reset}`);
   }
 
+  // Context % (#1453). Self-hides when Claude Code hasn't reported a window yet,
+  // rather than rendering a placeholder that reads as a real measurement.
+  if (SL_CONFIG.show_context && system.contextPct !== null) {
+    parts.push(`${contextColor(system.contextPct)}\uD83D\uDCC2 ${system.contextPct}%${c.reset}`);
+  }
+
   // Intelligence %
   if (SL_CONFIG.show_intelligence) {
     const intellColor = system.intelligencePct >= 80 ? c.brightGreen : system.intelligencePct >= 40 ? c.brightYellow : c.dim;
@@ -872,6 +904,14 @@ function generateDashboard() {
       `${c.brightYellow}\uD83E\uDD16 Swarm${c.reset}  ${swarmInd} [${agentsColor}${String(swarm.activeAgents).padStart(2)}${c.reset}/${c.brightWhite}${swarm.maxAgents}${c.reset}]  ` +
       `${c.brightPurple}\uD83D\uDC65 ${system.subAgents}${c.reset}    ` +
       `${c.brightCyan}\uD83D\uDCBE ${system.memoryMB}MB${c.reset}`
+    );
+  }
+
+  // Context % (#1453). Self-hides when the value is unknown.
+  if (SL_CONFIG.show_context && system.contextPct !== null) {
+    lines.push(
+      `${c.brightCyan}\uD83D\uDCC2 Context${c.reset}  ${contextColor(system.contextPct)}${system.contextPct}%${c.reset} ` +
+      `${c.dim}used${c.reset}`
     );
   }
 
@@ -952,8 +992,17 @@ function generateCompactDashboard() {
   pushUpgradeNoticeSegment(lines);
   lines.push(header);
 
-  // Combined swarm + embeddings + mcp line
+  // Combined context + swarm + embeddings + mcp line
   const segments = [];
+  // Context % (#1453). Read straight off the stdin payload rather than via
+  // getSystemMetrics() — compact mode deliberately avoids that call so it stays
+  // probe-free, and this value costs nothing to derive.
+  {
+    const pct = normalizeContextPct(STDIN_PAYLOAD?.context_window?.used_percentage);
+    if (SL_CONFIG.show_context && pct !== null) {
+      segments.push(`${contextColor(pct)}\uD83D\uDCC2 ${pct}%${c.reset}`);
+    }
+  }
   if (SL_CONFIG.show_swarm) {
     const swarm = getSwarmStatus();
     const swarmInd = swarm.coordinationActive ? `${c.brightGreen}\u25C9${c.reset}` : `${c.dim}\u25CB${c.reset}`;

--- a/src/cli/__tests__/statusline-context-pct.test.ts
+++ b/src/cli/__tests__/statusline-context-pct.test.ts
@@ -1,0 +1,202 @@
+// Statusline context-percentage sourcing tests (#1453).
+//
+// The statusline's context gauge must come from the ONE place that knows the
+// answer: `context_window.used_percentage` on the session payload Claude Code
+// pipes to a statusline command. Pre-#1453 it was computed from the stored
+// session count (`sessions * 5`), so it climbed 5 points per session and pinned
+// at 100% after 20 of them — an activity counter wearing a context gauge's
+// label, reading "full" precisely when a real gauge would matter most.
+//
+// Two invariants are load-bearing here:
+//   1. Unknown is reported as `null` and rendered as nothing — never as `0`,
+//      which is indistinguishable from a genuinely empty window.
+//   2. Nothing about `.moflo/metrics/learning.json` may move the number.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { resolve, join, dirname } from 'node:path';
+
+const STATUSLINE = resolve(__dirname, '../../../.claude/helpers/statusline.cjs');
+const REPO_ROOT = resolve(__dirname, '../../..');
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  status: number | null;
+}
+
+function makeTempRoot(): string {
+  const root = resolve(
+    REPO_ROOT,
+    '.testoutput',
+    '.test-statusline-ctx-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
+  );
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'sl-ctx-test', version: '0.0.0' }));
+  return root;
+}
+
+function cleanTempRoot(root: string) {
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* non-fatal on Windows */
+  }
+}
+
+/**
+ * Drive the real statusline the way Claude Code does: a piped stdin payload.
+ * `input` is always a string (never undefined) so stdin is a pipe rather than a
+ * TTY on every platform — the script only parses the payload when `!isTTY`.
+ */
+function runStatusline(cwd: string, payload: unknown, args: string[] = ['--json-compact']): RunResult {
+  const result = spawnSync('node', [STATUSLINE, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 25_000,
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: cwd,
+      CI: '1',
+      GIT_CEILING_DIRECTORIES: dirname(cwd),
+    },
+    input: payload === undefined ? '' : JSON.stringify(payload),
+  });
+  return { stdout: result.stdout || '', stderr: result.stderr || '', status: result.status };
+}
+
+function contextPctOf(cwd: string, payload: unknown): number | null {
+  const { stdout, stderr, status } = runStatusline(cwd, payload);
+  expect(stderr, `statusline wrote to stderr: ${stderr}`).toBe('');
+  expect(status).toBe(0);
+  return JSON.parse(stdout).system.contextPct;
+}
+
+function windowPayload(usedPercentage: number | null) {
+  return {
+    context_window: {
+      total_input_tokens: 12345,
+      total_output_tokens: 678,
+      context_window_size: 200_000,
+      current_usage: null,
+      used_percentage: usedPercentage,
+      remaining_percentage: usedPercentage === null ? null : 100 - usedPercentage,
+    },
+  };
+}
+
+/** Seed the file the old, wrong formula read from. */
+function writeLearningMetrics(root: string, sessionsTotal: number) {
+  const dir = join(root, '.moflo', 'metrics');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'learning.json'), JSON.stringify({ sessions: { total: sessionsTotal } }));
+}
+
+function writeMofloYaml(root: string, statusLineBlock: string) {
+  writeFileSync(join(root, 'moflo.yaml'), `status_line:\n${statusLineBlock}\n`);
+}
+
+/** Strip ANSI SGR sequences so assertions read against visible text only. */
+const ANSI = new RegExp(String.fromCharCode(0x1b) + '\\[[0-9;]*m', 'g');
+function plain(s: string): string {
+  return s.replace(ANSI, '');
+}
+
+describe('statusline context % (#1453)', () => {
+  let root: string;
+  beforeEach(() => { root = makeTempRoot(); });
+  afterEach(() => { cleanTempRoot(root); });
+
+  describe('sourcing', () => {
+    it('reports the rounded used_percentage from the stdin payload', () => {
+      expect(contextPctOf(root, windowPayload(42.6))).toBe(43);
+    });
+
+    it('reports null when used_percentage is null (no API response yet)', () => {
+      expect(contextPctOf(root, windowPayload(null))).toBeNull();
+    });
+
+    it('reports null when the payload carries no context_window at all', () => {
+      expect(contextPctOf(root, { model: { display_name: 'Opus 5' } })).toBeNull();
+    });
+
+    it('reports null when there is no stdin payload', () => {
+      expect(contextPctOf(root, undefined)).toBeNull();
+    });
+
+    it('reports null for a non-numeric used_percentage', () => {
+      expect(contextPctOf(root, { context_window: { used_percentage: '77' } })).toBeNull();
+    });
+
+    it('clamps out-of-range values into 0-100', () => {
+      expect(contextPctOf(root, windowPayload(130))).toBe(100);
+      expect(contextPctOf(root, windowPayload(-5))).toBe(0);
+    });
+
+    // The regression itself: the number must not track stored session count.
+    it('ignores learning.json session counts entirely', () => {
+      writeLearningMetrics(root, 40); // old formula: 40 * 5 -> clamped to 100
+      expect(contextPctOf(root, windowPayload(42.6))).toBe(43);
+    });
+
+    it('stays null with a high session count and no window payload', () => {
+      writeLearningMetrics(root, 40);
+      expect(contextPctOf(root, undefined)).toBeNull();
+    });
+  });
+
+  describe('rendering', () => {
+    it.each([['--single-line'], ['--compact'], ['--dashboard']])(
+      'renders the gauge in %s mode when the value is known',
+      (mode) => {
+        const out = plain(runStatusline(root, windowPayload(88), [mode]).stdout);
+        expect(out).toContain('88%');
+      },
+    );
+
+    it.each([['--single-line'], ['--compact'], ['--dashboard']])(
+      'renders no gauge in %s mode when the value is unknown',
+      (mode) => {
+        const out = plain(runStatusline(root, windowPayload(null), [mode]).stdout);
+        expect(out).not.toMatch(/📂/u);
+      },
+    );
+
+    it('hides the gauge when show_context is false', () => {
+      writeMofloYaml(root, '  show_context: false');
+      const out = plain(runStatusline(root, windowPayload(88), ['--compact']).stdout);
+      expect(out).not.toMatch(/📂/u);
+      expect(out).not.toContain('88%');
+    });
+
+    it('shows the gauge by default when moflo.yaml sets no show_context', () => {
+      writeMofloYaml(root, '  show_swarm: true');
+      const out = plain(runStatusline(root, windowPayload(88), ['--compact']).stdout);
+      expect(out).toContain('88%');
+    });
+  });
+});
+
+// A source-level guard: the fabricated formula is easy to reintroduce because
+// `sessions` sits right next to the real metrics in the same function. Assert on
+// the shape of the mistake rather than on any one spelling of it.
+describe('statusline context % has no session-count input (#1453)', () => {
+  const SURFACES = [
+    '.claude/helpers/statusline.cjs',
+    'src/cli/commands/hooks.ts',
+    'src/cli/hooks/statusline/index.ts',
+  ];
+
+  it.each(SURFACES)('%s never derives a context percentage from a session count', (rel) => {
+    const src = readFileSync(resolve(REPO_ROOT, rel), 'utf-8');
+    // Drop comments first: this file's own explanation of the old bug quotes the
+    // formula, and so do the fix comments in the surfaces themselves.
+    const code = src
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^[ \t]*\/\/.*$/gm, '');
+    const offenders = code
+      .split('\n')
+      .filter((line) => /contextPct/.test(line) && /session/i.test(line));
+    expect(offenders, `context % must not be computed from sessions in ${rel}`).toEqual([]);
+  });
+});

--- a/src/cli/commands/hooks.ts
+++ b/src/cli/commands/hooks.ts
@@ -3314,7 +3314,12 @@ const statuslineCommand: Command = {
         intelligencePct = Math.min(100, maturityScore);
       }
 
-      const contextPct = Math.min(100, Math.floor(learning.sessions * 5));
+      // Context-window usage is only knowable from the session payload Claude Code
+      // pipes to a statusline command; `flo hooks status` is a plain CLI invocation
+      // and never receives one. Report null rather than a stand-in (#1453) — this
+      // used to be `learning.sessions * 5`, an activity counter wearing a context
+      // gauge's label, which pinned at 100% after 20 stored sessions.
+      const contextPct: number | null = null;
 
       return { memoryMB, contextPct, intelligencePct, subAgents };
     }
@@ -3367,7 +3372,8 @@ const statuslineCommand: Command = {
 
     // Compact output
     if (ctx.flags.compact) {
-      const line = `DDD:${progress.domainsCompleted}/${progress.totalDomains} CVE:${security.cvesFixed}/${security.totalCves} Swarm:${swarm.activeAgents}/${swarm.maxAgents} Ctx:${system.contextPct}% Int:${system.intelligencePct}%`;
+      const ctxDisplay = system.contextPct === null ? '--' : `${system.contextPct}%`;
+      const line = `DDD:${progress.domainsCompleted}/${progress.totalDomains} CVE:${security.cvesFixed}/${security.totalCves} Swarm:${swarm.activeAgents}/${swarm.maxAgents} Ctx:${ctxDisplay} Int:${system.intelligencePct}%`;
       output.writeln(line);
       return { success: true, data: statusData };
     }

--- a/src/cli/config/moflo-config.ts
+++ b/src/cli/config/moflo-config.ts
@@ -264,6 +264,7 @@ export interface MofloConfig {
     show_model: boolean;
     show_session: boolean;
     show_intelligence: boolean;
+    show_context: boolean;
     show_swarm: boolean;
     show_hooks: boolean;
     show_mcp: boolean;
@@ -382,6 +383,7 @@ const DEFAULT_CONFIG: MofloConfig = {
     show_model: true,
     show_session: true,
     show_intelligence: true,
+    show_context: true,
     show_swarm: true,
     show_hooks: true,
     show_mcp: true,
@@ -639,6 +641,7 @@ function mergeConfig(raw: Record<string, any>, root: string): MofloConfig {
       show_model: raw.status_line?.show_model ?? raw.statusLine?.showModel ?? DEFAULT_CONFIG.status_line.show_model,
       show_session: raw.status_line?.show_session ?? raw.statusLine?.showSession ?? DEFAULT_CONFIG.status_line.show_session,
       show_intelligence: raw.status_line?.show_intelligence ?? raw.statusLine?.showIntelligence ?? DEFAULT_CONFIG.status_line.show_intelligence,
+      show_context: raw.status_line?.show_context ?? raw.statusLine?.showContext ?? DEFAULT_CONFIG.status_line.show_context,
       show_swarm: raw.status_line?.show_swarm ?? raw.statusLine?.showSwarm ?? DEFAULT_CONFIG.status_line.show_swarm,
       show_hooks: raw.status_line?.show_hooks ?? raw.statusLine?.showHooks ?? DEFAULT_CONFIG.status_line.show_hooks,
       show_mcp: raw.status_line?.show_mcp ?? raw.statusLine?.showMcp ?? DEFAULT_CONFIG.status_line.show_mcp,
@@ -891,6 +894,7 @@ status_line:
   show_model: true                # Current model name
   show_session: true              # Session duration
   show_intelligence: true         # Intelligence % indicator
+  show_context: true              # Context-window % used (from Claude Code's stdin payload)
   show_swarm: true                # Active swarm agents count
   show_hooks: true                # Enabled hooks count
   show_mcp: true                  # MCP server count

--- a/src/cli/hooks/statusline/index.ts
+++ b/src/cli/hooks/statusline/index.ts
@@ -26,7 +26,13 @@ import { join } from 'path';
 interface ExtendedStatuslineData extends StatuslineData {
   system: {
     memoryMB: number;
-    contextPct: number;
+    /**
+     * Context-window % used. `null` when unknown — this generator has no access
+     * to the session payload Claude Code pipes to a statusline command, so it
+     * renders `--` rather than a threshold-coloured number it can't stand
+     * behind (#1453).
+     */
+    contextPct: number | null;
     intelligencePct: number;
     subAgents: number;
   };
@@ -190,11 +196,19 @@ export class StatuslineGenerator {
     const memoryColor = data.system.memoryMB > 0 ? c.brightCyan : c.dim;
     const memoryDisplay = data.system.memoryMB > 0 ? `${data.system.memoryMB}MB` : '--';
 
-    // Context color (lower is better)
-    let contextColor = c.brightGreen;
-    if (data.system.contextPct >= 75) contextColor = c.brightRed;
-    else if (data.system.contextPct >= 50) contextColor = c.brightYellow;
-    const contextDisplay = String(data.system.contextPct).padStart(3);
+    // Context color (lower is better). An unknown value renders dim `--`, never a
+    // number: a threshold-coloured 0% reads as a real measurement (#1453).
+    const contextPct = data.system.contextPct;
+    let contextColor = c.dim;
+    // Unit lives in the string (as with memoryDisplay above) so the unknown case
+    // reads `--` rather than `--%`.
+    let contextDisplay = ' --';
+    if (contextPct !== null) {
+      contextColor = contextPct >= 75 ? c.brightRed
+        : contextPct >= 50 ? c.brightYellow
+        : c.brightGreen;
+      contextDisplay = `${String(contextPct).padStart(3)}%`;
+    }
 
     // Intelligence color
     let intelColor = c.dim;
@@ -211,7 +225,7 @@ export class StatuslineGenerator {
       `${subAgentColor}👥 ${data.system.subAgents}${c.reset}    ` +
       `${securityIcon} ${securityColor}CVE ${data.security.cvesFixed}${c.reset}/${c.brightWhite}${data.security.totalCves}${c.reset}    ` +
       `${memoryColor}💾 ${memoryDisplay}${c.reset}    ` +
-      `${contextColor}📂 ${contextDisplay}%${c.reset}    ` +
+      `${contextColor}📂 ${contextDisplay}${c.reset}    ` +
       `${intelColor}🧠 ${intelDisplay}%${c.reset}`
     );
 
@@ -596,7 +610,7 @@ export class StatuslineGenerator {
 
     return {
       memoryMB,
-      contextPct: 0, // Requires Claude Code input
+      contextPct: null, // Unknowable here: needs Claude Code's stdin payload (#1453)
       intelligencePct,
       subAgents,
     };

--- a/src/cli/init/moflo-yaml-template.ts
+++ b/src/cli/init/moflo-yaml-template.ts
@@ -333,6 +333,7 @@ status_line:
   branding: "MoFlo V4"
   show_git: true
   show_session: true
+  show_context: true      # Context-window % used; hides until Claude Code reports it
   show_swarm: true
   show_mcp: true
 


### PR DESCRIPTION
Closes #1453.

## The bug

The statusline's context gauge was computed from the **number of stored sessions**:

```js
contextPct = Math.min(100, learningData.sessions.total * 5);
```

It climbed 5 points per session and pinned at 100% after 20 of them, forever — an activity
counter wearing a context gauge's label, reading "full" precisely when a real gauge would matter
most.

## What the investigation added to the report

The report named one file. Three surfaces carried the defect, and the one it named turned out not
to *render* the value at all:

| Surface | Before | After |
|---|---|---|
| `.claude/helpers/statusline.cjs` | Fabricated the value; exposed it only via `--json`/`--json-compact`, so the number never reached the status bar | Real value from stdin; **rendered** as a self-hiding gauge in single-line, compact and dashboard modes behind a new `show_context` key (default on) |
| `src/cli/commands/hooks.ts` | Same `sessions * 5` formula behind `flo hooks statusline --compact`'s `Ctx:<n>%` | `Ctx:--`; `--json` reports `null` (this command never receives a Claude Code payload, so the honest answer is "unknown") |
| `src/cli/hooks/statusline/index.ts` | Hardcoded `0` rendered as a threshold-coloured `📂 0%` gauge | `number \| null`, rendering a dim `📂  --` |

Fixing only the computation would have shipped a correct number nobody sees — hence the render is
in scope, and is called out here deliberately as a **visible, default-on** change for consumers.

## The fix

```js
contextPct = normalizeContextPct(STDIN_PAYLOAD?.context_window?.used_percentage);
```

`used_percentage` is pre-calculated by Claude Code from **input** tokens only (`input_tokens +
cache_creation_input_tokens + cache_read_input_tokens`, excluding `output_tokens`) and already
accounts for `context_window_size`, so it stays correct on a 1M-context model. `exceeds_200k_tokens`
is a *fixed* 200k threshold and is deliberately not used — there's a comment at the call site so
nobody later "corrects" it.

**Unknown is `null`, never `0`.** A zero is indistinguishable from a genuinely empty window and
would leave the JSON surface publishing a number it cannot stand behind — the same defect in a
quieter form. Every renderer self-hides on `null`.

The payload schema was confirmed against the installed Claude Code (2.1.234) rather than taken on
trust: `context_window` carries `context_window_size`, `current_usage | null`,
`used_percentage: number | null`, `remaining_percentage: number | null`.

## Tests

19 new tests in `src/cli/__tests__/statusline-context-pct.test.ts` spawn the **real**
`statusline.cjs` with piped payloads — sourcing, rounding (`42.6` → `43`), clamping (`130`/`-5` →
`100`/`0`), null propagation for null / missing / absent payload, per-mode rendering, the
`show_context` toggle, and independence from `learning.json` session counts. A source-level guard
across all three surfaces fails if a session count is reintroduced as an input to a context
percentage.

**Mutation-verified:** restoring the old formula turns 13 of the 19 red.

Full suite: 10,875 passed, 0 failed. Lint clean. `/verify` returned PASS on all 9 acceptance
criteria (evidence recorded under `verify:1453`).

## Cross-platform (Rule #1)

Pure JSON parsing and string formatting — no paths, no shell, no process introspection. Tests drive
the script through `spawnSync` with a piped payload, identical on all three platforms; no `bash` or
`jq` in the test path. The two new emoji are spelled as `\uXXXX` surrogate pairs to match the rest of
the file and keep the shipped copy free of raw multibyte.

## Consumer blast radius (Rule #2)

- **Surface:** `.claude/helpers/statusline.cjs`, synced verbatim into every consumer's
  `.claude/helpers/` by the session-start launcher. Plus `moflo-config.ts` (new optional key), the
  `flo init` scaffold, and two CLI render paths.
- **Failure mode for a consumer on 4.12.9:** none. `show_context` is optional and defaults on; no
  `.moflo/` state changes shape; no migration.
- **Visible change:** consumers gain a context% segment in the status bar, and it self-hides until
  Claude Code reports a window. `status_line.show_context: false` opts out.
- **Round-trip:** runtime file — needs publish + reinstall + Claude Code restart to take effect in a
  consumer session.
