### PR TITLE
fix(guidance): bound the Spawn-and-Wait pattern with a deadline and one liveness check

### DIFF
--- a/.claude/guidance/internal/guidance-sync.md
+++ b/.claude/guidance/internal/guidance-sync.md
@@ -111,22 +111,25 @@ The consumer experiences this as: open a session → wait for the indexers → s
 
 When you change `shipped/` (rename, split, delete, large rewrite), verify the cleanup ran by snapshotting the chunk counts before and after a reindex:
 
+The store is `node:sqlite`, not `sql.js`, and the chunk body lives in `content` (there is no `value`
+column). Run the snapshot, reindex, then run the identical snapshot again:
+
 ```bash
-# BEFORE: snapshot chunk counts for the affected files
-node --input-type=module -e "
-import initSqlJs from 'sql.js';
-import { readFileSync } from 'fs';
-const SQL = await initSqlJs();
-const db = new SQL.Database(readFileSync('.moflo/moflo.db'));
-const r = db.exec(\"SELECT COUNT(*) FROM memory_entries WHERE namespace='guidance' AND key LIKE 'chunk-guidance-<file-stem>%'\");
-console.log('chunks:', r[0]?.values[0][0]);
-"
+# BEFORE: snapshot chunk counts for the affected file
+node -e "const{DatabaseSync}=require('node:sqlite');const db=new DatabaseSync('.moflo/moflo.db',{readOnly:true});console.log('chunks:',db.prepare(\"SELECT COUNT(*) AS n FROM memory_entries WHERE namespace='guidance' AND key LIKE 'chunk-guidance-<file-stem>%'\").get().n)"
 
 # Run the indexer
 node bin/index-guidance.mjs
 
-# AFTER: same query — confirm the count matches the new shape
+# AFTER: same command — confirm the count matches the new shape
 ```
+
+To see which sections actually became chunks (the useful check after an in-place rewrite, where the
+count barely moves), select `key` and `substr(content, 1, 70)` instead of `COUNT(*)`. A new H3
+should appear as its own `chunk-guidance-<file-stem>-<n>` row.
+
+`--input-type=module` with a multi-line `-e` string is POSIX-shell only; the single-line `node -e`
+form above also works in PowerShell and `cmd.exe` (Rule #1).
 
 If chunks remain after deletion, `cleanStaleEntries` did not run (likely `--file` mode) or the doc key is still appearing in `currentDocKeys` (the file is still on disk). If chunks dropped but search still returns the old content, the HNSW sidecar didn't rebuild — re-run with `node bin/build-embeddings.mjs --force`.
 

--- a/.claude/guidance/shipped/moflo-claude-swarm-cohesion.md
+++ b/.claude/guidance/shipped/moflo-claude-swarm-cohesion.md
@@ -250,14 +250,37 @@ CLI/MCP coordinates; the `Task` tool runs the agents that do the actual work.
 
 ### Spawn-and-Wait Pattern
 
-After spawning background agents:
+After spawning background agents, wait — but wait against a deadline you announced. A wait whose
+failure mode is silence is indistinguishable from a wait that is still working, so **every fan-out
+must end in a report, including the failed ones.**
 
 | Do | Don't |
 |----|-------|
 | Tell the user "I've spawned X agents working in parallel on: [list]" | Continuously poll swarm status |
-| Stop further tool calls and let agents run | Repeatedly call `TaskOutput` |
-| Wait for agent results to arrive (you'll be notified) | Add more tool calls after spawning |
-| Synthesize results when they return | Ask "should I check on the agents?" |
+| State the expected time-to-first-notification in that same message — "first results in ~2–3 min" | Repeatedly call `TaskOutput` to ask "are you done yet?" |
+| Stop further tool calls and let the agents run until that window elapses | Add unrelated tool calls after spawning |
+| Synthesize results when they return | Read continued silence as patience — it looks identical to a dead fan-out |
+| Once the announced window passes with **no** notification, run **one** liveness check — `ListAgents`, or a single `TaskOutput` | Keep waiting past that window because a result "might still arrive" |
+| Treat a stall as a fault: stop the agents, tell the user which ones never reported, and say what you will do instead | Let a fan-out end in silence, or ask the user "should I check on the agents?" |
+
+**Polling and a liveness check are different questions.** Polling asks *"are you done yet?"*
+repeatedly and burns context on agents that are working fine — still banned. A liveness check asks
+*"are you alive at all?"* **once**, after a deadline you stated up front — mandatory. Never make the
+user be the one who notices: in a consumer project, three Opus agents budgeted at ~450k tokens
+returned nothing at all, and the stall surfaced only because the operator saw the token counters
+still climbing.
+
+### Never Pass `name:` to a Fan-Out Spawn
+
+**Label a parallel spawn with `description` and leave the `Agent` tool's `name` unset.** `name`
+registers the spawn as a persistent, `SendMessage`-addressable teammate — use it only when you
+genuinely intend to message that agent later, never for one-shot fan-out work.
+
+Confirmed on Claude Code 2.1.239: a named spawn returned an `agent_id` and "will receive
+instructions via mailbox", then **never executed its `prompt`** — no output file, absent from
+`ListAgents`, no completion notification, and a follow-up `SendMessage` accepted but never
+processed. The identical unnamed spawn ran and reported normally. This is the exact silent stall the
+deadline above exists to catch.
 
 ---
 

--- a/tests/guards/spawn-and-wait-bounded-1460.test.ts
+++ b/tests/guards/spawn-and-wait-bounded-1460.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Guard: the Spawn-and-Wait pattern must stay bounded (#1460).
+ *
+ * `moflo-claude-swarm-cohesion.md` used to tell an orchestrator to stop making
+ * tool calls after a fan-out and wait for completion notifications, while its
+ * Don't column closed off every check that could reveal the notifications were
+ * never coming — polling status, reading task output, and asking the operator.
+ * A wait whose failure mode is silence is indistinguishable from a wait that is
+ * still working, so a dead fan-out read as patience.
+ *
+ * The cost was measured, not hypothetical: three Opus agents in a consumer
+ * project, budgeted at ~450k tokens, returned nothing at all, and the stall
+ * surfaced only because the operator noticed the counters still climbing.
+ *
+ * The fix is prose, so nothing else pins it. A future editor "simplifying" the
+ * table back to four tidy rows would silently restore the unbounded wait — this
+ * guard is what makes that a red test instead of a re-run of the incident.
+ *
+ * The anti-polling intent is deliberately pinned alongside the deadline: the
+ * repair must not swing into "poll continuously", which is the failure mode the
+ * original table existed to prevent.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+const DOC = resolve(
+  REPO_ROOT,
+  '.claude/guidance/shipped/moflo-claude-swarm-cohesion.md',
+);
+
+// Rule #1: normalise CRLF so a Windows checkout matches a POSIX one.
+const text = readFileSync(DOC, 'utf-8').replace(/\r\n/g, '\n');
+
+/**
+ * The body of an H3 section, up to the next heading of any level or the
+ * horizontal rule that closes it.
+ *
+ * Splits on the heading rather than slicing by offset — an index-based slice
+ * has to account for the `### ` prefix as well as the title, and getting that
+ * arithmetic wrong silently leaks the tail of the heading into the body
+ * instead of failing. Mirrors the helper in
+ * `agent-persona-mcp-examples-1330.test.ts`, which reads H3 sections the same
+ * way; it is a closure over that file's own text, so the approach is shared
+ * here rather than the function.
+ *
+ * Returns '' when the heading is absent so a missing section fails the
+ * individual assertions rather than aborting collection for the whole file —
+ * a partial regression then names the invariant it broke.
+ */
+function section(heading: string): string {
+  const after = text.split(`### ${heading}`)[1] ?? '';
+  return after.split(/\n(?:#{1,4}\s|---)/)[0];
+}
+
+describe('Spawn-and-Wait pattern stays bounded', () => {
+  const spawnWait = section('Spawn-and-Wait Pattern');
+
+  it('is still present under Critical Execution Rules', () => {
+    expect(spawnWait, `missing "### Spawn-and-Wait Pattern" in ${DOC}`).not.toBe('');
+  });
+
+  it('states an expected time-to-first-notification', () => {
+    expect(spawnWait).toMatch(/time-to-first-notification/i);
+  });
+
+  it('permits exactly one liveness check after the announced window', () => {
+    expect(spawnWait).toMatch(/liveness check/i);
+    expect(spawnWait).toMatch(/\*\*one\*\* liveness check/i);
+    // The check has to name a call the orchestrator can actually make.
+    // `TaskOutput` cannot pin it — that string also appears in the banned
+    // "Repeatedly call `TaskOutput`" row, so it would survive deleting the
+    // liveness row outright. `ListAgents` appears only in the allowance.
+    expect(spawnWait).toMatch(/ListAgents/);
+  });
+
+  it('keeps the ban on continuous polling', () => {
+    expect(spawnWait).toMatch(/Continuously poll/i);
+    expect(spawnWait).toMatch(/Repeatedly call `TaskOutput`/);
+  });
+
+  it('distinguishes polling from a liveness check', () => {
+    expect(spawnWait).toMatch(/are you done yet\?/i);
+    expect(spawnWait).toMatch(/are you alive at all\?/i);
+  });
+
+  it('forbids a fan-out that ends in silence', () => {
+    expect(spawnWait).toMatch(/in silence/i);
+    expect(spawnWait).toMatch(/every fan-out\s+must end in a report/i);
+  });
+
+  it('no longer states notification as an unconditional guarantee', () => {
+    expect(spawnWait).not.toMatch(/Wait for agent results to arrive \(you'll be notified\)/);
+  });
+});
+
+describe('Fan-out spawns are warned off the Agent `name` parameter', () => {
+  const nameRule = section('Never Pass `name:` to a Fan-Out Spawn');
+
+  it('has a discoverable heading of its own', () => {
+    expect(nameRule, `missing "### Never Pass \`name:\` to a Fan-Out Spawn" in ${DOC}`).not.toBe('');
+  });
+
+  it('directs fan-outs to label with description instead', () => {
+    expect(nameRule).toMatch(/`description`/);
+    expect(nameRule).toMatch(/leave the `Agent` tool's `name` unset/i);
+  });
+
+  it('explains that `name` registers an addressable teammate', () => {
+    expect(nameRule).toMatch(/SendMessage/);
+    expect(nameRule).toMatch(/teammate/i);
+  });
+
+  it('records the observed failure so the rule is not mistaken for style', () => {
+    expect(nameRule).toMatch(/never executed its `prompt`/i);
+  });
+});
+
+describe('the edited doc still satisfies the shipped-guidance contract', () => {
+  it('cites no issue or PR numbers', () => {
+    // shipped/moflo-guidance-rules.md rule #10 — the number resolves against
+    // the consumer's tracker, not moflo's.
+    expect(text).not.toMatch(/#\d{2,}/);
+  });
+
+  it('cross-references the top-level mirror, never the shipped/ path', () => {
+    // internal/guidance-rules.md §2 — `shipped/` is not a directory that
+    // exists in a consumer project.
+    expect(text).not.toMatch(/\.claude\/guidance\/shipped\//);
+  });
+
+  it('stays under the 500-line guidance cap', () => {
+    expect(text.split('\n').length).toBeLessThan(500);
+  });
+
+  it('keeps its See Also section', () => {
+    expect(text).toMatch(/\n## See Also\n/);
+  });
+});


### PR DESCRIPTION
## What

Gives the **Spawn-and-Wait Pattern** in `.claude/guidance/shipped/moflo-claude-swarm-cohesion.md` a
bounded expectation, and warns fan-out spawns off the `Agent` tool's `name` parameter.

Closes #1460.

## Why

The table told an orchestrator to stop making tool calls after a fan-out and wait for completion
notifications — and its Don't column closed off all three ways it could have noticed the
notifications were never coming: polling status, reading task output, and asking the operator.
`Wait for agent results to arrive (you'll be notified)` was stated as a guarantee, so silence read as
patience.

A wait whose failure mode is silence is indistinguishable from a wait that is still working. Measured
cost of one such stall in a consumer project: three Opus agents budgeted at ~450k tokens delivered
zero output, caught only because the operator noticed the token counters still climbing.

**The anti-polling intent is not reversed** — it is preserved verbatim. What was missing was a
deadline.

## Changes

**`shipped/moflo-claude-swarm-cohesion.md` § Spawn-and-Wait Pattern**

- Do: state an expected time-to-first-notification when announcing the fan-out.
- Do: once that window passes with **no** notification, run **one** liveness check (`ListAgents`, or
  a single `TaskOutput`).
- Do: treat a stall as a fault — stop the agents, name the ones that never reported, say what you
  will do instead.
- Don't: read continued silence as patience; keep waiting past the window; let a fan-out end in
  silence.
- Prose fixes the distinction that keeps the anti-polling rule intact: polling asks *"are you done
  yet?"* repeatedly (banned); a liveness check asks *"are you alive at all?"* **once**, after an
  announced deadline (mandatory).

**New `### Never Pass `name:` to a Fan-Out Spawn`** — its own H3 so it retrieves independently.
`name` registers the spawn as a persistent, `SendMessage`-addressable teammate rather than a one-shot
task runner. Confirmed on Claude Code 2.1.239: a named spawn never executed its `prompt` — no output
file, absent from `ListAgents`, no completion notification, a follow-up `SendMessage` accepted but
never processed. The identical unnamed spawn ran and reported normally.

Triage note: `name?: string` is a live `AgentInput` field in Claude Code 2.1.240
(`sdk-tools.d.ts:644`), documented as "makes it addressable via `SendMessage`" — so routing a named
spawn into the teammate registry is the documented design; the defect is that such a spawn never runs
its prompt. That fix belongs in Claude Code. This PR is documentation only.

**Drive-by** — `internal/guidance-sync.md`'s verification recipe called `sql.js` (not installed in
this repo) against a `value` column that does not exist; it could never have run. Corrected to
`node:sqlite` / `content`, given a single-line form that also works in PowerShell and `cmd.exe`, and
confirmed to run verbatim. Fixed here rather than filed, per the inline-fixes rule.

## Testing

- **New guard** `tests/guards/spawn-and-wait-bounded-1460.test.ts`, verified **bidirectionally**:
  **15 pass** on the fix, **9 targeted failures** when run against the pre-fix text. A guard on prose
  is otherwise trivially satisfiable, so the red run is the part that proves it pins something.
- Full suite: **10,942 passed, 0 failed**. `eslint --max-warnings 0` clean. `tsc --noEmit` clean.
- `/verify`: **PASS**, all 11 acceptance criteria with per-criterion evidence (`verify:1460`).

## Guidance-authoring rules applied

- **No issue or PR numbers in the shipped file** (universal rule #10; `internal/guidance-rules.md`
  §4) — the initial draft cited `(#1460)` twice and both were stripped. `issue-attribution-guard`
  green.
- No client or consumer project name (Rule #3) — the cost anecdote says "a consumer project".
  `client-name-leak-guard` green.
- Cross-refs use the top-level mirror path, never `shipped/` (§2) — that segment does not exist in a
  consumer project.
- 294 lines (under the 500 cap); edited sections 17 and 8 body lines, inside the 5–30 line RAG band;
  imperative voice; decision table for the conditional logic; specific H3 headings; `See Also` intact.
- Single source of truth — confirmed no other surface (`skills/fl/execution-modes.md`,
  `moflo-subagents.md`) restates the pattern, so no conflicting phrasing was introduced.

## Cross-platform (Rule #1)

Markdown only — no shell, no path separators, no platform-sensitive primitives in the shipped text.
LF preserved (verified: no CRLF bytes). The guard normalises CRLF so a Windows checkout matches
POSIX. The one command this PR adds, in the internal recipe, is the cross-platform single-line form.

## Consumer impact (Rule #2)

1. **Surface** — `.claude/guidance/shipped/**`, synced into every consumer's `.claude/guidance/` by
   the session-start launcher. Prose only; no code, no config, no `.moflo/` state.
2. **Failure mode on upgrade** — none. The mirror carries a "do not edit" header and is overwritten
   wholesale on the version-bump branch; no migration, nothing for the consumer to do. A consumer
   with `auto_index.guidance: false` keeps the old chunks until they reindex, which is the documented
   behaviour of that opt-out.
3. **Round-trip** — publish + reinstall for consumers and for this repo's own mirror; the source edit
   alone is sufficient for the PR. Dogfood verified locally: `node bin/index-guidance.mjs` took the
   doc **19 → 20 chunks**, with the new H3 landing as its own retrievable chunk and `See Also` intact.
