### PR TITLE
chore: install moflo@4.12.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^10.8.0",
         "glob": "^11.1.0",
-        "moflo": "^4.12.9",
+        "moflo": "^4.12.10",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.0"
@@ -3412,9 +3412,9 @@
       }
     },
     "node_modules/moflo": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.12.9.tgz",
-      "integrity": "sha512-4yQ6lFW/x7SUQzIVfYoDA8q68F+8zLoU/NBYQRQex2E/9uDC+rssXdRs8uqBmjS/buNLVaRXr1mLsBVIv5TjRw==",
+      "version": "4.12.10",
+      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.12.10.tgz",
+      "integrity": "sha512-YRIHvQKQTqmvDjaNaVAZxrMM5bW6PiVrRea7D5IoXOAQRZVImO4pMXYe7RKb0270chrr9N4e4AukFn3yqLdCKw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@typescript-eslint/parser": "^8.65.0",
     "eslint": "^10.8.0",
     "glob": "^11.1.0",
-    "moflo": "^4.12.9",
+    "moflo": "^4.12.10",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.0"


### PR DESCRIPTION
Dogfood the just-published release: bumps the `moflo` devDependency to 4.12.10 and updates the lockfile.

- `npm install moflo@4.12.10 --save-dev` — installed, `node_modules/moflo` reports 4.12.10
- `npm install --package-lock-only --force` — backfills cross-platform optional-dependency entries npm omits when installing on a single host platform
- `npm ci --dry-run --legacy-peer-deps` — lockfile in sync with package.json

Published against merge SHA f9e72b71b with release-smoke run 32181621932 green (9/9 jobs, 3-OS × 2-harness).