### PR TITLE
fix(memory): reconcile durable-learning sync instead of appending (#1463)

### DIFF
--- a/.claude/guidance/shipped/moflo-cross-install-memory-sharing.md
+++ b/.claude/guidance/shipped/moflo-cross-install-memory-sharing.md
@@ -31,7 +31,9 @@ Choose by who needs the learnings, not by what is easiest to wire.
 | A team sharing one repo | Git-tracked team artifact | `flo memory team-export` writes `.moflo/shared/learnings.jsonl`; teammates' session-start import-merges it after `git pull` |
 | A fresh/empty workspace that must be ready FAST | Whole-DB snapshot (`memory.hydrate_from`) | `flo memory backup --to <snap>` once; a new workspace restores the entire DB so search works on session one — no cold reindex |
 
-The first three move the SAME durable slice and dedupe on `UNIQUE(namespace, key)`, so combining them is conflict-free. The snapshot is a different tool — a one-time whole-DB seed that composes with the durable-slice modes (see the next section but one).
+The first three move the SAME durable slice and reconcile on `UNIQUE(namespace, key)`, so combining them is safe. The snapshot is a different tool — a one-time whole-DB seed that composes with the durable-slice modes (see the next section but one).
+
+**All three propagate edits and deletions, not just new entries.** The newer `updated_at` wins, a deleted entry travels as a tombstone, and an entry that exists on only one side is never touched — so a learning you wrote and have not shared yet cannot be removed by someone else's sync. Deleting a learning archives it rather than dropping the row, which is what lets the deletion reach the other stores; archived rows are invisible to search, list and stats, and are purged after 90 days.
 
 ---
 
@@ -79,7 +81,9 @@ flo memory team-export                       # writes .moflo/shared/learnings.js
 git add .moflo/shared/learnings.jsonl && git commit -m "share learnings"
 ```
 
-Teammates' session-start import-merges the file after `git pull` (first-write-wins on conflicts; author/host provenance is retained). JSONL keeps git diffs reviewable; embeddings are regenerated on import. Enable it with `memory.team_artifact: .moflo/shared/learnings.jsonl`.
+Teammates' session-start import-merges the file after `git pull`. Conflicts resolve by `updated_at` — the more recently edited version wins — and author/host provenance records who wrote each line last. JSONL keeps git diffs reviewable; embeddings are regenerated on import. Enable it with `memory.team_artifact: .moflo/shared/learnings.jsonl`.
+
+**Run `flo memory team-import` before `team-export` when you have been away.** Export reports any local change it did NOT share because the artifact's version is newer; importing first resolves that. Deletions appear in the artifact as `__moflo_tombstone__` lines — moflo versions older than this one ignore them and keep their copy of the entry, so a team mid-upgrade loses nothing.
 
 ---
 

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -2612,11 +2612,19 @@ try {
       const artifactPath = mod.resolveTeamArtifactPath(projectRoot);
       if (artifactPath && existsSync(artifactPath)) {
         const report = mod.importTeamArtifact({ projectRoot, artifactPath });
-        if (report?.imported > 0) {
-          emitMutation(
-            'merged team learnings',
-            `${plural(report.imported, 'shared learning')} imported from the git-tracked team artifact`,
-          );
+        // Corrections and deletions are changes the user needs told about just
+        // as much as inserts (#1463) — reporting only `imported` is what let
+        // the additive bug sit unnoticed.
+        const changed =
+          (report?.imported ?? 0) + (report?.updated ?? 0) + (report?.deleted ?? 0) + (report?.resurrected ?? 0);
+        if (changed > 0) {
+          const detail = [
+            report.imported > 0 ? `${plural(report.imported, 'shared learning')} imported` : null,
+            report.updated > 0 ? `${report.updated} corrected` : null,
+            report.deleted > 0 ? `${report.deleted} retired` : null,
+            report.resurrected > 0 ? `${report.resurrected} restored` : null,
+          ].filter(Boolean).join(', ');
+          emitMutation('merged team learnings', `${detail} from the git-tracked team artifact`);
         }
       }
     }

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -2612,11 +2612,19 @@ try {
       const artifactPath = mod.resolveTeamArtifactPath(projectRoot);
       if (artifactPath && existsSync(artifactPath)) {
         const report = mod.importTeamArtifact({ projectRoot, artifactPath });
-        if (report?.imported > 0) {
-          emitMutation(
-            'merged team learnings',
-            `${plural(report.imported, 'shared learning')} imported from the git-tracked team artifact`,
-          );
+        // Corrections and deletions are changes the user needs told about just
+        // as much as inserts (#1463) — reporting only `imported` is what let
+        // the additive bug sit unnoticed.
+        const changed =
+          (report?.imported ?? 0) + (report?.updated ?? 0) + (report?.deleted ?? 0) + (report?.resurrected ?? 0);
+        if (changed > 0) {
+          const detail = [
+            report.imported > 0 ? `${plural(report.imported, 'shared learning')} imported` : null,
+            report.updated > 0 ? `${report.updated} corrected` : null,
+            report.deleted > 0 ? `${report.deleted} retired` : null,
+            report.resurrected > 0 ? `${report.resurrected} restored` : null,
+          ].filter(Boolean).join(', ');
+          emitMutation('merged team learnings', `${detail} from the git-tracked team artifact`);
         }
       }
     }

--- a/src/cli/__tests__/commands/memory-team.test.ts
+++ b/src/cli/__tests__/commands/memory-team.test.ts
@@ -55,17 +55,50 @@ function run(cmd: Command, root: string, flags: Record<string, string> = {}): Pr
   return cmd.action!(ctxWith(flags));
 }
 
-function seedLearnings(root: string, rows: Array<{ key: string; namespace: string }>): Promise<void> {
+function seedLearnings(
+  root: string,
+  rows: Array<{ key: string; namespace: string; content?: string; updatedAt?: number; status?: string }>,
+): Promise<void> {
   return makeMemoryDb(memoryDbPath(root), MEMORY_SCHEMA_V3, (db: FixtureDb) => {
     for (const r of rows) {
-      db.run(`INSERT INTO memory_entries (id, key, namespace, content) VALUES (?, ?, ?, ?)`, [
-        `id-${r.namespace}-${r.key}`,
-        r.key,
-        r.namespace,
-        `content-${r.key}`,
-      ]);
+      const ts = r.updatedAt ?? Date.now();
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, created_at, updated_at, status) ` +
+          `VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [
+          `id-${r.namespace}-${r.key}`,
+          r.key,
+          r.namespace,
+          r.content ?? `content-${r.key}`,
+          ts,
+          ts,
+          r.status ?? 'active',
+        ],
+      );
     }
   });
+}
+
+/** Capture what the command actually prints, so the summary itself is covered. */
+async function captureRun(
+  cmd: Command,
+  root: string,
+  flags: Record<string, string> = {},
+): Promise<{ result: CommandResult; printed: string }> {
+  const { output } = await import('../../output.js');
+  const chunks: string[] = [];
+  const sinks = ['printSuccess', 'printInfo', 'printWarning', 'printError'] as const;
+  const spies = sinks.map((name) =>
+    vi.spyOn(output as never, name as never).mockImplementation(((msg: string) => {
+      chunks.push(String(msg));
+    }) as never),
+  );
+  try {
+    const result = await run(cmd, root, flags);
+    return { result, printed: chunks.join('\n') };
+  } finally {
+    for (const spy of spies) spy.mockRestore();
+  }
 }
 
 describe('flo memory team-export', () => {
@@ -117,5 +150,68 @@ describe('flo memory team-import', () => {
     } finally {
       db.close();
     }
+  });
+});
+
+describe('the team-export / team-import summaries report every category (#1463)', () => {
+  // The old summary named only the appends, which read as "everything was
+  // shared" while 32 corrections and 34 deletions sat unpropagated. The
+  // rendering is the part that failed, so the rendering is what gets asserted.
+  it('names corrections and retirements, not just appends', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, '.moflo', 'shared', 'learnings.jsonl');
+    await seedLearnings(root, [
+      { key: 'corrected', namespace: 'learnings', content: 'v1', updatedAt: Date.now() - 5_000 },
+      { key: 'retired', namespace: 'learnings', content: 'v1', updatedAt: Date.now() - 5_000 },
+    ]);
+    await run(teamExport, root);
+
+    // Correct one entry and purge another, then re-export.
+    const db = new DatabaseSync(memoryDbPath(root));
+    db.prepare(`UPDATE memory_entries SET content = ?, updated_at = ? WHERE key = 'corrected'`).run('v2', Date.now());
+    db.prepare(`UPDATE memory_entries SET status = 'archived', updated_at = ? WHERE key = 'retired'`).run(Date.now());
+    db.close();
+
+    const { result, printed } = await captureRun(teamExport, root);
+    expect(result.success).toBe(true);
+    expect(printed).toMatch(/1 corrected/);
+    expect(printed).toMatch(/1 retired/);
+    expect(existsSync(artifact)).toBe(true);
+  });
+
+  it('warns when a local change was NOT shared because the artifact is newer', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, '.moflo', 'shared', 'learnings.jsonl');
+    await seedLearnings(root, [{ key: 'k', namespace: 'learnings', content: 'local', updatedAt: 1_000 }]);
+    const { writeFileSync, mkdirSync } = await import('node:fs');
+    mkdirSync(join(root, '.moflo', 'shared'), { recursive: true });
+    writeFileSync(
+      artifact,
+      JSON.stringify({
+        namespace: 'learnings',
+        key: 'k',
+        content: 'newer from a teammate',
+        type: 'semantic',
+        updated_at: Date.now(),
+        provenance: { author: 'A', source: 'h', sharedAt: 'x' },
+      }) + '\n',
+      'utf-8',
+    );
+
+    const { printed } = await captureRun(teamExport, root);
+    expect(printed).toMatch(/NOT shared/);
+    expect(printed).toMatch(/team-import/);
+  });
+
+  it('reports what an import applied beyond plain inserts', async () => {
+    const rootA = await makeRoot();
+    const rootB = await makeRoot();
+    await seedLearnings(rootA, [{ key: 'k', namespace: 'learnings', content: 'v2', updatedAt: Date.now() }]);
+    await seedLearnings(rootB, [{ key: 'k', namespace: 'learnings', content: 'v1', updatedAt: 1_000 }]);
+    await run(teamExport, rootA);
+
+    const artifact = join(rootA, '.moflo', 'shared', 'learnings.jsonl');
+    const { printed } = await captureRun(teamImport, rootB, { from: artifact });
+    expect(printed).toMatch(/1 corrected/);
   });
 });

--- a/src/cli/__tests__/services/durable-delete-archives.test.ts
+++ b/src/cli/__tests__/services/durable-delete-archives.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Deleting a durable learning archives it instead of dropping the row (#1463).
+ *
+ * A hard delete cannot propagate — it is indistinguishable from a row that
+ * never existed — so before this the entry came straight back at the next
+ * session-start import or worktree seed. Both delete paths are covered: the
+ * offline one in `entries-write.deleteEntry` and the daemon-side
+ * `bridgeDeleteEntry`, since a rule enforced in only one of them is a rule that
+ * holds only until the daemon is running.
+ *
+ * Non-durable namespaces must still hard-delete: they are never shared, so a
+ * tombstone there would be the write-only kind story #728 removed.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import { deleteEntry } from '../../memory/entries-write.js';
+import { bridgeDeleteEntry } from '../../memory/bridge-entries.js';
+import { MEMORY_SCHEMA_V3 } from '../../memory/memory-initializer.js';
+import { makeMemoryDb, type FixtureDb } from '../_helpers/legacy-memory-db.js';
+
+const tmpDirs: string[] = [];
+afterEach(async () => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop()!;
+    try {
+      await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    } catch {
+      /* Windows file-lock — non-fatal for tests */
+    }
+  }
+});
+
+async function makeDb(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'moflo-del-'));
+  tmpDirs.push(dir);
+  const dbPath = join(dir, 'moflo.db');
+  await makeMemoryDb(dbPath, MEMORY_SCHEMA_V3, (db: FixtureDb) => {
+    for (const [ns, key] of [
+      ['learnings', 'durable-one'],
+      ['knowledge', 'durable-two'],
+      ['code-map', 'structural'],
+    ] as const) {
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, created_at, updated_at, status) ` +
+          `VALUES (?, ?, ?, ?, ?, ?, 'active')`,
+        [`id-${ns}-${key}`, key, ns, `content-${key}`, 1_000, 1_000],
+      );
+    }
+  });
+  return dbPath;
+}
+
+function row(dbPath: string, key: string): { status: string; updated_at: number } | undefined {
+  const db = new DatabaseSync(dbPath);
+  try {
+    return db.prepare(`SELECT status, updated_at FROM memory_entries WHERE key = ?`).get(key) as
+      | { status: string; updated_at: number }
+      | undefined;
+  } finally {
+    db.close();
+  }
+}
+
+describe('deleteEntry (offline path)', () => {
+  it('archives a learnings row and stamps the deletion time', async () => {
+    const dbPath = await makeDb();
+    const before = Date.now();
+    const result = await deleteEntry({ key: 'durable-one', namespace: 'learnings', dbPath });
+
+    expect(result.deleted).toBe(true);
+    const after = row(dbPath, 'durable-one');
+    expect(after?.status).toBe('archived');
+    // The stamp is what a later re-creation has to beat, so it must be the
+    // deletion time and not the row's original updated_at.
+    expect(after!.updated_at).toBeGreaterThanOrEqual(before);
+  });
+
+  it('archives a knowledge row too — both durable namespaces are shared', async () => {
+    const dbPath = await makeDb();
+    await deleteEntry({ key: 'durable-two', namespace: 'knowledge', dbPath });
+    expect(row(dbPath, 'durable-two')?.status).toBe('archived');
+  });
+
+  it('still hard-deletes a non-durable row', async () => {
+    const dbPath = await makeDb();
+    const result = await deleteEntry({ key: 'structural', namespace: 'code-map', dbPath });
+
+    expect(result.deleted).toBe(true);
+    expect(row(dbPath, 'structural')).toBeUndefined();
+  });
+
+  it('reports the entry as gone — every read path filters status', async () => {
+    const dbPath = await makeDb();
+    await deleteEntry({ key: 'durable-one', namespace: 'learnings', dbPath });
+
+    const db = new DatabaseSync(dbPath);
+    try {
+      const active = db
+        .prepare(`SELECT key FROM memory_entries WHERE status = 'active' ORDER BY key`)
+        .all() as Array<{ key: string }>;
+      expect(active.map((r) => r.key)).toEqual(['durable-two', 'structural']);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('is idempotent — re-deleting an archived row reports not-found', async () => {
+    const dbPath = await makeDb();
+    await deleteEntry({ key: 'durable-one', namespace: 'learnings', dbPath });
+    const second = await deleteEntry({ key: 'durable-one', namespace: 'learnings', dbPath });
+    expect(second.deleted).toBe(false);
+  });
+});
+
+describe('bridgeDeleteEntry (daemon path)', () => {
+  it('archives a learnings row rather than dropping it', async () => {
+    const dbPath = await makeDb();
+    const result = await bridgeDeleteEntry({ key: 'durable-one', namespace: 'learnings', dbPath });
+
+    expect(result?.success).toBe(true);
+    expect(result?.deleted).toBe(true);
+    expect(row(dbPath, 'durable-one')?.status).toBe('archived');
+  });
+
+  it('still hard-deletes a non-durable row', async () => {
+    const dbPath = await makeDb();
+    const result = await bridgeDeleteEntry({ key: 'structural', namespace: 'code-map', dbPath });
+
+    expect(result?.success).toBe(true);
+    expect(row(dbPath, 'structural')).toBeUndefined();
+  });
+});

--- a/src/cli/__tests__/services/durable-reconcile.test.ts
+++ b/src/cli/__tests__/services/durable-reconcile.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for the shared durable-learning reconciliation plan (#1463).
+ *
+ * The conflict matrix is the whole point of the module, so every row of it is
+ * driven in BOTH orderings — a test that only exercises the ordering that
+ * happens to pass would not have caught the additive bug this replaces.
+ *
+ * Pure module: no fs, no sqlite, no clock.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  planReconcile,
+  reconcileId,
+  splitReconcileId,
+  isTombstone,
+  isNoOpPlan,
+  isPrunableTombstone,
+  TOMBSTONE_TTL_MS,
+  type ReconcileRecord,
+} from '../../services/durable-reconcile.js';
+
+const live = (key: string, content: string, updatedAt: number, namespace = 'learnings'): ReconcileRecord =>
+  ({ namespace, key, content, updatedAt });
+
+const dead = (key: string, deletedAt: number, namespace = 'learnings'): ReconcileRecord =>
+  ({ namespace, key, updatedAt: 0, deletedAt });
+
+const mapOf = (...records: ReconcileRecord[]): Map<string, ReconcileRecord> =>
+  new Map(records.map((r) => [reconcileId(r.namespace, r.key), r]));
+
+const opFor = (source: Map<string, ReconcileRecord>, target: Map<string, ReconcileRecord>): string => {
+  const plan = planReconcile(source, target);
+  return plan.actions.length === 0 ? 'none' : plan.actions[0].op;
+};
+
+describe('reconcileId', () => {
+  it('separates namespace from key so the two durable namespaces cannot collide', () => {
+    expect(reconcileId('learnings', 'x')).not.toBe(reconcileId('knowledge', 'x'));
+  });
+
+  it('round-trips through splitReconcileId, including keys containing separators', () => {
+    for (const key of ['plain', 'with:colon', 'with/slash', 'with\tnewline-ish']) {
+      expect(splitReconcileId(reconcileId('learnings', key))).toEqual({ namespace: 'learnings', key });
+    }
+  });
+});
+
+describe('planReconcile — the conflict matrix', () => {
+  it('inserts a key the target lacks', () => {
+    expect(opFor(mapOf(live('a', 'v1', 100)), new Map())).toBe('insert');
+  });
+
+  it('leaves a matching entry alone', () => {
+    const plan = planReconcile(mapOf(live('a', 'v1', 200)), mapOf(live('a', 'v1', 100)));
+    expect(plan.actions).toHaveLength(0);
+    expect(plan.summary.unchanged).toBe(1);
+  });
+
+  // The correction case — the one the additive implementations could never do.
+  it('updates when the source is newer and the content differs', () => {
+    expect(opFor(mapOf(live('a', 'corrected', 200)), mapOf(live('a', 'stale', 100)))).toBe('update');
+  });
+
+  it('keeps the target when the target is newer — the same pair, reversed', () => {
+    const plan = planReconcile(mapOf(live('a', 'stale', 100)), mapOf(live('a', 'corrected', 200)));
+    expect(plan.actions).toHaveLength(0);
+    expect(plan.summary.keptTargetNewer).toBe(1);
+  });
+
+  it('deletes a live target when the source tombstone is newer', () => {
+    expect(opFor(mapOf(dead('a', 200)), mapOf(live('a', 'v1', 100)))).toBe('delete');
+  });
+
+  it('does NOT delete an entry re-created after the purge — the same pair, reversed', () => {
+    const plan = planReconcile(mapOf(dead('a', 100)), mapOf(live('a', 'recreated', 200)));
+    expect(plan.actions).toHaveLength(0);
+    expect(plan.summary.keptTargetNewer).toBe(1);
+  });
+
+  it('resurrects when a live source is newer than a target tombstone', () => {
+    expect(opFor(mapOf(live('a', 'recreated', 200)), mapOf(dead('a', 100)))).toBe('resurrect');
+  });
+
+  it('lets the purge stand when the tombstone is newer — the same pair, reversed', () => {
+    expect(opFor(mapOf(live('a', 'v1', 100)), mapOf(dead('a', 200)))).toBe('none');
+  });
+
+  it('does nothing for a tombstone the target never had', () => {
+    const plan = planReconcile(mapOf(dead('gone', 500)), new Map());
+    expect(plan.actions).toHaveLength(0);
+    expect(plan.summary.inserted).toBe(0);
+  });
+
+  it('treats two tombstones as settled', () => {
+    const plan = planReconcile(mapOf(dead('a', 200)), mapOf(dead('a', 100)));
+    expect(plan.actions).toHaveLength(0);
+    expect(plan.summary.unchanged).toBe(1);
+  });
+});
+
+describe('planReconcile — local-only work is never touched', () => {
+  // The regression that matters most: "delete anything the source lacks" would
+  // destroy work authored here and not yet exported.
+  it('leaves a target-only key alone with no tombstones in play', () => {
+    const plan = planReconcile(mapOf(live('shared', 'v1', 100)), mapOf(live('shared', 'v1', 100), live('mine', 'local', 100)));
+    expect(plan.actions).toHaveLength(0);
+    expect(plan.summary.targetOnly).toBe(1);
+  });
+
+  it('leaves a target-only key alone even when the source carries tombstones for other keys', () => {
+    const plan = planReconcile(mapOf(dead('purged', 500)), mapOf(live('mine', 'local', 100)));
+    expect(plan.actions).toHaveLength(0);
+    expect(plan.summary.targetOnly).toBe(1);
+  });
+});
+
+describe('planReconcile — ties', () => {
+  it('changes nothing when two live records share a timestamp', () => {
+    expect(opFor(mapOf(live('a', 'theirs', 100)), mapOf(live('a', 'ours', 100)))).toBe('none');
+  });
+
+  it('changes nothing when a tombstone ties with a live record', () => {
+    expect(opFor(mapOf(dead('a', 100)), mapOf(live('a', 'ours', 100)))).toBe('none');
+  });
+});
+
+describe('planReconcile — a record with no usable timestamp', () => {
+  // A pre-#1463 artifact line has no updated_at; callers pass 0. It must still
+  // seed a store that lacks the key, and must never overwrite one that has it.
+  it('still inserts where the target lacks the key', () => {
+    expect(opFor(mapOf(live('a', 'legacy', 0)), new Map())).toBe('insert');
+  });
+
+  it('never overwrites an existing target row', () => {
+    const plan = planReconcile(mapOf(live('a', 'legacy', 0)), mapOf(live('a', 'corrected locally', 1)));
+    expect(plan.actions).toHaveLength(0);
+    expect(plan.summary.keptTargetNewer).toBe(1);
+  });
+});
+
+describe('planReconcile — summary', () => {
+  it('accounts for every source key exactly once, plus target-only keys', () => {
+    const source = mapOf(
+      live('ins', 'new', 100),
+      live('upd', 'newer', 200),
+      live('same', 'v1', 100),
+      live('older', 'stale', 50),
+      dead('del', 300),
+    );
+    const target = mapOf(
+      live('upd', 'older', 100),
+      live('same', 'v1', 100),
+      live('older', 'fresher', 100),
+      live('del', 'doomed', 100),
+      live('theirs', 'untouched', 100),
+    );
+    const { summary, actions } = planReconcile(source, target);
+
+    expect(summary.inserted).toBe(1);
+    expect(summary.updated).toBe(1);
+    expect(summary.deleted).toBe(1);
+    expect(summary.unchanged).toBe(1);
+    expect(summary.keptTargetNewer).toBe(1);
+    expect(summary.targetOnly).toBe(1);
+
+    const accountedSourceKeys =
+      summary.inserted + summary.updated + summary.deleted + summary.resurrected +
+      summary.unchanged + summary.keptTargetNewer;
+    expect(accountedSourceKeys).toBe(source.size);
+    expect(actions).toHaveLength(3);
+  });
+
+  it('reports a no-op plan for two identical stores', () => {
+    const both = () => mapOf(live('a', 'v1', 100), live('b', 'v2', 200));
+    expect(isNoOpPlan(planReconcile(both(), both()))).toBe(true);
+  });
+});
+
+describe('isTombstone / isPrunableTombstone', () => {
+  it('classifies by deletedAt, not by empty content', () => {
+    expect(isTombstone(dead('a', 1))).toBe(true);
+    expect(isTombstone(live('a', '', 1))).toBe(false);
+  });
+
+  it('prunes a tombstone past the TTL and keeps one inside it', () => {
+    const now = 10 * TOMBSTONE_TTL_MS;
+    expect(isPrunableTombstone(dead('a', now - TOMBSTONE_TTL_MS - 1), now)).toBe(true);
+    expect(isPrunableTombstone(dead('a', now - TOMBSTONE_TTL_MS + 1), now)).toBe(false);
+  });
+
+  it('never prunes a live record however old', () => {
+    expect(isPrunableTombstone(live('a', 'ancient', 0), 10 * TOMBSTONE_TTL_MS)).toBe(false);
+  });
+});

--- a/src/cli/__tests__/services/durable-sync-reconcile.test.ts
+++ b/src/cli/__tests__/services/durable-sync-reconcile.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Tests for reconciling worktree/cross-install durable sync (#1463).
+ *
+ * This is the third site that was additive on keys, and the one that needs no
+ * configuration to be active (`worktree_sharing` defaults on), so it reaches
+ * every user with a linked worktree. Corrections and deletions must cross
+ * between worktrees, and a learning authored in one and never flushed must
+ * survive every sync.
+ *
+ * Real node:sqlite DBs in tmp dirs; paths via path.join / os.tmpdir (Rule #1).
+ */
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import {
+  reconcileDurableStores,
+  seedDurableFromShared,
+  flushDurableToShared,
+  syncDurableAtSessionStart,
+  writeThroughDurable,
+  changedRows,
+} from '../../services/durable-sync.js';
+import { loadMofloConfig, type MofloConfig } from '../../config/moflo-config.js';
+import { pruneExpiredArchives } from '../../services/durable-store-io.js';
+import { TOMBSTONE_TTL_MS } from '../../services/durable-reconcile.js';
+import { openDaemonDatabase } from '../../memory/daemon-backend.js';
+import { memoryDbPath } from '../../services/moflo-paths.js';
+import { MEMORY_SCHEMA_V3 } from '../../memory/memory-initializer.js';
+import { makeMemoryDb, type FixtureDb } from '../_helpers/legacy-memory-db.js';
+
+const tmpDirs: string[] = [];
+afterEach(async () => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop()!;
+    try {
+      await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    } catch {
+      /* Windows file-lock — non-fatal for tests */
+    }
+  }
+});
+
+const savedEnv = process.env.MOFLO_DURABLE_PATH;
+beforeEach(() => {
+  delete process.env.MOFLO_DURABLE_PATH;
+});
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.MOFLO_DURABLE_PATH;
+  else process.env.MOFLO_DURABLE_PATH = savedEnv;
+});
+
+/** Ordering-only timestamps, anchored near now so nothing looks expired. */
+const T = (offset: number): number => Date.now() - 1_000_000 + offset;
+
+async function makeRoot(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'moflo-durable-rec-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+interface Row {
+  key: string;
+  content?: string;
+  updatedAt?: number;
+  status?: 'active' | 'archived';
+  namespace?: string;
+}
+
+function seedDb(dbPath: string, rows: Row[]): Promise<void> {
+  return makeMemoryDb(dbPath, MEMORY_SCHEMA_V3, (db: FixtureDb) => {
+    for (const r of rows) {
+      const ns = r.namespace ?? 'learnings';
+      const ts = r.updatedAt ?? T(1_000);
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, created_at, updated_at, status) ` +
+          `VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [`id-${ns}-${r.key}`, r.key, ns, r.content ?? `content-${r.key}`, ts, ts, r.status ?? 'active'],
+      );
+    }
+  });
+}
+
+function activeRows(dbPath: string): Array<{ key: string; content: string }> {
+  const db = new DatabaseSync(dbPath);
+  try {
+    return db
+      .prepare(`SELECT key, content FROM memory_entries WHERE status = 'active' ORDER BY key`)
+      .all() as Array<{ key: string; content: string }>;
+  } finally {
+    db.close();
+  }
+}
+
+function allKeys(dbPath: string): string[] {
+  const db = new DatabaseSync(dbPath);
+  try {
+    return (db.prepare(`SELECT key FROM memory_entries ORDER BY key`).all() as Array<{ key: string }>).map(
+      (r) => r.key,
+    );
+  } finally {
+    db.close();
+  }
+}
+
+describe('reconcileDurableStores (#1463)', () => {
+  it('carries a correction into the target', async () => {
+    const root = await makeRoot();
+    const source = join(root, 'source.db');
+    const target = join(root, 'target.db');
+    await seedDb(source, [{ key: 'lesson', content: 'corrected', updatedAt: T(3_000) }]);
+    await seedDb(target, [{ key: 'lesson', content: 'stale', updatedAt: T(1_000) }]);
+
+    const result = reconcileDurableStores(source, target);
+    expect(result.updated).toBe(1);
+    expect(activeRows(target)).toEqual([{ key: 'lesson', content: 'corrected' }]);
+  });
+
+  it('keeps the target when it is newer — the same pair, reversed', async () => {
+    const root = await makeRoot();
+    const source = join(root, 'source.db');
+    const target = join(root, 'target.db');
+    await seedDb(source, [{ key: 'lesson', content: 'stale', updatedAt: T(1_000) }]);
+    await seedDb(target, [{ key: 'lesson', content: 'corrected', updatedAt: T(3_000) }]);
+
+    const result = reconcileDurableStores(source, target);
+    expect(result.updated).toBe(0);
+    expect(result.keptTarget).toBe(1);
+    expect(activeRows(target)).toEqual([{ key: 'lesson', content: 'corrected' }]);
+  });
+
+  it('carries a purge into the target', async () => {
+    const root = await makeRoot();
+    const source = join(root, 'source.db');
+    const target = join(root, 'target.db');
+    await seedDb(source, [{ key: 'purged', content: 'v1', updatedAt: T(3_000), status: 'archived' }]);
+    await seedDb(target, [{ key: 'purged', content: 'v1', updatedAt: T(1_000) }]);
+
+    const result = reconcileDurableStores(source, target);
+    expect(result.archived).toBe(1);
+    expect(activeRows(target)).toEqual([]);
+  });
+
+  it('does NOT purge an entry the target re-created after the deletion', async () => {
+    const root = await makeRoot();
+    const source = join(root, 'source.db');
+    const target = join(root, 'target.db');
+    await seedDb(source, [{ key: 'lesson', content: 'v1', updatedAt: T(1_000), status: 'archived' }]);
+    await seedDb(target, [{ key: 'lesson', content: 'learned again', updatedAt: T(3_000) }]);
+
+    const result = reconcileDurableStores(source, target);
+    expect(result.archived).toBe(0);
+    expect(activeRows(target)).toEqual([{ key: 'lesson', content: 'learned again' }]);
+  });
+
+  it('never touches a row only the target has', async () => {
+    const root = await makeRoot();
+    const source = join(root, 'source.db');
+    const target = join(root, 'target.db');
+    await seedDb(source, [{ key: 'shared', content: 'v1', updatedAt: T(1_000) }]);
+    await seedDb(target, [{ key: 'target-only', content: 'authored here', updatedAt: T(1_000) }]);
+
+    reconcileDurableStores(source, target);
+    expect(activeRows(target)).toEqual([
+      { key: 'shared', content: 'v1' },
+      { key: 'target-only', content: 'authored here' },
+    ]);
+  });
+
+  it('is a no-op against a missing source rather than a throw', async () => {
+    const root = await makeRoot();
+    const target = join(root, 'target.db');
+    await seedDb(target, [{ key: 'mine', updatedAt: T(1_000) }]);
+
+    const result = reconcileDurableStores(join(root, 'not-there.db'), target);
+    expect(changedRows(result)).toBe(0);
+    expect(activeRows(target)).toHaveLength(1);
+  });
+
+  it('refuses to reconcile a store with itself', async () => {
+    const root = await makeRoot();
+    const db = join(root, 'one.db');
+    await seedDb(db, [{ key: 'a', updatedAt: T(1_000) }]);
+
+    const result = reconcileDurableStores(db, db);
+    expect(changedRows(result)).toBe(0);
+    expect(result.sources[0].reason).toBe('self-reference');
+  });
+
+  it('ignores non-durable namespaces in both directions', async () => {
+    const root = await makeRoot();
+    const source = join(root, 'source.db');
+    const target = join(root, 'target.db');
+    await seedDb(source, [{ key: 'ephemeral', namespace: 'code-map', updatedAt: T(3_000) }]);
+    await seedDb(target, [{ key: 'x', updatedAt: T(1_000) }]);
+
+    const result = reconcileDurableStores(source, target);
+    expect(result.copied).toBe(0);
+    expect(allKeys(target)).toEqual(['x']);
+  });
+});
+
+describe('a purge survives a full worktree session-start sync', () => {
+  // The #1463 symptom in miniature: before this, flush+seed was a union, so an
+  // entry purged in this worktree was resurrected by the seed within seconds.
+  it('does not come back from the shared store', async () => {
+    const root = await makeRoot();
+    const shared = join(root, 'shared.db');
+    const local = memoryDbPath(root);
+
+    await seedDb(local, [
+      { key: 'kept', content: 'v1', updatedAt: T(1_000) },
+      { key: 'purged', content: 'v1', updatedAt: T(1_000) },
+    ]);
+    await flushDurableToShared(root, shared);
+    expect(activeRows(shared).map((r) => r.key)).toEqual(['kept', 'purged']);
+
+    // Purge locally, the way `flo memory delete` now does it.
+    const db = new DatabaseSync(local);
+    db.prepare(`UPDATE memory_entries SET status = 'archived', updated_at = ? WHERE key = 'purged'`).run(T(5_000));
+    db.close();
+
+    // Session-start order: flush first, then seed.
+    await flushDurableToShared(root, shared);
+    await seedDurableFromShared(root, shared);
+
+    expect(activeRows(local).map((r) => r.key)).toEqual(['kept']);
+    expect(activeRows(shared).map((r) => r.key)).toEqual(['kept']);
+  });
+});
+
+describe('pruneExpiredArchives', () => {
+  it('drops archives past the retention window and keeps live rows and fresh archives', async () => {
+    const root = await makeRoot();
+    const dbPath = join(root, 'store.db');
+    const now = Date.now();
+    await seedDb(dbPath, [
+      { key: 'live-and-ancient', content: 'v1', updatedAt: now - TOMBSTONE_TTL_MS - 10_000 },
+      { key: 'archived-ancient', content: 'v1', updatedAt: now - TOMBSTONE_TTL_MS - 10_000, status: 'archived' },
+      { key: 'archived-fresh', content: 'v1', updatedAt: now - 1_000, status: 'archived' },
+    ]);
+
+    const db = openDaemonDatabase(dbPath);
+    let removed = 0;
+    try {
+      removed = pruneExpiredArchives(db, now, TOMBSTONE_TTL_MS);
+    } finally {
+      db.close();
+    }
+
+    expect(removed).toBe(1);
+    expect(allKeys(dbPath)).toEqual(['archived-fresh', 'live-and-ancient']);
+  });
+});
+
+/** Config with an explicit durable_path, built off the real defaults. */
+function configWithDurable(root: string, durablePath?: string): MofloConfig {
+  const cfg = loadMofloConfig(root);
+  cfg.memory.durable_path = durablePath;
+  return cfg;
+}
+
+describe('archive retention never resurrects a purge', () => {
+  // Regression: the prune used to run inside each direction. A worktree dormant
+  // past the retention window flushed its stale live row first, the shared
+  // tombstone correctly won — and was then pruned as expired in that same
+  // flush, before the seed could apply the deletion here. The next session
+  // re-inserted the purged entry into every workspace.
+  it('applies the deletion before dropping the evidence for it', async () => {
+    const root = await makeRoot();
+    const shared = join(root, 'shared.db');
+    const local = memoryDbPath(root);
+    const now = Date.now();
+
+    // This worktree has been dormant far longer than the retention window.
+    await seedDb(local, [{ key: 'purged', content: 'v1', updatedAt: now - TOMBSTONE_TTL_MS - 20 * 86_400_000 }]);
+    // The shared store's tombstone is itself already expired.
+    await seedDb(shared, [
+      { key: 'purged', content: 'v1', updatedAt: now - TOMBSTONE_TTL_MS - 86_400_000, status: 'archived' },
+    ]);
+
+    await syncDurableAtSessionStart({ projectRoot: root, config: configWithDurable(root, shared) });
+    expect(activeRows(local)).toEqual([]);
+
+    // The session after — this is where the resurrection used to happen.
+    await syncDurableAtSessionStart({ projectRoot: root, config: configWithDurable(root, shared) });
+    expect(activeRows(local)).toEqual([]);
+    expect(activeRows(shared)).toEqual([]);
+  });
+
+  it('prunes the local store even when sharing is switched off', async () => {
+    const root = await makeRoot();
+    const local = memoryDbPath(root);
+    const now = Date.now();
+    await seedDb(local, [
+      { key: 'live', content: 'v1', updatedAt: now - 1_000 },
+      { key: 'old-archive', content: 'v1', updatedAt: now - TOMBSTONE_TTL_MS - 1_000, status: 'archived' },
+    ]);
+
+    const report = await syncDurableAtSessionStart({ projectRoot: root, config: configWithDurable(root, undefined) });
+    expect(report.durablePath).toBeNull();
+    expect(report.prunedArchives).toBe(1);
+    expect(allKeys(local)).toEqual(['live']);
+  });
+});
+
+describe('writeThroughDurable flushes only the key that changed', () => {
+  it('propagates the written key and leaves the rest to session-start', async () => {
+    const root = await makeRoot();
+    const shared = join(root, 'shared.db');
+    await seedDb(memoryDbPath(root), [
+      { key: 'just-written', content: 'v1', updatedAt: T(2_000) },
+      { key: 'written-earlier', content: 'v1', updatedAt: T(1_000) },
+    ]);
+
+    await writeThroughDurable('learnings', {
+      projectRoot: root,
+      config: configWithDurable(root, shared),
+      key: 'just-written',
+    });
+
+    expect(activeRows(shared).map((r) => r.key)).toEqual(['just-written']);
+
+    // The full reconciliation at session-start catches everything else up.
+    await flushDurableToShared(root, shared);
+    expect(activeRows(shared).map((r) => r.key)).toEqual(['just-written', 'written-earlier']);
+  });
+});

--- a/src/cli/__tests__/services/team-artifact-reconcile.test.ts
+++ b/src/cli/__tests__/services/team-artifact-reconcile.test.ts
@@ -1,0 +1,560 @@
+/**
+ * Tests for reconciling team-artifact sync (#1463) — the half the original
+ * additive implementation could not do: corrections, deletions, and the
+ * refusal to touch anything the other side never shared.
+ *
+ * Every conflict is driven in BOTH orderings. The pure matrix lives in
+ * `durable-reconcile.test.ts`; this file proves the two real stores (a JSONL
+ * file and a SQLite DB) are wired to it correctly in both directions.
+ *
+ * Real node:sqlite DBs + real files in tmp dirs. All paths via path.join /
+ * os.tmpdir for cross-platform safety (Rule #1).
+ */
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import {
+  exportTeamArtifact,
+  importTeamArtifact,
+  TOMBSTONE_NAMESPACE,
+  type TeamArtifactEntry,
+  type TeamTombstone,
+} from '../../services/team-artifact-sync.js';
+import { isDurableNamespace } from '../../services/cherry-pick-learnings.js';
+import { TOMBSTONE_TTL_MS } from '../../services/durable-reconcile.js';
+import { memoryDbPath } from '../../services/moflo-paths.js';
+import { MEMORY_SCHEMA_V3 } from '../../memory/memory-initializer.js';
+import { makeMemoryDb, type FixtureDb } from '../_helpers/legacy-memory-db.js';
+
+const tmpDirs: string[] = [];
+afterEach(async () => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop()!;
+    try {
+      await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    } catch {
+      /* Windows file-lock — non-fatal for tests */
+    }
+  }
+});
+
+const savedEnv = process.env.MOFLO_TEAM_ARTIFACT;
+beforeEach(() => {
+  delete process.env.MOFLO_TEAM_ARTIFACT;
+});
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.MOFLO_TEAM_ARTIFACT;
+  else process.env.MOFLO_TEAM_ARTIFACT = savedEnv;
+});
+
+const NOW_ISO = '2026-06-28T00:00:00.000Z';
+const NOW_MS = Date.parse(NOW_ISO);
+
+/**
+ * Tests care about ORDER, not absolute time, so they pass small offsets. `T`
+ * anchors them just before `NOW_MS`: a bare `1_000` would be an epoch-1970
+ * timestamp, i.e. older than the tombstone TTL, and every tombstone in the
+ * suite would be pruned before the assertion ran.
+ */
+const T = (offset: number): number => NOW_MS - 1_000_000 + offset;
+
+async function makeRoot(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'moflo-reconcile-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+interface Row {
+  key: string;
+  content?: string;
+  updatedAt?: number;
+  status?: 'active' | 'archived';
+  namespace?: string;
+}
+
+function seedDb(dbPath: string, rows: Row[]): Promise<void> {
+  return makeMemoryDb(dbPath, MEMORY_SCHEMA_V3, (db: FixtureDb) => {
+    for (const r of rows) {
+      const ns = r.namespace ?? 'learnings';
+      const ts = r.updatedAt ?? T(1_000);
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, created_at, updated_at, status) ` +
+          `VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [`id-${ns}-${r.key}`, r.key, ns, r.content ?? `content-${r.key}`, ts, ts, r.status ?? 'active'],
+      );
+    }
+  });
+}
+
+/** Read the rows a normal moflo read would see — every read path filters active. */
+function activeRows(dbPath: string): Array<{ key: string; content: string }> {
+  const db = new DatabaseSync(dbPath);
+  try {
+    return db
+      .prepare(`SELECT key, content FROM memory_entries WHERE status = 'active' ORDER BY key`)
+      .all() as Array<{ key: string; content: string }>;
+  } finally {
+    db.close();
+  }
+}
+
+function rowStatus(dbPath: string, key: string): string | undefined {
+  const db = new DatabaseSync(dbPath);
+  try {
+    const row = db.prepare(`SELECT status FROM memory_entries WHERE key = ?`).get(key) as
+      | { status: string }
+      | undefined;
+    return row?.status;
+  } finally {
+    db.close();
+  }
+}
+
+function entry(key: string, content: string, updatedAt?: number): TeamArtifactEntry {
+  return {
+    namespace: 'learnings',
+    key,
+    content,
+    type: 'semantic',
+    created_at: 1_000,
+    ...(updatedAt === undefined ? {} : { updated_at: updatedAt }),
+    provenance: { author: 'Teammate A', source: 'host-a', sharedAt: '2026-01-01T00:00:00.000Z' },
+  };
+}
+
+function tombstone(key: string, at: number): TeamTombstone {
+  return {
+    namespace: TOMBSTONE_NAMESPACE,
+    key,
+    deleted: { namespace: 'learnings', key, at },
+    provenance: { author: 'Teammate A', source: 'host-a', sharedAt: '2026-01-01T00:00:00.000Z' },
+  };
+}
+
+function writeArtifact(path: string, lines: Array<TeamArtifactEntry | TeamTombstone>): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, lines.map((l) => JSON.stringify(l)).join('\n') + '\n', 'utf-8');
+}
+
+function readArtifact(path: string): Array<TeamArtifactEntry | TeamTombstone> {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf-8')
+    .split(/\r?\n/)
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l));
+}
+
+const liveKeys = (path: string): string[] =>
+  readArtifact(path)
+    .filter((l) => l.namespace !== TOMBSTONE_NAMESPACE)
+    .map((l) => l.key)
+    .sort();
+
+const tombstoneKeys = (path: string): string[] =>
+  readArtifact(path)
+    .filter((l): l is TeamTombstone => l.namespace === TOMBSTONE_NAMESPACE)
+    .map((l) => l.deleted.key)
+    .sort();
+
+describe('exportTeamArtifact — deletions become tombstones (#1463)', () => {
+  it('replaces a locally archived entry with a tombstone', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [entry('purged', 'was shared', T(1_000)), entry('kept', 'still here', T(1_000))]);
+    await seedDb(memoryDbPath(root), [
+      { key: 'purged', content: 'was shared', updatedAt: T(2_000), status: 'archived' },
+      { key: 'kept', content: 'still here', updatedAt: T(1_000) },
+    ]);
+
+    const report = exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW_ISO });
+
+    expect(report.deleted).toBe(1);
+    expect(liveKeys(artifact)).toEqual(['kept']);
+    expect(tombstoneKeys(artifact)).toEqual(['purged']);
+    expect(report.total).toBe(1);
+    expect(report.tombstones).toBe(1);
+  });
+
+  it('does not tombstone an entry the artifact never held', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [entry('shared', 'v1', T(1_000))]);
+    await seedDb(memoryDbPath(root), [
+      { key: 'shared', content: 'v1', updatedAt: T(1_000) },
+      { key: 'never-shared', content: 'local only', updatedAt: T(2_000), status: 'archived' },
+    ]);
+
+    const report = exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW_ISO });
+    expect(report.deleted).toBe(0);
+    expect(tombstoneKeys(artifact)).toEqual([]);
+  });
+
+  it('restores an entry re-created locally after a purge, over its tombstone', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [tombstone('lesson', T(1_000))]);
+    await seedDb(memoryDbPath(root), [{ key: 'lesson', content: 'learned it again', updatedAt: T(2_000) }]);
+
+    const report = exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW_ISO });
+    expect(report.resurrected).toBe(1);
+    expect(liveKeys(artifact)).toEqual(['lesson']);
+    expect(tombstoneKeys(artifact)).toEqual([]);
+  });
+
+  it('lets the purge stand when the tombstone is newer — the same pair, reversed', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [tombstone('lesson', T(3_000))]);
+    await seedDb(memoryDbPath(root), [{ key: 'lesson', content: 'stale local copy', updatedAt: T(2_000) }]);
+
+    const report = exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW_ISO });
+    expect(report.resurrected).toBe(0);
+    expect(report.keptRemote).toBe(1);
+    expect(tombstoneKeys(artifact)).toEqual(['lesson']);
+  });
+});
+
+describe('exportTeamArtifact — housekeeping', () => {
+  it('prunes tombstones past the TTL and keeps the ones inside it', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [
+      tombstone('ancient', NOW_MS - TOMBSTONE_TTL_MS - 1),
+      tombstone('recent', NOW_MS - 1_000),
+    ]);
+    await seedDb(memoryDbPath(root), [{ key: 'unrelated', content: 'v1', updatedAt: T(1_000) }]);
+
+    const report = exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW_ISO });
+    expect(report.prunedTombstones).toBe(1);
+    expect(tombstoneKeys(artifact)).toEqual(['recent']);
+  });
+
+  it('leaves a git-tracked artifact untouched when nothing changed', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    await seedDb(memoryDbPath(root), [{ key: 'a', content: 'v1', updatedAt: T(1_000) }]);
+
+    const first = exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW_ISO });
+    expect(first.wrote).toBe(true);
+    const stamp = statSync(artifact).mtimeMs;
+
+    const second = exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW_ISO });
+    expect(second.wrote).toBe(false);
+    expect(second.added).toBe(0);
+    expect(second.unchanged).toBe(1);
+    expect(statSync(artifact).mtimeMs).toBe(stamp);
+  });
+});
+
+describe('importTeamArtifact — corrections and deletions land (#1463)', () => {
+  it('updates a local row from a newer artifact entry', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [entry('lesson', 'corrected by a teammate', T(3_000))]);
+    await seedDb(memoryDbPath(root), [{ key: 'lesson', content: 'stale', updatedAt: T(1_000) }]);
+
+    const report = importTeamArtifact({ projectRoot: root, artifactPath: artifact });
+    expect(report.updated).toBe(1);
+    expect(activeRows(memoryDbPath(root))).toEqual([{ key: 'lesson', content: 'corrected by a teammate' }]);
+  });
+
+  it('keeps the local row when it is newer — the same pair, reversed', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [entry('lesson', 'stale artifact text', T(1_000))]);
+    await seedDb(memoryDbPath(root), [{ key: 'lesson', content: 'corrected locally', updatedAt: T(3_000) }]);
+
+    const report = importTeamArtifact({ projectRoot: root, artifactPath: artifact });
+    expect(report.updated).toBe(0);
+    expect(report.keptLocal).toBe(1);
+    expect(activeRows(memoryDbPath(root))).toEqual([{ key: 'lesson', content: 'corrected locally' }]);
+  });
+
+  it('archives a local row on a newer tombstone, so it leaves every read path', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [tombstone('purged', T(3_000)), entry('kept', 'v1', T(1_000))]);
+    await seedDb(memoryDbPath(root), [
+      { key: 'purged', content: 'doomed', updatedAt: T(1_000) },
+      { key: 'kept', content: 'v1', updatedAt: T(1_000) },
+    ]);
+
+    const report = importTeamArtifact({ projectRoot: root, artifactPath: artifact });
+    expect(report.deleted).toBe(1);
+    expect(activeRows(memoryDbPath(root))).toEqual([{ key: 'kept', content: 'v1' }]);
+    // Archived, not dropped — the row is the evidence that lets the deletion
+    // reach the next store, and the timestamp a later re-creation must beat.
+    expect(rowStatus(memoryDbPath(root), 'purged')).toBe('archived');
+  });
+
+  it('does NOT delete an entry re-created after the purge — the same pair, reversed', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [tombstone('lesson', T(1_000))]);
+    await seedDb(memoryDbPath(root), [{ key: 'lesson', content: 'learned it again', updatedAt: T(3_000) }]);
+
+    const report = importTeamArtifact({ projectRoot: root, artifactPath: artifact });
+    expect(report.deleted).toBe(0);
+    expect(activeRows(memoryDbPath(root))).toEqual([{ key: 'lesson', content: 'learned it again' }]);
+  });
+
+  it('restores a locally archived row when the artifact has a newer entry', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [entry('lesson', 'a teammate re-learned it', T(3_000))]);
+    await seedDb(memoryDbPath(root), [
+      { key: 'lesson', content: 'purged here', updatedAt: T(1_000), status: 'archived' },
+    ]);
+
+    const report = importTeamArtifact({ projectRoot: root, artifactPath: artifact });
+    expect(report.resurrected).toBe(1);
+    expect(activeRows(memoryDbPath(root))).toEqual([{ key: 'lesson', content: 'a teammate re-learned it' }]);
+  });
+});
+
+describe('importTeamArtifact — local-only work is never touched', () => {
+  // The regression that matters most (#1463 acceptance criteria): a purge must
+  // never reach an entry authored here and not yet exported.
+  it('leaves a local-only row alone, with tombstones present in the artifact', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [tombstone('theirs', T(9_000)), entry('shared', 'v1', T(1_000))]);
+    await seedDb(memoryDbPath(root), [
+      { key: 'shared', content: 'v1', updatedAt: T(1_000) },
+      { key: 'mine', content: 'never exported', updatedAt: T(1_000) },
+    ]);
+
+    importTeamArtifact({ projectRoot: root, artifactPath: artifact });
+    expect(activeRows(memoryDbPath(root)).map((r) => r.key)).toEqual(['mine', 'shared']);
+  });
+
+  it('leaves a local-only row alone when the artifact holds no tombstones at all', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [entry('shared', 'v1', T(1_000))]);
+    await seedDb(memoryDbPath(root), [{ key: 'mine', content: 'never exported', updatedAt: T(1_000) }]);
+
+    importTeamArtifact({ projectRoot: root, artifactPath: artifact });
+    expect(activeRows(memoryDbPath(root)).map((r) => r.key)).toEqual(['mine', 'shared']);
+  });
+});
+
+describe('artifact lines with no updated_at (written before #1463)', () => {
+  // Asymmetric on purpose: whichever side has real evidence wins. On import the
+  // artifact line has none, so it must never clobber a local row; on export the
+  // local row does, which is what pushes a correction into a legacy artifact.
+  it('still seeds a store that lacks the key', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [entry('legacy', 'from an old artifact')]);
+    await seedDb(memoryDbPath(root), []);
+
+    const report = importTeamArtifact({ projectRoot: root, artifactPath: artifact });
+    expect(report.imported).toBe(1);
+    expect(activeRows(memoryDbPath(root))).toEqual([{ key: 'legacy', content: 'from an old artifact' }]);
+  });
+
+  it('never overwrites an existing local row', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [entry('legacy', 'stale artifact text')]);
+    await seedDb(memoryDbPath(root), [{ key: 'legacy', content: 'corrected locally', updatedAt: T(1) }]);
+
+    const report = importTeamArtifact({ projectRoot: root, artifactPath: artifact });
+    expect(report.updated).toBe(0);
+    expect(activeRows(memoryDbPath(root))).toEqual([{ key: 'legacy', content: 'corrected locally' }]);
+  });
+});
+
+describe('timestamps survive a round trip', () => {
+  // Import used to bind created_at into BOTH columns, flattening the one value
+  // last-writer-wins depends on. A store that loses updated_at on every import
+  // can never win a later comparison it should.
+  it('preserves created_at and updated_at through export and import', async () => {
+    const rootA = await makeRoot();
+    const rootB = await makeRoot();
+    const artifact = join(rootA, 'team.jsonl');
+
+    const created = T(1_000);
+    const edited = T(7_000);
+    await makeMemoryDb(memoryDbPath(rootA), MEMORY_SCHEMA_V3, (db: FixtureDb) => {
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, created_at, updated_at, status) ` +
+          `VALUES (?, ?, ?, ?, ?, ?, 'active')`,
+        ['id-1', 'lesson', 'learnings', 'v2', created, edited],
+      );
+    });
+
+    exportTeamArtifact({ projectRoot: rootA, artifactPath: artifact, sharedAt: NOW_ISO });
+    const line = readArtifact(artifact)[0] as TeamArtifactEntry;
+    expect(line.created_at).toBe(created);
+    expect(line.updated_at).toBe(edited);
+
+    await seedDb(memoryDbPath(rootB), []);
+    importTeamArtifact({ projectRoot: rootB, artifactPath: artifact });
+
+    const db = new DatabaseSync(memoryDbPath(rootB));
+    try {
+      const row = db
+        .prepare(`SELECT created_at, updated_at FROM memory_entries WHERE key = 'lesson'`)
+        .get() as { created_at: number; updated_at: number };
+      expect(row.created_at).toBe(created);
+      expect(row.updated_at).toBe(edited);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe('legacy lines get a timestamp backfilled on export', () => {
+  // A pre-#1463 line stamps 0 forever otherwise: content-equal lines are never
+  // rewritten, so the ambiguity would never retire and every future comparison
+  // against a real timestamp would be decided by the missing field.
+  it('backfills updated_at without disturbing the original provenance', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [entry('lesson', 'same text')]); // no updated_at
+    await seedDb(memoryDbPath(root), [{ key: 'lesson', content: 'same text', updatedAt: T(4_000) }]);
+
+    const report = exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW_ISO });
+    expect(report.backfilled).toBe(1);
+    expect(report.updated).toBe(0); // content matched — this is not a rewrite
+
+    const line = readArtifact(artifact)[0] as TeamArtifactEntry;
+    expect(line.updated_at).toBe(T(4_000));
+    expect(line.content).toBe('same text');
+    expect(line.provenance.author).toBe('Teammate A'); // untouched
+  });
+
+  it('leaves a line this machine does not hold without a timestamp', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [entry('theirs', 'never imported here')]);
+    await seedDb(memoryDbPath(root), []);
+
+    const report = exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW_ISO });
+    expect(report.backfilled).toBe(0);
+    expect((readArtifact(artifact)[0] as TeamArtifactEntry).updated_at).toBeUndefined();
+  });
+
+  it('is a one-time migration — the next export is a no-op', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [entry('lesson', 'same text')]);
+    await seedDb(memoryDbPath(root), [{ key: 'lesson', content: 'same text', updatedAt: T(4_000) }]);
+
+    exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW_ISO });
+    const second = exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW_ISO });
+    expect(second.backfilled).toBe(0);
+    expect(second.wrote).toBe(false);
+  });
+});
+
+describe('backward compatibility with pre-#1463 clients', () => {
+  // A rename of the marker namespace would silently break deletion handling for
+  // every client that has not upgraded. These two properties are the whole
+  // compatibility mechanism, so they are pinned literally.
+  it('marks tombstones with a namespace old clients treat as non-durable', () => {
+    expect(TOMBSTONE_NAMESPACE).toBe('__moflo_tombstone__');
+    expect(isDurableNamespace(TOMBSTONE_NAMESPACE)).toBe(false);
+  });
+
+  it('emits tombstone lines a 4.12.11 parser accepts and then skips', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [entry('purged', 'was shared', T(1_000))]);
+    await seedDb(memoryDbPath(root), [
+      { key: 'purged', content: 'was shared', updatedAt: T(2_000), status: 'archived' },
+    ]);
+    exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW_ISO });
+
+    // 4.12.11's readArtifact: JSON.parse, then require string namespace + key.
+    // 4.12.11's import: isDurableNamespace(namespace) === false -> skippedNonDurable.
+    for (const raw of readFileSync(artifact, 'utf-8').split(/\r?\n/).filter((l) => l.trim())) {
+      const parsed = JSON.parse(raw);
+      expect(typeof parsed.namespace).toBe('string');
+      expect(typeof parsed.key).toBe('string');
+    }
+    const lines = readArtifact(artifact);
+    expect(lines).toHaveLength(1);
+    expect(isDurableNamespace(lines[0].namespace)).toBe(false);
+  });
+
+  it('lets the tombstone stand when an old client re-appends the live line beside it', async () => {
+    // An old client keys tombstones under the marker namespace, so the retired
+    // key looks absent to it and its export re-adds a live line — with no
+    // updated_at, because it never wrote one. The tombstone must still win.
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    writeArtifact(artifact, [tombstone('purged', T(5_000)), entry('purged', 're-added by an old client')]);
+    await seedDb(memoryDbPath(root), []);
+
+    const report = importTeamArtifact({ projectRoot: root, artifactPath: artifact });
+    expect(report.imported).toBe(0);
+    expect(activeRows(memoryDbPath(root))).toEqual([]);
+  });
+});
+
+describe('round trip between two machines', () => {
+  it('carries an edit and a purge from A to B', async () => {
+    const rootA = await makeRoot();
+    const rootB = await makeRoot();
+    const artifact = join(rootA, 'shared', 'team.jsonl');
+
+    await seedDb(memoryDbPath(rootA), [
+      { key: 'edited', content: 'v1', updatedAt: T(1_000) },
+      { key: 'doomed', content: 'v1', updatedAt: T(1_000) },
+    ]);
+    await seedDb(memoryDbPath(rootB), [
+      { key: 'edited', content: 'v1', updatedAt: T(1_000) },
+      { key: 'doomed', content: 'v1', updatedAt: T(1_000) },
+      { key: 'b-only', content: 'authored on B', updatedAt: T(1_000) },
+    ]);
+
+    // A and B share a baseline first — that is the state a correction and a
+    // purge have to travel over.
+    exportTeamArtifact({ projectRoot: rootA, artifactPath: artifact, sharedAt: NOW_ISO });
+    importTeamArtifact({ projectRoot: rootB, artifactPath: artifact });
+
+    // A corrects one entry and purges another, then re-exports.
+    const dbA = new DatabaseSync(memoryDbPath(rootA));
+    dbA.prepare(`UPDATE memory_entries SET content = ?, updated_at = ? WHERE key = 'edited'`).run('v2 corrected', T(5_000));
+    dbA.prepare(`UPDATE memory_entries SET status = 'archived', updated_at = ? WHERE key = 'doomed'`).run(T(5_000));
+    dbA.close();
+    const exported = exportTeamArtifact({ projectRoot: rootA, artifactPath: artifact, sharedAt: NOW_ISO });
+    expect(exported.updated).toBe(1);
+    expect(exported.deleted).toBe(1);
+
+    // B imports.
+    const imported = importTeamArtifact({ projectRoot: rootB, artifactPath: artifact });
+    expect(imported.updated).toBe(1);
+    expect(imported.deleted).toBe(1);
+    expect(activeRows(memoryDbPath(rootB))).toEqual([
+      { key: 'b-only', content: 'authored on B' },
+      { key: 'edited', content: 'v2 corrected' },
+    ]);
+  });
+
+  it('converges: a second import changes nothing', async () => {
+    const rootA = await makeRoot();
+    const rootB = await makeRoot();
+    const artifact = join(rootA, 'shared', 'team.jsonl');
+    await seedDb(memoryDbPath(rootA), [
+      { key: 'a', content: 'v1', updatedAt: T(1_000) },
+      { key: 'gone', content: 'v1', updatedAt: T(2_000), status: 'archived' },
+    ]);
+    await seedDb(memoryDbPath(rootB), [{ key: 'gone', content: 'v1', updatedAt: T(1_000) }]);
+    exportTeamArtifact({ projectRoot: rootA, artifactPath: artifact, sharedAt: NOW_ISO });
+
+    importTeamArtifact({ projectRoot: rootB, artifactPath: artifact });
+    const second = importTeamArtifact({ projectRoot: rootB, artifactPath: artifact });
+    expect(second.imported).toBe(0);
+    expect(second.updated).toBe(0);
+    expect(second.deleted).toBe(0);
+    expect(second.resurrected).toBe(0);
+  });
+});

--- a/src/cli/__tests__/services/team-artifact-reconcile.test.ts
+++ b/src/cli/__tests__/services/team-artifact-reconcile.test.ts
@@ -20,6 +20,7 @@ import { DatabaseSync } from 'node:sqlite';
 import {
   exportTeamArtifact,
   importTeamArtifact,
+  ensureSharedArtifactEol,
   TOMBSTONE_NAMESPACE,
   type TeamArtifactEntry,
   type TeamTombstone,
@@ -556,5 +557,64 @@ describe('round trip between two machines', () => {
     expect(second.updated).toBe(0);
     expect(second.deleted).toBe(0);
     expect(second.resurrected).toBe(0);
+  });
+});
+
+describe('ensureSharedArtifactEol — the artifact is git-tracked in someone else\'s repo', () => {
+  // Rule #1: moflo always writes the artifact with \n. On a Windows checkout
+  // with core.autocrlf, git hands back CRLF — so every export rewrites the
+  // whole file, and a merge of two divergent artifacts conflicts on every
+  // line, which is exactly the merge-friendliness JSONL was chosen for.
+  const readAttrs = (root: string): string => readFileSync(join(root, '.gitattributes'), 'utf-8');
+
+  it('creates a .gitattributes pinning the artifact to LF', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, '.moflo', 'shared', 'learnings.jsonl');
+
+    expect(ensureSharedArtifactEol(root, artifact)).toBe('created');
+    expect(readAttrs(root)).toContain('/.moflo/shared/learnings.jsonl text eol=lf');
+  });
+
+  it('appends to an existing .gitattributes without disturbing it', async () => {
+    const root = await makeRoot();
+    writeFileSync(join(root, '.gitattributes'), '*.png binary\n', 'utf-8');
+    const artifact = join(root, '.moflo', 'shared', 'learnings.jsonl');
+
+    expect(ensureSharedArtifactEol(root, artifact)).toBe('updated');
+    const attrs = readAttrs(root);
+    expect(attrs).toContain('*.png binary');
+    expect(attrs).toContain('/.moflo/shared/learnings.jsonl text eol=lf');
+  });
+
+  it('is idempotent', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, '.moflo', 'shared', 'learnings.jsonl');
+    ensureSharedArtifactEol(root, artifact);
+    const first = readAttrs(root);
+
+    expect(ensureSharedArtifactEol(root, artifact)).toBe('unchanged');
+    expect(readAttrs(root)).toBe(first);
+  });
+
+  it("leaves a consumer's own rule for the same path exactly as written", async () => {
+    const root = await makeRoot();
+    writeFileSync(join(root, '.gitattributes'), '/.moflo/shared/learnings.jsonl text eol=crlf\n', 'utf-8');
+    const artifact = join(root, '.moflo', 'shared', 'learnings.jsonl');
+
+    expect(ensureSharedArtifactEol(root, artifact)).toBe('unchanged');
+    expect(readAttrs(root)).toContain('eol=crlf');
+  });
+
+  it('writes no rule for an artifact outside the project', async () => {
+    const root = await makeRoot();
+    const elsewhere = await makeRoot();
+    expect(ensureSharedArtifactEol(root, join(elsewhere, 'learnings.jsonl'))).toBe('unchanged');
+    expect(existsSync(join(root, '.gitattributes'))).toBe(false);
+  });
+
+  it('writes the pattern with forward slashes on every platform', async () => {
+    const root = await makeRoot();
+    ensureSharedArtifactEol(root, join(root, '.moflo', 'shared', 'learnings.jsonl'));
+    expect(readAttrs(root)).not.toContain('\\\\');
   });
 });

--- a/src/cli/__tests__/services/team-artifact-reconcile.test.ts
+++ b/src/cli/__tests__/services/team-artifact-reconcile.test.ts
@@ -612,6 +612,47 @@ describe('ensureSharedArtifactEol — the artifact is git-tracked in someone els
     expect(existsSync(join(root, '.gitattributes'))).toBe(false);
   });
 
+  it('preserves a CRLF file\'s line endings instead of rewriting the whole file', async () => {
+    // The narrow-edit promise is only kept if the writer hands back the EOL
+    // style it was given — otherwise a Windows consumer gets a full-file diff
+    // on every export, which is what this rule exists to prevent.
+    const root = await makeRoot();
+    writeFileSync(join(root, '.gitattributes'), '*.png binary\r\n*.jpg binary\r\n', 'utf-8');
+    ensureSharedArtifactEol(root, join(root, '.moflo', 'shared', 'learnings.jsonl'));
+
+    const attrs = readAttrs(root);
+    expect(attrs).toContain('*.png binary\r\n');
+    expect(attrs.split('\r\n').length).toBeGreaterThan(3);
+    // No bare LF introduced anywhere.
+    expect(/[^\r]\n/.test(attrs)).toBe(false);
+  });
+
+  it('escapes a path with spaces or glob metacharacters', async () => {
+    const root = await makeRoot();
+    // `--to` is caller-supplied: unescaped, `team notes.jsonl` parses as the
+    // pattern `team`, and a `*` would match files the user never named.
+    ensureSharedArtifactEol(root, join(root, '.moflo', 'team notes[1].jsonl'));
+
+    const attrs = readAttrs(root);
+    // Quoted because of the space, and the brackets escaped so the pattern
+    // matches the literal filename rather than a one-character class. The
+    // backslashes are doubled: git un-quotes the C-string first, leaving the
+    // single backslashes the glob layer needs.
+    expect(attrs).toMatch(/^".*" text eol=lf$/m);
+    expect(attrs).toContain('team notes');
+    expect(attrs).toContain('\\\\[1\\\\]');
+  });
+
+  it('recognises its own escaped rule on a second run', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, '.moflo', 'team notes[1].jsonl');
+    ensureSharedArtifactEol(root, artifact);
+    const first = readAttrs(root);
+
+    expect(ensureSharedArtifactEol(root, artifact)).toBe('unchanged');
+    expect(readAttrs(root)).toBe(first);
+  });
+
   it('writes the pattern with forward slashes on every platform', async () => {
     const root = await makeRoot();
     ensureSharedArtifactEol(root, join(root, '.moflo', 'shared', 'learnings.jsonl'));

--- a/src/cli/__tests__/services/team-artifact-sync.test.ts
+++ b/src/cli/__tests__/services/team-artifact-sync.test.ts
@@ -67,14 +67,26 @@ function configWith(root: string, teamArtifact?: string): MofloConfig {
   return cfg;
 }
 
-function makeDbWith(
-  dbPath: string,
-  rows: Array<{ key: string; namespace: string; content?: string; embedding?: number[]; tags?: string[] }>,
-): Promise<void> {
+interface FixtureRow {
+  key: string;
+  namespace: string;
+  content?: string;
+  embedding?: number[];
+  tags?: string[];
+  /** Epoch-ms. Defaults to the schema default (now) when omitted. */
+  createdAt?: number;
+  updatedAt?: number;
+  /** 'archived' makes the row a tombstone source — see durable-store-io. */
+  status?: 'active' | 'archived';
+}
+
+function makeDbWith(dbPath: string, rows: FixtureRow[]): Promise<void> {
   return makeMemoryDb(dbPath, MEMORY_SCHEMA_V3, (db: FixtureDb) => {
     for (const r of rows) {
+      const ts = r.updatedAt ?? r.createdAt ?? Date.now();
       db.run(
-        `INSERT INTO memory_entries (id, key, namespace, content, embedding, tags) VALUES (?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO memory_entries (id, key, namespace, content, embedding, tags, created_at, updated_at, status) ` +
+          `VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           `id-${r.namespace}-${r.key}`,
           r.key,
@@ -82,6 +94,9 @@ function makeDbWith(
           r.content ?? `content-${r.key}`,
           r.embedding ? JSON.stringify(r.embedding) : null,
           r.tags ? JSON.stringify(r.tags) : null,
+          r.createdAt ?? ts,
+          ts,
+          r.status ?? 'active',
         ],
       );
     }
@@ -169,11 +184,12 @@ describe('exportTeamArtifact (#1234)', () => {
     expect(keys).toEqual(['knowledge/mid', 'learnings/alpha', 'learnings/zeta']);
   });
 
-  it('first-write-wins: an existing artifact entry is never overwritten on re-export', async () => {
+  it('last-writer-wins: a locally corrected entry overwrites its stale artifact line (#1463)', async () => {
     const root = await makeRoot();
     const artifact = join(root, 'team.jsonl');
     mkdirSync(dirname(artifact), { recursive: true });
-    // A teammate already shared lesson-1 with their own provenance.
+    // A teammate shared lesson-1 before #1463, so the line carries no
+    // updated_at — the exact shape of the 32 entries measured stale in the wild.
     const original: TeamArtifactEntry = {
       namespace: 'learnings',
       key: 'lesson-1',
@@ -183,18 +199,42 @@ describe('exportTeamArtifact (#1234)', () => {
     };
     writeFileSync(artifact, JSON.stringify(original) + '\n', 'utf-8');
 
-    // Locally we have a different lesson-1 + a brand-new lesson-2.
+    // Locally we corrected lesson-1 and wrote a brand-new lesson-2.
     await makeDbWith(memoryDbPath(root), [
-      { key: 'lesson-1', namespace: 'learnings', content: 'my divergent content' },
+      { key: 'lesson-1', namespace: 'learnings', content: 'corrected content', updatedAt: 5_000 },
       { key: 'lesson-2', namespace: 'learnings' },
     ]);
     const report = exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW });
-    expect(report.added).toBe(1); // only lesson-2
+    expect(report.added).toBe(1); // lesson-2
+    expect(report.updated).toBe(1); // lesson-1 — what the old export could never do
 
     const lines = readArtifactLines(artifact);
     const lesson1 = lines.find((l) => l.key === 'lesson-1')!;
-    expect(lesson1.content).toBe('original teammate content'); // preserved
-    expect(lesson1.provenance.author).toBe('Teammate A'); // preserved
+    expect(lesson1.content).toBe('corrected content');
+    // Provenance now records who wrote the line LAST, so a diff reviewer can
+    // see where the correction came from.
+    expect(lesson1.provenance.author).not.toBe('Teammate A');
+    expect(lesson1.updated_at).toBe(5_000);
+  });
+
+  it('leaves an artifact entry this machine does not have strictly alone', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    const theirs: TeamArtifactEntry = {
+      namespace: 'learnings',
+      key: 'theirs',
+      content: 'a teammate learning we never imported',
+      type: 'semantic',
+      updated_at: 1_000,
+      provenance: { author: 'Teammate A', source: 'host-a', sharedAt: '2020-01-01T00:00:00.000Z' },
+    };
+    writeFileSync(artifact, JSON.stringify(theirs) + '\n', 'utf-8');
+    await makeDbWith(memoryDbPath(root), [{ key: 'mine', namespace: 'learnings' }]);
+
+    exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW });
+    const lines = readArtifactLines(artifact);
+    expect(lines.find((l) => l.key === 'theirs')!.content).toBe('a teammate learning we never imported');
+    expect(lines.map((l) => l.key).sort()).toEqual(['mine', 'theirs']);
   });
 });
 

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -2846,9 +2846,11 @@ const teamExportCommand: Command = {
     const projectRoot = findProjectRoot();
     const artifactPath = await resolveTeamArtifact(projectRoot, ctx.flags.to);
     try {
-      const { exportTeamArtifact, ensureSharedArtifactTracked } = await import('../services/team-artifact-sync.js');
+      const { exportTeamArtifact, ensureSharedArtifactTracked, ensureSharedArtifactEol } =
+        await import('../services/team-artifact-sync.js');
       const report = exportTeamArtifact({ projectRoot, artifactPath, sharedAt: new Date().toISOString() });
       const gitignore = ensureSharedArtifactTracked(projectRoot, artifactPath);
+      const gitattributes = ensureSharedArtifactEol(projectRoot, artifactPath);
 
       const rel = pathModule.relative(projectRoot, artifactPath) || artifactPath;
       output.printSuccess(`Shared ${report.added} new durable entr${report.added === 1 ? 'y' : 'ies'} → ${rel}`);
@@ -2875,6 +2877,9 @@ const teamExportCommand: Command = {
       output.printInfo(`Artifact now holds ${report.total} entr${report.total === 1 ? 'y' : 'ies'}${tombstoneNote}.`);
       if (gitignore !== 'unchanged') {
         output.printInfo(`.gitignore ${gitignore} so the shared artifact is tracked while the rest of .moflo/ stays ignored.`);
+      }
+      if (gitattributes !== 'unchanged') {
+        output.printInfo(`.gitattributes ${gitattributes} to pin the artifact to LF — without it a Windows checkout conflicts on every line when two teammates' artifacts merge.`);
       }
       output.printInfo(`Commit it to share: git add ${rel} && git commit -m "share learnings"`);
       return { success: true, data: report };

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -569,6 +569,15 @@ const deleteCommand: Command = {
       if (result.deleted) {
         output.printSuccess(`Deleted "${key}" from namespace "${namespace}"`);
         output.printInfo(`Remaining entries: ${result.remainingEntries}`);
+        // Durable deletes are retained as an archived row so the deletion can
+        // reach the team artifact and sibling worktrees (#1463). Say so — a
+        // user auditing the DB should not be surprised to find the row.
+        const { isDurableNamespace } = await import('../services/cherry-pick-learnings.js');
+        if (isDurableNamespace(namespace)) {
+          output.printInfo(
+            'Retained as an archived row so the deletion propagates on the next share; invisible to search and purged after 90 days.',
+          );
+        }
       } else {
         output.printWarning(`Key not found: "${key}" in namespace "${namespace}"`);
       }
@@ -2843,7 +2852,27 @@ const teamExportCommand: Command = {
 
       const rel = pathModule.relative(projectRoot, artifactPath) || artifactPath;
       output.printSuccess(`Shared ${report.added} new durable entr${report.added === 1 ? 'y' : 'ies'} → ${rel}`);
-      output.printInfo(`Artifact now holds ${report.total} entr${report.total === 1 ? 'y' : 'ies'}.`);
+      // Report every category, not just the appends (#1463). The old summary
+      // named only `added`, which read as "everything was shared" while 32
+      // corrections and 34 deletions sat unpropagated for weeks.
+      const changes: string[] = [];
+      if (report.updated > 0) changes.push(`${report.updated} corrected`);
+      if (report.deleted > 0) changes.push(`${report.deleted} retired`);
+      if (report.resurrected > 0) changes.push(`${report.resurrected} restored`);
+      if (changes.length > 0) output.printInfo(`Also propagated: ${changes.join(', ')}.`);
+      if (report.keptRemote > 0) {
+        output.printWarning(
+          `${report.keptRemote} local change${report.keptRemote === 1 ? '' : 's'} NOT shared — the artifact's version is newer. Run \`flo memory team-import\` first.`,
+        );
+      }
+      if (report.skippedMalformed > 0) {
+        output.printWarning(`${report.skippedMalformed} malformed line${report.skippedMalformed === 1 ? '' : 's'} skipped.`);
+      }
+      if (!report.wrote) {
+        output.printInfo('Nothing changed — the artifact was left untouched.');
+      }
+      const tombstoneNote = report.tombstones > 0 ? ` (+ ${report.tombstones} tombstone${report.tombstones === 1 ? '' : 's'})` : '';
+      output.printInfo(`Artifact now holds ${report.total} entr${report.total === 1 ? 'y' : 'ies'}${tombstoneNote}.`);
       if (gitignore !== 'unchanged') {
         output.printInfo(`.gitignore ${gitignore} so the shared artifact is tracked while the rest of .moflo/ stays ignored.`);
       }
@@ -2881,8 +2910,13 @@ const teamImportCommand: Command = {
       const { importTeamArtifact } = await import('../services/team-artifact-sync.js');
       const report = importTeamArtifact({ projectRoot, artifactPath });
       output.printSuccess(`Merged ${report.imported} durable entr${report.imported === 1 ? 'y' : 'ies'} from the team artifact`);
-      if (report.considered > report.imported) {
-        output.printInfo(`${report.considered - report.imported} already present (skipped, conflict-free).`);
+      const applied: string[] = [];
+      if (report.updated > 0) applied.push(`${report.updated} corrected`);
+      if (report.deleted > 0) applied.push(`${report.deleted} retired locally`);
+      if (report.resurrected > 0) applied.push(`${report.resurrected} restored`);
+      if (applied.length > 0) output.printInfo(`Also applied: ${applied.join(', ')}.`);
+      if (report.keptLocal > 0) {
+        output.printInfo(`${report.keptLocal} artifact change${report.keptLocal === 1 ? '' : 's'} skipped — the local entry is newer.`);
       }
       if (report.skippedMalformed > 0) {
         output.printWarning(`${report.skippedMalformed} malformed line${report.skippedMalformed === 1 ? '' : 's'} skipped.`);
@@ -2890,7 +2924,7 @@ const teamImportCommand: Command = {
       if (report.skippedNonDurable > 0) {
         output.printWarning(`${report.skippedNonDurable} non-durable entr${report.skippedNonDurable === 1 ? 'y' : 'ies'} skipped (only learnings/knowledge are shared).`);
       }
-      if (report.imported > 0) {
+      if (report.imported > 0 || report.updated > 0 || report.resurrected > 0) {
         output.printInfo(
           'Restart your Claude Code session (or run `flo memory rebuild-index`) so the merged learnings are embedded + searchable.',
         );

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -11,6 +11,7 @@
 import { cosineSim, execRows, generateId, logBridgeError, persistBridgeDb, refreshVectorStatsCache, searchCandidateCap, withDb } from './bridge-core.js';
 import { embeddingResponseFrom, getBridgeEmbedder, resolveBridgeEmbedding } from './bridge-embedder.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
+import { archiveDurableRow, isDurableNamespace } from '../services/durable-store-io.js';
 
 /**
  * Run `persistBridgeDb` and convert any throw into a `persist failed:`
@@ -1060,12 +1061,21 @@ export async function bridgeDeleteEntry(options: {
 
     let changes = 0;
     try {
-      ctx.db.prepare(`
-        DELETE FROM memory_entries
-        WHERE key = ? AND namespace = ? AND status = 'active'
-      `).run([key, namespace]);
+      // Durable namespaces archive rather than hard-delete, so the deletion can
+      // reach the team artifact and sibling worktrees (#1463). Same rule as the
+      // offline path in `entries-write.deleteEntry` — see the rationale there.
+      if (isDurableNamespace(namespace)) {
+        archiveDurableRow(ctx.db, namespace, key, Date.now());
+      } else {
+        ctx.db.prepare(`
+          DELETE FROM memory_entries
+          WHERE key = ? AND namespace = ? AND status = 'active'
+        `).run([key, namespace]);
+      }
       // sql.js Statement.run returns true/false, not { changes }. Use
-      // db.getRowsModified() to read the row count from the last statement.
+      // db.getRowsModified() to read the row count from the last statement —
+      // an UPDATE reports rows affected the same way, so the zero-rows
+      // inconsistency check below covers the archive path too.
       changes = ctx.db.getRowsModified?.() ?? 0;
     } catch (err) {
       return deleteFail(`DELETE failed: ${errorDetail(err)}`);

--- a/src/cli/memory/entries-write.ts
+++ b/src/cli/memory/entries-write.ts
@@ -26,6 +26,7 @@ import { toFloat32 } from './controllers/_shared.js';
 import { serialiseMetadata } from './bridge-entries.js';
 import { logRoutingFault, writeVectorStatsCache } from './entries-shared.js';
 import { writeThroughDurable } from '../services/durable-sync.js';
+import { archiveDurableRow, isDurableNamespace } from '../services/durable-store-io.js';
 import { resolveStateRoot } from '../services/project-root.js';
 import { generateId } from '../shared/utils/id.js';
 
@@ -39,8 +40,8 @@ import { generateId } from '../shared/utils/id.js';
  * reaches the shared store. `writeThroughDurable` swallows its own errors and
  * is a no-op unless `memory.durable_path` is set, so this is safe either way.
  */
-async function propagateDurable(namespace: string, projectRoot: string): Promise<void> {
-  const flush = writeThroughDurable(namespace, { projectRoot });
+async function propagateDurable(namespace: string, projectRoot: string, key: string): Promise<void> {
+  const flush = writeThroughDurable(namespace, { projectRoot, key });
   if (process.env.MOFLO_IS_DAEMON === '1') { void flush; return; }
   await flush;
 }
@@ -155,7 +156,7 @@ export async function storeEntry(options: {
       // this same bridge path, so the flush happens exactly once (in whichever
       // process actually persisted the row). The bridge resolves its DB via
       // findProjectRoot(), so source the flush from the same root.
-      if (bridgeResult.success) await propagateDurable(options.namespace ?? 'default', findProjectRoot());
+      if (bridgeResult.success) await propagateDurable(options.namespace ?? 'default', findProjectRoot(), options.key);
       return bridgeResult;
     }
   }
@@ -319,7 +320,7 @@ export async function storeEntry(options: {
     // fallback. Source the flush from the root the row actually landed under
     // (`dbPath` = <root>/.moflo/moflo.db) rather than process.cwd(), which can
     // differ from the project root.
-    await propagateDurable(namespace, path.dirname(path.dirname(dbPath)));
+    await propagateDurable(namespace, path.dirname(path.dirname(dbPath)), key);
 
     return {
       success: true,
@@ -485,13 +486,27 @@ export async function deleteEntry(options: {
       };
     }
 
-    // Hard-delete the entry. Soft-delete was retired in story #728: tombstones
-    // were write-only (no code ever restored from status='deleted') and bloated
-    // the DB indefinitely.
-    db.run(
-      `DELETE FROM memory_entries WHERE key = ? AND namespace = ? AND status = 'active'`,
-      [key, namespace],
-    );
+    // Durable namespaces ARCHIVE instead of hard-deleting (#1463). A hard
+    // delete cannot propagate — it is indistinguishable from a row that never
+    // existed — so the entry returned at the next session-start import or
+    // worktree seed, and the operator saw a clean local store with no signal
+    // that the purge would be undone.
+    //
+    // This narrows story #728's hard-delete rather than reverting it: #728
+    // retired a soft-delete that nothing read and nothing bounded. The archived
+    // row is read by every sync direction and by a later re-creation that has
+    // to beat its timestamp, and `pruneExpiredArchives` bounds it at the same
+    // 90-day window the artifact tombstones use. Non-durable namespaces are
+    // unchanged — they are never shared, so a tombstone there would be the
+    // write-only kind #728 removed.
+    if (isDurableNamespace(namespace)) {
+      archiveDurableRow(db, namespace, key, Date.now());
+    } else {
+      db.run(
+        `DELETE FROM memory_entries WHERE key = ? AND namespace = ? AND status = 'active'`,
+        [key, namespace],
+      );
+    }
 
     // Get remaining count
     const countResult = db.exec(`SELECT COUNT(*) FROM memory_entries WHERE status = 'active'`);

--- a/src/cli/services/cherry-pick-learnings.ts
+++ b/src/cli/services/cherry-pick-learnings.ts
@@ -75,6 +75,16 @@ export function isDurableNamespace(namespace: string): boolean {
  * between the two writers would silently mis-bind or drop rows (INSERT OR IGNORE
  * swallows the constraint violation). Single source of truth for both.
  */
+/**
+ * The 14 durable-row columns, in the order {@link DURABLE_INSERT_OR_IGNORE_SQL}
+ * binds them. Exported so every reader SELECTs exactly what the writer expects
+ * — the read half used to be retyped per call site, which is the same drift
+ * hazard the shared INSERT exists to prevent.
+ */
+export const DURABLE_ROW_COLUMNS =
+  `id, key, namespace, content, type, embedding, embedding_model, ` +
+  `embedding_dimensions, tags, metadata, owner_id, created_at, updated_at, status`;
+
 export const DURABLE_INSERT_OR_IGNORE_SQL =
   `INSERT OR IGNORE INTO memory_entries ` +
   `(id, key, namespace, content, type, embedding, embedding_model, ` +
@@ -208,9 +218,7 @@ export async function cherryPickLearningsFromLegacy(
 
     const placeholders = namespaces.map(() => '?').join(',');
     const selectSql =
-      `SELECT id, key, namespace, content, type, embedding, embedding_model, ` +
-      `embedding_dimensions, tags, metadata, owner_id, created_at, updated_at, status ` +
-      `FROM memory_entries WHERE namespace IN (${placeholders})`;
+      `SELECT ${DURABLE_ROW_COLUMNS} FROM memory_entries WHERE namespace IN (${placeholders})`;
     // Hoisted prepare — avoids re-parsing the SQL for every INSERT. Matters
     // for legacy DBs with hundreds of learnings rows.
     insertStmt = targetDb.prepare(DURABLE_INSERT_OR_IGNORE_SQL);

--- a/src/cli/services/durable-reconcile.ts
+++ b/src/cli/services/durable-reconcile.ts
@@ -1,0 +1,238 @@
+/**
+ * The durable-learning reconciliation plan (#1463).
+ *
+ * Before this module, every path that synced durable learnings between two
+ * stores was additive on keys: team export skipped any key already in the
+ * artifact, team import ran `INSERT OR IGNORE`, and the worktree durable sync
+ * ran both directions through the same ignore-on-conflict copy. A correction
+ * and a deletion were dropped in every direction, so a purge could not be made
+ * to stick — the entry came back at the next session-start import.
+ *
+ * That was three independent copies of the same defect. This module is the ONE
+ * implementation of the merge rule; the four call sites differ only in how they
+ * read records out of their store and how they apply the resulting actions.
+ * Adding a fifth sync path means reading records into {@link ReconcileRecord}
+ * and applying {@link ReconcileAction} — never re-deriving the rule.
+ *
+ * The module is deliberately pure: no fs, no sqlite, no clock. Everything it
+ * decides is a function of the two maps handed to it, which is what makes the
+ * conflict matrix directly testable in both orderings.
+ *
+ * ## The rule
+ *
+ * A record is either **live** (has `content`) or a **tombstone** (has
+ * `deletedAt`). For each key present in the SOURCE:
+ *
+ * | source | target | outcome |
+ * |---|---|---|
+ * | live | absent | `insert` |
+ * | live | live, same content | unchanged |
+ * | live | live, source newer | `update` |
+ * | live | live, target newer | kept (target wins) |
+ * | live | tombstone, source newer | `resurrect` |
+ * | live | tombstone, tombstone newer | kept (the purge stands) |
+ * | tombstone | absent | nothing — never shared, nothing to delete |
+ * | tombstone | live, tombstone newer | `delete` |
+ * | tombstone | live, target newer | kept (re-created after the purge) |
+ * | tombstone | tombstone | unchanged |
+ *
+ * And the rule that matters most, covering every key present in the TARGET but
+ * absent from the source: **leave it alone.** The naive alternative — delete
+ * anything the source lacks — cannot tell a remote deletion from local work
+ * that was never exported, and would destroy the latter. Only an explicit
+ * tombstone ever deletes.
+ *
+ * Comparisons are strict: equal timestamps produce no action. A tie means two
+ * stores disagree with no evidence about which is later, and the safe reading
+ * of "no evidence" is "change nothing".
+ *
+ * @module cli/services/durable-reconcile
+ */
+
+/** Separator for the composite (namespace, key) identity. NUL can't occur in either. */
+const ID_SEP = String.fromCharCode(0);
+
+/**
+ * Composite identity for a durable row. Namespaces share keys — the
+ * `knowledge` → `learnings` migration guarantees overlap — so a key alone is
+ * not an identity and never was.
+ */
+export function reconcileId(namespace: string, key: string): string {
+  return `${namespace}${ID_SEP}${key}`;
+}
+
+/** Split a {@link reconcileId} back into its parts. */
+export function splitReconcileId(id: string): { namespace: string; key: string } {
+  const at = id.indexOf(ID_SEP);
+  return at < 0
+    ? { namespace: '', key: id }
+    : { namespace: id.slice(0, at), key: id.slice(at + 1) };
+}
+
+/**
+ * One record as the merge rule sees it — the minimum needed to decide. Callers
+ * keep their own richer row/line objects keyed by the same {@link reconcileId}
+ * and look them up when applying, so nothing store-specific leaks in here.
+ */
+export interface ReconcileRecord {
+  namespace: string;
+  key: string;
+  /**
+   * Epoch-ms of the last edit. A store that cannot supply one (a pre-#1463
+   * artifact line) MUST pass 0 rather than substituting `created_at`: 0 loses
+   * every comparison, which preserves the old append-only behaviour for those
+   * lines instead of letting a stale line overwrite a corrected local row.
+   */
+  updatedAt: number;
+  /** Epoch-ms of the deletion. Present iff this record is a tombstone. */
+  deletedAt?: number;
+  /** The comparable payload. Absent on tombstones. */
+  content?: string;
+}
+
+/** True when a record represents a deletion rather than a live entry. */
+export function isTombstone(record: ReconcileRecord): boolean {
+  return typeof record.deletedAt === 'number';
+}
+
+/**
+ * The instant a record last changed, whichever kind it is. Used for every
+ * cross-kind comparison (live vs tombstone) so the matrix stays one rule —
+ * exported because callers settling duplicates within one store need the same
+ * basis, and a second copy of it is a second policy waiting to diverge.
+ */
+export function recordStamp(record: ReconcileRecord): number {
+  return isTombstone(record) ? (record.deletedAt as number) : record.updatedAt;
+}
+
+export type ReconcileOp =
+  /** Key absent from the target — add it. */
+  | 'insert'
+  /** Live in both, source newer and different — overwrite the target. */
+  | 'update'
+  /** Source tombstone beats a live target — tombstone/archive the target. */
+  | 'delete'
+  /** Live source beats a target tombstone — the entry was re-created. */
+  | 'resurrect';
+
+export interface ReconcileAction {
+  id: string;
+  op: ReconcileOp;
+  /** The SOURCE record the action carries. Applying means making the target match it. */
+  record: ReconcileRecord;
+}
+
+/** Per-run tallies. Every source key lands in exactly one of these, plus `targetOnly`. */
+export interface ReconcileSummary {
+  inserted: number;
+  updated: number;
+  deleted: number;
+  resurrected: number;
+  /** Present in both and already in agreement. */
+  unchanged: number;
+  /** Source had a change, but the target's version is newer and wins. */
+  keptTargetNewer: number;
+  /** Keys only the target has. Never touched — see the module header. */
+  targetOnly: number;
+}
+
+export interface ReconcilePlan {
+  actions: ReconcileAction[];
+  summary: ReconcileSummary;
+}
+
+/** True when the plan would change nothing. Callers use it to skip a write. */
+export function isNoOpPlan(plan: ReconcilePlan): boolean {
+  return plan.actions.length === 0;
+}
+
+/**
+ * Compute what the target must do to match the source. Pure — the caller
+ * applies the actions and owns every side effect.
+ *
+ * Direction is entirely the caller's: pass (DB, artifact) to export and
+ * (artifact, DB) to import. The rule is symmetric, which is the point.
+ */
+export function planReconcile(
+  source: ReadonlyMap<string, ReconcileRecord>,
+  target: ReadonlyMap<string, ReconcileRecord>,
+): ReconcilePlan {
+  const actions: ReconcileAction[] = [];
+  const summary: ReconcileSummary = {
+    inserted: 0,
+    updated: 0,
+    deleted: 0,
+    resurrected: 0,
+    unchanged: 0,
+    keptTargetNewer: 0,
+    targetOnly: 0,
+  };
+
+  for (const [id, src] of source) {
+    const dst = target.get(id);
+
+    if (!dst) {
+      // A tombstone for a key the target never had is not a deletion to
+      // propagate — the entry was never shared there. Dropping it here is also
+      // what keeps a tombstone from resurrecting as a row on a fresh install.
+      if (isTombstone(src)) {
+        summary.unchanged++;
+        continue;
+      }
+      actions.push({ id, op: 'insert', record: src });
+      summary.inserted++;
+      continue;
+    }
+
+    const srcDead = isTombstone(src);
+    const dstDead = isTombstone(dst);
+
+    if (srcDead && dstDead) {
+      // Both sides already agree the entry is gone. Refreshing the target's
+      // timestamp would churn the artifact diff for no semantic gain.
+      summary.unchanged++;
+      continue;
+    }
+
+    if (!srcDead && !dstDead && src.content === dst.content) {
+      summary.unchanged++;
+      continue;
+    }
+
+    // Strict: a tie changes nothing. See the module header.
+    if (recordStamp(src) <= recordStamp(dst)) {
+      summary.keptTargetNewer++;
+      continue;
+    }
+
+    const op: ReconcileOp = srcDead ? 'delete' : dstDead ? 'resurrect' : 'update';
+    actions.push({ id, op, record: src });
+    if (op === 'delete') summary.deleted++;
+    else if (op === 'resurrect') summary.resurrected++;
+    else summary.updated++;
+  }
+
+  for (const id of target.keys()) {
+    if (!source.has(id)) summary.targetOnly++;
+  }
+
+  return { actions, summary };
+}
+
+/** Default age past which a tombstone is dropped from an artifact on export. */
+export const TOMBSTONE_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+/**
+ * True when a tombstone is old enough to drop. Every store that was going to
+ * see the deletion has seen it long before 90 days, and keeping them forever
+ * would grow the artifact without bound.
+ *
+ * Live records are never prunable — the caller passes the whole map through.
+ */
+export function isPrunableTombstone(
+  record: ReconcileRecord,
+  now: number,
+  ttlMs: number = TOMBSTONE_TTL_MS,
+): boolean {
+  return isTombstone(record) && now - (record.deletedAt as number) > ttlMs;
+}

--- a/src/cli/services/durable-store-io.ts
+++ b/src/cli/services/durable-store-io.ts
@@ -1,0 +1,397 @@
+/**
+ * Reading durable rows out of a memory DB and applying a reconciliation plan
+ * back into one (#1463).
+ *
+ * The merge rule itself lives in {@link module:cli/services/durable-reconcile}
+ * and knows nothing about SQLite. This module is the other half: the SQL that
+ * turns `memory_entries` into {@link ReconcileRecord}s and the SQL that applies
+ * the resulting {@link ReconcileAction}s. Both the team JSONL artifact
+ * (`team-artifact-sync.ts`) and the worktree/cross-install durable sync
+ * (`durable-sync.ts`) use it, so the DB half of the sync exists once.
+ *
+ * ## Deletions are archives, not DELETEs
+ *
+ * A hard-deleted row is indistinguishable from a row that never existed, so it
+ * can never propagate — and "delete anything the other side lacks" is the rule
+ * we must not adopt (see the reconcile module header). Durable deletions
+ * therefore set `status = 'archived'` and stamp `updated_at` with the deletion
+ * time. Nothing else has to change for that to be invisible: every read path in
+ * moflo already filters `status = 'active'` — search, list, stats, retrieve,
+ * cleanup, and the HNSW index build. The archived row survives only as the
+ * evidence that lets the deletion cross to another store, and as the timestamp
+ * that lets a legitimate re-creation win later.
+ *
+ * ## Writer classification
+ *
+ * `daemon-offline`, same shape as `cherry-pick-learnings.ts` and the existing
+ * team-artifact import: these run pre-boot at session-start or from a CLI
+ * command, not concurrently with a live daemon writer. Registered in
+ * `tests/system/fixtures/writer-audit-whitelist.json` (#1054).
+ *
+ * @module cli/services/durable-store-io
+ */
+
+import { MEMORY_SCHEMA_V3 } from '../memory/schema.js';
+import type { SqlJsLikeDatabase } from '../memory/daemon-backend.js';
+import {
+  DURABLE_NAMESPACES,
+  DURABLE_INSERT_OR_IGNORE_SQL,
+  DURABLE_ROW_COLUMNS,
+  hasMemoryEntriesTable,
+  isDurableNamespace,
+} from './cherry-pick-learnings.js';
+
+// Re-exported so the two delete paths (`entries-write`, `bridge-entries`) can
+// reach the durable check and the archive statement through ONE import,
+// rather than each assembling its own copy of the retire-a-durable-row rule.
+export { isDurableNamespace };
+import {
+  reconcileId,
+  type ReconcileAction,
+  type ReconcileRecord,
+} from './durable-reconcile.js';
+
+/** The `status` value that marks a durable row as deleted-but-propagatable. */
+export const ARCHIVED_STATUS = 'archived';
+
+/**
+ * A full durable row, carrying everything an insert or update needs. The
+ * reconcile plan compares only {@link ReconcileRecord}s; this is what the
+ * caller looks up by the same id when applying an action.
+ */
+export interface DurablePayload {
+  id: string;
+  namespace: string;
+  key: string;
+  content: string;
+  type: string;
+  /** JSON-encoded array, or null. Stored verbatim — never re-parsed here. */
+  tags: string | null;
+  metadata: string | null;
+  ownerId: string | null;
+  createdAt: number;
+  updatedAt: number;
+  /**
+   * JSON-encoded vector, or null to have the daemon's index pass regenerate it.
+   * A caller whose content came from somewhere the embedding does NOT match
+   * (the JSONL artifact carries no vectors) must pass null — a stale vector
+   * would leave the row findable under its old meaning.
+   */
+  embedding: string | null;
+  embeddingModel: string | null;
+  embeddingDimensions: number | null;
+}
+
+export interface DurableSnapshot {
+  /** What the merge rule compares. Includes archived rows, as tombstones. */
+  records: Map<string, ReconcileRecord>;
+  /** The same rows in full, for the caller to hand back when applying. */
+  payloads: Map<string, DurablePayload>;
+}
+
+// Same column list as the shared INSERT, so a future column can never be added
+// to one half of the round trip only. The status filter is what differs from
+// the legacy cherry-pick read: archived rows are the deletions we must carry.
+const selectDurableSql = (placeholders: string, columns: string, byKey: boolean): string =>
+  `SELECT ${columns} FROM memory_entries ` +
+  `WHERE namespace IN (${placeholders}) AND status IN ('active', '${ARCHIVED_STATUS}')` +
+  (byKey ? ` AND key = ?` : '');
+
+/**
+ * The columns the merge rule alone needs. A comparison never looks at the
+ * embedding, and on a 1,600-row store those JSON vectors are tens of MB of
+ * string allocation — so the side of a sync that only supplies records (the
+ * TARGET, always) must not pay for them.
+ */
+const RECORD_ONLY_COLUMNS = `key, namespace, content, updated_at, status`;
+
+export interface SnapshotOptions {
+  /**
+   * Build the full {@link DurablePayload} map too. Only the SOURCE of a sync
+   * needs it — payloads are what gets written into the target. Defaults false.
+   */
+  withPayloads?: boolean;
+  /** Restrict the read to one key. Used by the per-write flush, which knows exactly what changed. */
+  key?: string;
+}
+
+/**
+ * Read the durable slice of a DB into comparable records plus full payloads.
+ * An archived row becomes a tombstone stamped with its `updated_at` — which is
+ * the deletion time, because that is what the archive write sets.
+ *
+ * Returns empty maps for a DB with no `memory_entries` table rather than
+ * throwing: a not-yet-initialised store is "nothing to sync", not an error.
+ */
+export function readDurableSnapshot(
+  db: SqlJsLikeDatabase,
+  namespaces: readonly string[] = DURABLE_NAMESPACES,
+  opts: SnapshotOptions = {},
+): DurableSnapshot {
+  const records = new Map<string, ReconcileRecord>();
+  const payloads = new Map<string, DurablePayload>();
+  if (!hasMemoryEntriesTable(db)) return { records, payloads };
+
+  const withPayloads = opts.withPayloads === true;
+  const placeholders = namespaces.map(() => '?').join(',');
+  const stmt = db.prepare(
+    selectDurableSql(placeholders, withPayloads ? DURABLE_ROW_COLUMNS : RECORD_ONLY_COLUMNS, opts.key != null),
+  );
+  try {
+    stmt.bind(opts.key != null ? [...namespaces, opts.key] : namespaces.slice());
+    while (stmt.step()) {
+      const row = stmt.getAsObject();
+      const namespace = String(row.namespace);
+      const key = String(row.key);
+      const id = reconcileId(namespace, key);
+      const createdAt = row.created_at == null ? 0 : Number(row.created_at);
+      // A row predating the updated_at backfill falls back to created_at: for a
+      // DB row that IS the last-known edit time, unlike an artifact line where
+      // substituting created_at would let a stale line win (see the reconcile
+      // module's note on passing 0).
+      const updatedAt = row.updated_at == null ? createdAt : Number(row.updated_at);
+      const archived = String(row.status ?? 'active') === ARCHIVED_STATUS;
+
+      records.set(
+        id,
+        archived
+          ? { namespace, key, updatedAt, deletedAt: updatedAt }
+          : { namespace, key, updatedAt, content: row.content == null ? '' : String(row.content) },
+      );
+      if (!withPayloads) continue;
+      payloads.set(id, {
+        id: String(row.id),
+        namespace,
+        key,
+        content: row.content == null ? '' : String(row.content),
+        type: row.type == null ? 'semantic' : String(row.type),
+        tags: row.tags == null ? null : String(row.tags),
+        metadata: row.metadata == null ? null : String(row.metadata),
+        ownerId: row.owner_id == null ? null : String(row.owner_id),
+        createdAt,
+        updatedAt,
+        embedding: row.embedding == null ? null : String(row.embedding),
+        embeddingModel: row.embedding_model == null ? null : String(row.embedding_model),
+        embeddingDimensions:
+          row.embedding_dimensions == null ? null : Number(row.embedding_dimensions),
+      });
+    }
+  } finally {
+    try {
+      stmt.free();
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+  return { records, payloads };
+}
+
+/** What {@link applyDurableActions} actually wrote. Counts are rows affected, never inputs. */
+export interface ApplyReport {
+  inserted: number;
+  updated: number;
+  archived: number;
+  resurrected: number;
+  /** Actions whose payload the caller could not supply — a caller bug, counted not thrown. */
+  skippedMissingPayload: number;
+  /**
+   * Inserts the UNIQUE(namespace, key) constraint swallowed. Non-zero means a
+   * row exists that the snapshot cannot see — e.g. a pre-#728 `status='deleted'`
+   * row surviving in an old consumer DB. Without this counter the plan would
+   * re-attempt that insert every session with nothing to show for it.
+   */
+  skippedConflict: number;
+}
+
+const UPDATE_ROW_SQL =
+  `UPDATE memory_entries SET content = ?, type = ?, tags = ?, metadata = ?, ` +
+  `embedding = ?, embedding_model = ?, embedding_dimensions = ?, ` +
+  `updated_at = ?, status = 'active' WHERE namespace = ? AND key = ?`;
+
+const ARCHIVE_DURABLE_ROW_SQL =
+  `UPDATE memory_entries SET status = '${ARCHIVED_STATUS}', updated_at = ?, ` +
+  // The vector goes with the deletion: an archived row is excluded from index
+  // builds anyway, and dropping it means a later resurrect cannot reuse a
+  // vector that no longer matches whatever content wins.
+  `embedding = NULL, embedding_model = NULL, embedding_dimensions = NULL ` +
+  // `status = 'active'` guard: re-archiving an already-archived row would move
+  // its deletion timestamp forward and could beat a legitimate re-creation on
+  // the other side that had already won.
+  `WHERE namespace = ? AND key = ? AND status = 'active'`;
+
+/**
+ * Apply a reconciliation plan to `db`. The whole batch runs in ONE transaction
+ * — a half-applied merge would leave the store in a state no later run could
+ * reason about, and a single commit is also one fsync instead of one per row on
+ * the session-start hot path.
+ *
+ * `payloads` supplies the full row for every insert/update/resurrect action;
+ * `delete` actions need only the timestamp the plan already carries.
+ */
+export function applyDurableActions(
+  db: SqlJsLikeDatabase,
+  actions: readonly ReconcileAction[],
+  payloads: ReadonlyMap<string, DurablePayload>,
+): ApplyReport {
+  const report: ApplyReport = {
+    inserted: 0,
+    updated: 0,
+    archived: 0,
+    resurrected: 0,
+    skippedMissingPayload: 0,
+    skippedConflict: 0,
+  };
+  if (actions.length === 0) return report;
+
+  db.run(MEMORY_SCHEMA_V3);
+
+  let insertStmt: ReturnType<SqlJsLikeDatabase['prepare']> | null = null;
+  let updateStmt: ReturnType<SqlJsLikeDatabase['prepare']> | null = null;
+  let archiveStmt: ReturnType<SqlJsLikeDatabase['prepare']> | null = null;
+  try {
+    insertStmt = db.prepare(DURABLE_INSERT_OR_IGNORE_SQL);
+    updateStmt = db.prepare(UPDATE_ROW_SQL);
+    archiveStmt = db.prepare(ARCHIVE_DURABLE_ROW_SQL);
+
+    db.run('BEGIN');
+    try {
+      for (const action of actions) {
+        if (action.op === 'delete') {
+          const { namespace, key } = action.record;
+          archiveStmt.bind([action.record.deletedAt ?? Date.now(), namespace, key]);
+          archiveStmt.step();
+          if (db.getRowsModified() > 0) report.archived++;
+          archiveStmt.reset();
+          continue;
+        }
+
+        const payload = payloads.get(action.id);
+        if (!payload) {
+          report.skippedMissingPayload++;
+          continue;
+        }
+
+        if (action.op === 'insert') {
+          insertStmt.bind([
+            payload.id,
+            payload.key,
+            payload.namespace,
+            payload.content,
+            payload.type,
+            payload.embedding,
+            payload.embeddingModel,
+            payload.embeddingDimensions,
+            payload.tags,
+            payload.metadata,
+            payload.ownerId,
+            payload.createdAt,
+            payload.updatedAt,
+            'active',
+          ]);
+          insertStmt.step();
+          if (db.getRowsModified() > 0) report.inserted++;
+          else report.skippedConflict++;
+          insertStmt.reset();
+          continue;
+        }
+
+        // update | resurrect — the same write. They differ only in what the
+        // target was before (a live row vs an archived one), which the plan has
+        // already decided; `status = 'active'` covers both.
+        updateStmt.bind([
+          payload.content,
+          payload.type,
+          payload.tags,
+          payload.metadata,
+          payload.embedding,
+          payload.embeddingModel,
+          payload.embeddingDimensions,
+          payload.updatedAt,
+          payload.namespace,
+          payload.key,
+        ]);
+        updateStmt.step();
+        if (db.getRowsModified() > 0) {
+          if (action.op === 'resurrect') report.resurrected++;
+          else report.updated++;
+        }
+        updateStmt.reset();
+      }
+      db.run('COMMIT');
+    } catch (e) {
+      try {
+        db.run('ROLLBACK');
+      } catch {
+        /* best-effort — close() also discards an open transaction */
+      }
+      throw e;
+    }
+  } finally {
+    for (const stmt of [insertStmt, updateStmt, archiveStmt]) {
+      if (!stmt) continue;
+      try {
+        stmt.free();
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+  }
+  return report;
+}
+
+/**
+ * Archive one durable row so the deletion can propagate, returning whether a
+ * row was actually affected.
+ *
+ * The single archive implementation: both `flo memory delete` paths (offline
+ * `entries-write.deleteEntry` and daemon `bridgeDeleteEntry`) call this rather
+ * than binding the statement themselves, so the bind order and the
+ * `status = 'active'` guard exist once. A hard delete in a durable namespace
+ * would silently un-share nothing — the entry returns on the next import,
+ * which is the #1463 failure mode in miniature.
+ */
+export function archiveDurableRow(
+  db: SqlJsLikeDatabase,
+  namespace: string,
+  key: string,
+  deletedAt: number,
+): boolean {
+  if (!hasMemoryEntriesTable(db)) return false;
+  db.run(ARCHIVE_DURABLE_ROW_SQL, [deletedAt, namespace, key]);
+  return db.getRowsModified() > 0;
+}
+
+/**
+ * Drop archived durable rows whose deletion is older than `ttlMs`.
+ *
+ * Story #728 retired the previous soft-delete because tombstones were
+ * write-only and grew without bound. Both halves of that are answered here: the
+ * rows are read (by every sync direction, and by a re-creation that must beat
+ * them), and this prune bounds them on the same 90-day window the artifact uses
+ * — by which point every store has long since seen the deletion.
+ *
+ * Returns the number of rows removed.
+ */
+export function pruneExpiredArchives(
+  db: SqlJsLikeDatabase,
+  now: number,
+  ttlMs: number,
+  namespaces: readonly string[] = DURABLE_NAMESPACES,
+): number {
+  if (!hasMemoryEntriesTable(db)) return 0;
+  // Probe before writing. `idx_memory_status` makes this a cheap index hit, and
+  // most stores hold no archived rows at all — running the DELETE regardless
+  // would open a write transaction on every session start for nothing.
+  const probe = db.exec(
+    `SELECT 1 FROM memory_entries WHERE status = '${ARCHIVED_STATUS}' AND updated_at < ? LIMIT 1`,
+    [now - ttlMs],
+  );
+  if (!probe[0]?.values?.[0]) return 0;
+  const placeholders = namespaces.map(() => '?').join(',');
+  db.run(
+    `DELETE FROM memory_entries WHERE status = '${ARCHIVED_STATUS}' ` +
+      `AND namespace IN (${placeholders}) AND updated_at < ?`,
+    [...namespaces, now - ttlMs],
+  );
+  return db.getRowsModified();
+}

--- a/src/cli/services/durable-sync.ts
+++ b/src/cli/services/durable-sync.ts
@@ -356,9 +356,18 @@ export async function flushDurableToShared(
 /**
  * Bidirectional durable sync run once at session-start: flush local → shared
  * (bootstraps pre-existing local learnings into the shared store), then seed
- * shared → local (pulls in sibling workspaces' learnings). Both directions are
- * `INSERT OR IGNORE`, so the result is the union of durable rows on both sides
- * with no conflicts. Safe to call unconditionally — a no-op when unconfigured.
+ * shared → local (pulls in sibling workspaces' learnings). Both directions run
+ * the shared reconciliation rule, so corrections and deletions converge across
+ * worktrees instead of accumulating as the union of both sides.
+ *
+ * Flush-then-seed order is load-bearing for deletions, and so is doing the
+ * archive pruning only once BOTH have run — see the prune comment in the body.
+ *
+ * Safe to call unconditionally, but no longer a true no-op when unconfigured:
+ * durable deletes archive rather than drop rows, so the local store still needs
+ * its retention window applied with sharing off. That costs one DB open and one
+ * indexed probe per session start, and nothing further unless expired archives
+ * actually exist.
  *
  * Intended to run BEFORE the daemon starts so the freshly-seeded rows are
  * present when the daemon builds its in-memory HNSW index.

--- a/src/cli/services/durable-sync.ts
+++ b/src/cli/services/durable-sync.ts
@@ -19,10 +19,21 @@
  *     every durable write, so a new learning propagates to sibling workspaces
  *     by their next session-start.
  *
- * Both directions are a single call to {@link cherryPickLearningsFromLegacy}
- * with source/target swapped — it already copies durable rows with
- * `INSERT OR IGNORE` on `UNIQUE(namespace, key)` (conflict-free, idempotent,
- * embeddings carried forward verbatim). No new SQL lives here.
+ * Both directions are a single call to {@link reconcileDurableStores} with
+ * source/target swapped — the same {@link planReconcile} rule the team artifact
+ * uses, so a correction and a deletion cross between worktrees instead of being
+ * dropped.
+ *
+ * Until #1463 both directions ran `INSERT OR IGNORE`, making the result the
+ * union of durable rows on both sides: an entry purged in one worktree came
+ * straight back at the next session-start seed. That mattered more here than
+ * for the team artifact, because worktree sharing needs no configuration —
+ * `worktree_sharing` defaults on — so every user with a linked worktree had it.
+ *
+ * `cherryPickLearningsFromLegacy` is deliberately NOT used any more for these
+ * two directions, and deliberately still used for the legacy upgrade path it
+ * was written for: reconciling against a legacy DB could archive rows on the
+ * strength of a store that predates tombstones entirely.
  *
  * Safety: the shared store is a plain transfer DB — moflo never *searches* it
  * directly, so it has no HNSW sidecar and no index-divergence concern. Row
@@ -40,12 +51,15 @@ import { findProjectRoot } from './project-root.js';
 import { stableAbsolute, pickConfiguredPath } from './configured-path.js';
 import { memoryDbPath } from './moflo-paths.js';
 import { loadMofloConfig, type MofloConfig } from '../config/moflo-config.js';
+import { openDaemonDatabase } from '../memory/daemon-backend.js';
 import {
-  cherryPickLearningsFromLegacy,
+  CHERRY_PICK_SKIP_REASONS,
   DURABLE_NAMESPACES,
   isDurableNamespace,
   type CherryPickResult,
 } from './cherry-pick-learnings.js';
+import { planReconcile, TOMBSTONE_TTL_MS } from './durable-reconcile.js';
+import { readDurableSnapshot, applyDurableActions, pruneExpiredArchives } from './durable-store-io.js';
 
 export { isDurableNamespace };
 
@@ -55,8 +69,10 @@ export interface DurableSyncReport {
   durablePath: string | null;
   /** Reason the sync was a no-op, when `durablePath` is null. */
   skipped?: 'not-configured' | 'same-as-local';
-  /** Rows copied local → shared (flush direction). */
+  /** Rows CHANGED local → shared (flush direction) — inserts, corrections, archives. */
   flushedToShared: number;
+  /** Archived rows dropped for being past the retention window (both stores). */
+  prunedArchives: number;
   /** Rows copied shared → local (seed direction). */
   seededToLocal: number;
   /**
@@ -188,6 +204,126 @@ export function resolveDurablePath(
 }
 
 /**
+ * One direction of a durable sync, as a superset of {@link CherryPickResult} so
+ * existing callers reading `copied` keep working. `copied` stays "rows newly
+ * added"; the other counts are what reconciliation added on top.
+ */
+export interface DurableDirectionResult extends CherryPickResult {
+  /** Rows whose content was corrected from the source. */
+  updated: number;
+  /** Rows archived because the source carries a newer deletion. */
+  archived: number;
+  /** Rows restored from an archive because the source re-created them. */
+  resurrected: number;
+  /** Source changes not applied because the target's row is newer. */
+  keptTarget: number;
+}
+
+const emptyDirection = (target: string): DurableDirectionResult => ({
+  copied: 0,
+  considered: 0,
+  sources: [],
+  target,
+  updated: 0,
+  archived: 0,
+  resurrected: 0,
+  keptTarget: 0,
+});
+
+/**
+ * Reconcile the durable slice of `sourcePath` into `targetPath`. Both stores
+ * are real memory DBs; the merge rule is the shared one, so a key present only
+ * in the target is never touched and only an explicit archive deletes.
+ *
+ * Missing source → a zero result rather than a throw: "the sibling worktree has
+ * not written anything yet" is a normal state, not an error.
+ */
+export function reconcileDurableStores(
+  sourcePath: string,
+  targetPath: string,
+  opts: { key?: string } = {},
+): DurableDirectionResult {
+  const result = emptyDirection(targetPath);
+  if (stableAbsolute(sourcePath) === stableAbsolute(targetPath)) {
+    result.sources.push({ path: sourcePath, rowsRead: 0, rowsInserted: 0, reason: CHERRY_PICK_SKIP_REASONS.SELF_REFERENCE });
+    return result;
+  }
+  if (!fs.existsSync(sourcePath)) {
+    result.sources.push({ path: sourcePath, rowsRead: 0, rowsInserted: 0, reason: CHERRY_PICK_SKIP_REASONS.NO_ROWS });
+    return result;
+  }
+
+  let sourceDb;
+  try {
+    sourceDb = openDaemonDatabase(sourcePath);
+  } catch {
+    result.sources.push({ path: sourcePath, rowsRead: 0, rowsInserted: 0, reason: CHERRY_PICK_SKIP_REASONS.OPEN_FAILED });
+    return result;
+  }
+
+  let snapshot;
+  try {
+    snapshot = readDurableSnapshot(sourceDb, DURABLE_NAMESPACES, { withPayloads: true, key: opts.key });
+  } finally {
+    sourceDb.close();
+  }
+
+  result.considered = snapshot.records.size;
+  if (snapshot.records.size === 0) {
+    result.sources.push({ path: sourcePath, rowsRead: 0, rowsInserted: 0, reason: CHERRY_PICK_SKIP_REASONS.NO_ROWS });
+    return result;
+  }
+
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  const targetDb = openDaemonDatabase(targetPath);
+  try {
+    const { records: target } = readDurableSnapshot(targetDb, DURABLE_NAMESPACES, { key: opts.key });
+    const { actions, summary } = planReconcile(snapshot.records, target);
+    const applied = applyDurableActions(targetDb, actions, snapshot.payloads);
+    result.copied = applied.inserted;
+    result.updated = applied.updated;
+    result.archived = applied.archived;
+    result.resurrected = applied.resurrected;
+    result.keptTarget = summary.keptTargetNewer;
+  } finally {
+    targetDb.close();
+  }
+
+  result.sources.push({
+    path: sourcePath,
+    rowsRead: result.considered,
+    rowsInserted: result.copied,
+  });
+  return result;
+}
+
+/**
+ * Apply the archive retention window to one store. Best-effort: a missing or
+ * unopenable store is "nothing to prune", never an error that fails a sync.
+ */
+function pruneStore(dbPath: string): number {
+  if (!fs.existsSync(dbPath)) return 0;
+  let db;
+  try {
+    db = openDaemonDatabase(dbPath);
+  } catch {
+    return 0;
+  }
+  try {
+    return pruneExpiredArchives(db, Date.now(), TOMBSTONE_TTL_MS);
+  } catch {
+    return 0;
+  } finally {
+    db.close();
+  }
+}
+
+/** Total rows a direction actually changed — what the launcher reports. */
+export function changedRows(result: DurableDirectionResult): number {
+  return result.copied + result.updated + result.archived + result.resurrected;
+}
+
+/**
  * Seed durable rows from the shared store into this project's local DB.
  * Shared is the source, local `.moflo/moflo.db` the target. No-op when the
  * shared store doesn't exist yet (nothing to seed).
@@ -195,13 +331,8 @@ export function resolveDurablePath(
 export async function seedDurableFromShared(
   projectRoot: string,
   durablePath: string,
-): Promise<CherryPickResult> {
-  return cherryPickLearningsFromLegacy({
-    projectRoot,
-    legacyPaths: [durablePath],
-    toPath: memoryDbPath(projectRoot),
-    namespaces: DURABLE_NAMESPACES,
-  });
+): Promise<DurableDirectionResult> {
+  return reconcileDurableStores(durablePath, memoryDbPath(projectRoot));
 }
 
 /**
@@ -211,7 +342,7 @@ export async function seedDurableFromShared(
 export async function flushDurableToShared(
   projectRoot: string,
   durablePath: string,
-): Promise<CherryPickResult> {
+): Promise<DurableDirectionResult> {
   // Ensure the parent dir exists — auto-derived worktree stores live under
   // `<git-common-dir>/moflo/`, which won't exist on the very first flush.
   try {
@@ -219,12 +350,7 @@ export async function flushDurableToShared(
   } catch {
     /* a real open failure surfaces from cherry-pick below */
   }
-  return cherryPickLearningsFromLegacy({
-    projectRoot,
-    legacyPaths: [memoryDbPath(projectRoot)],
-    toPath: durablePath,
-    namespaces: DURABLE_NAMESPACES,
-  });
+  return reconcileDurableStores(memoryDbPath(projectRoot), durablePath);
 }
 
 /**
@@ -243,18 +369,40 @@ export async function syncDurableAtSessionStart(
   const projectRoot = opts.projectRoot ?? findProjectRoot();
   const { path: durablePath, skipped, autoWorktree } = resolveDurablePath(projectRoot, opts.config);
   if (!durablePath) {
-    return { durablePath: null, skipped, flushedToShared: 0, seededToLocal: 0 };
+    // Sharing off, but deletes still archive — so the local store still needs
+    // its retention window applied. This is the majority case (one checkout,
+    // no team artifact); skipping it here is what would let archived rows grow
+    // without bound for most users.
+    return {
+      durablePath: null,
+      skipped,
+      flushedToShared: 0,
+      seededToLocal: 0,
+      prunedArchives: pruneStore(memoryDbPath(projectRoot)),
+    };
   }
 
   // Flush first so this worktree's existing learnings land in the shared store
   // before we seed — keeps the very first opt-in symmetric across workspaces.
   const flush = await flushDurableToShared(projectRoot, durablePath);
   const seed = await seedDurableFromShared(projectRoot, durablePath);
+
+  // Prune AFTER both directions, never inside one. Pruning during the flush
+  // deletes tombstones the seed has not applied yet: a worktree dormant past
+  // the retention window flushes its stale live row first, the shared
+  // tombstone correctly wins but is then pruned as expired, and the next
+  // flush re-inserts the purged entry into every workspace. Running the seed
+  // first means this store has applied the deletion before anything drops the
+  // evidence for it.
+  const pruned =
+    pruneStore(memoryDbPath(projectRoot)) + pruneStore(durablePath);
+
   return {
     durablePath,
     autoWorktree: autoWorktree ?? false,
-    flushedToShared: flush.copied,
-    seededToLocal: seed.copied,
+    flushedToShared: changedRows(flush),
+    seededToLocal: changedRows(seed),
+    prunedArchives: pruned,
   };
 }
 
@@ -270,7 +418,7 @@ export async function syncDurableAtSessionStart(
  */
 export async function writeThroughDurable(
   namespace: string,
-  opts: { projectRoot?: string; config?: MofloConfig } = {},
+  opts: { projectRoot?: string; config?: MofloConfig; key?: string } = {},
 ): Promise<void> {
   if (!isDurableNamespace(namespace)) return;
   try {
@@ -281,7 +429,12 @@ export async function writeThroughDurable(
     const projectRoot = opts.projectRoot ?? findProjectRoot();
     const { path: durablePath } = resolveDurablePath(projectRoot, opts.config);
     if (!durablePath) return;
-    await flushDurableToShared(projectRoot, durablePath);
+    // Flush ONLY the key that just changed. A full reconciliation here would
+    // read both stores end to end after every single learning written — the
+    // caller already knows exactly what moved, so a one-row plan is enough.
+    // The session-start sync remains the full-store reconciliation.
+    fs.mkdirSync(path.dirname(durablePath), { recursive: true });
+    reconcileDurableStores(memoryDbPath(projectRoot), durablePath, { key: opts.key });
   } catch {
     // Swallow entirely — see the rationale above.
   }

--- a/src/cli/services/team-artifact-sync.ts
+++ b/src/cli/services/team-artifact-sync.ts
@@ -621,6 +621,35 @@ export function importTeamArtifact(opts: { projectRoot?: string; artifactPath: s
 }
 
 /**
+ * The dominant line ending already in a file. Both writers below rewrite whole
+ * files they did not author, so they must hand back the style they were given —
+ * splitting on `/\r?\n/` and re-joining with `\n` silently converts every
+ * unrelated line in a CRLF checkout, which is the opposite of the narrow,
+ * one-line edit these functions promise (Rule #1).
+ */
+function detectEol(raw: string): '\r\n' | '\n' {
+  const newlines = (raw.match(/\n/g) ?? []).length;
+  const crlf = (raw.match(/\r\n/g) ?? []).length;
+  return crlf > newlines - crlf ? '\r\n' : '\n';
+}
+
+/**
+ * Render one path as a literal gitattributes pattern.
+ *
+ * The artifact path is caller-supplied (`flo memory team-export --to ...`), so
+ * it can carry whitespace or glob metacharacters. Unescaped, `team notes.jsonl`
+ * parses as the pattern `team` plus garbage, and a `*` in the name would match
+ * files the user never named. Glob metacharacters are escaped first; the result
+ * is then C-quoted if it contains whitespace, which doubles the backslashes the
+ * escape pass added — that is correct, since git un-quotes before globbing.
+ */
+function gitattributesPattern(rel: string): string {
+  const pattern = `/${rel.replace(/([\\*?[\]])/g, '\\$1')}`;
+  if (!/[\s"]/.test(pattern)) return pattern;
+  return `"${pattern.replace(/(["\\])/g, '\\$1')}"`;
+}
+
+/**
  * Ensure a git-tracked shared artifact is actually trackable. Once `.moflo/` is
  * gitignored, git won't descend into it to re-include a child — the canonical
  * fix is to ignore the *contents* (`.moflo/*`) and negate the shared subtree.
@@ -647,7 +676,9 @@ export function ensureSharedArtifactTracked(
   const negation = `!/${relDir}`;
 
   const existed = fs.existsSync(gitignorePath);
-  const lines = existed ? fs.readFileSync(gitignorePath, 'utf-8').split(/\r?\n/) : [];
+  const raw = existed ? fs.readFileSync(gitignorePath, 'utf-8') : '';
+  const eol = existed ? detectEol(raw) : '\n';
+  const lines = existed ? raw.split(/\r?\n/) : [];
 
   const isBareMoflo = (t: string): boolean =>
     t === '.moflo/' || t === '/.moflo/' || t === '.moflo' || t === '/.moflo';
@@ -692,7 +723,7 @@ export function ensureSharedArtifactTracked(
   }
 
   if (!changed) return 'unchanged';
-  const content = next.join('\n').replace(/\n+$/, '') + '\n';
+  const content = next.join(eol).replace(/(\r?\n)+$/, '') + eol;
   atomicWriteFileSync(gitignorePath, content);
   return existed ? 'updated' : 'created';
 }
@@ -724,25 +755,37 @@ export function ensureSharedArtifactEol(
   if (rel.startsWith('..') || path.isAbsolute(rel)) return 'unchanged';
 
   const attributesPath = path.join(projectRoot, '.gitattributes');
-  const rule = `/${rel} text eol=lf`;
+  const pattern = gitattributesPattern(rel);
   const existed = fs.existsSync(attributesPath);
-  const lines = existed ? fs.readFileSync(attributesPath, 'utf-8').split(/\r?\n/) : [];
+  const raw = existed ? fs.readFileSync(attributesPath, 'utf-8') : '';
+  const eol = existed ? detectEol(raw) : '\n';
+  const lines = existed ? raw.split(/\r?\n/) : [];
 
-  // Any existing rule naming this exact path wins, whatever it says.
+  // macOS APFS and Windows NTFS are case-insensitive by default, so a rule
+  // differing only in case there names the SAME file and must count as already
+  // ruled. On a case-sensitive filesystem it names a different file, and
+  // skipping ours would leave the artifact unpinned — so the fold is applied
+  // only where the filesystem actually folds (Rule #1).
+  const caseInsensitive = process.platform === 'win32' || process.platform === 'darwin';
+  const fold = (v: string): string => (caseInsensitive ? v.toLowerCase() : v);
+  const candidates = [fold(pattern), fold(`/${rel}`), fold(rel)];
+
+  // Any existing rule naming this path wins, whatever it says.
   const alreadyRuled = lines.some((line) => {
-    const trimmed = line.trim();
+    const trimmed = fold(line.trim());
     if (!trimmed || trimmed.startsWith('#')) return false;
-    const pattern = trimmed.split(/\s+/)[0];
-    return pattern === `/${rel}` || pattern === rel;
+    return candidates.some(
+      (c) => trimmed === c || trimmed.startsWith(`${c} `) || trimmed.startsWith(`${c}\t`),
+    );
   });
   if (alreadyRuled) return 'unchanged';
 
   const next = [...lines];
   if (next.length && next[next.length - 1].trim() !== '') next.push('');
   next.push('# moflo team-shared learnings: LF so the artifact stays diffable and merge-friendly');
-  next.push(rule);
+  next.push(`${pattern} text eol=lf`);
 
-  const content = next.join('\n').replace(/\n+$/, '') + '\n';
+  const content = next.join(eol).replace(/(\r?\n)+$/, '') + eol;
   atomicWriteFileSync(attributesPath, content);
   return existed ? 'updated' : 'created';
 }

--- a/src/cli/services/team-artifact-sync.ts
+++ b/src/cli/services/team-artifact-sync.ts
@@ -696,3 +696,53 @@ export function ensureSharedArtifactTracked(
   atomicWriteFileSync(gitignorePath, content);
   return existed ? 'updated' : 'created';
 }
+
+/**
+ * Pin the shared artifact to LF in the consumer's `.gitattributes`.
+ *
+ * The artifact is a git-tracked file in someone else's repo, and moflo always
+ * writes it with `\n`. On a Windows checkout with `core.autocrlf=true` git
+ * hands back CRLF, so every export rewrites the whole file and — far worse — a
+ * git merge of two divergent artifacts conflicts on EVERY line. That destroys
+ * the merge-friendliness that made JSONL the format in the first place, and it
+ * only bites the platform least likely to be running CI.
+ *
+ * One narrowly-scoped line for one file; never touches unrelated patterns.
+ * Idempotent — an existing rule for this path is left exactly as written, so a
+ * consumer who tuned it keeps their version.
+ *
+ * Gitattributes patterns always use `/` regardless of OS (Rule #1), so the
+ * path is POSIX-normalised here.
+ */
+export function ensureSharedArtifactEol(
+  projectRoot: string,
+  artifactAbsPath: string,
+): 'created' | 'updated' | 'unchanged' {
+  const rel = path.relative(projectRoot, artifactAbsPath).split(path.sep).join('/');
+  // Outside the project entirely (an absolute artifact on a shared drive) —
+  // there is no repo of ours to annotate.
+  if (rel.startsWith('..') || path.isAbsolute(rel)) return 'unchanged';
+
+  const attributesPath = path.join(projectRoot, '.gitattributes');
+  const rule = `/${rel} text eol=lf`;
+  const existed = fs.existsSync(attributesPath);
+  const lines = existed ? fs.readFileSync(attributesPath, 'utf-8').split(/\r?\n/) : [];
+
+  // Any existing rule naming this exact path wins, whatever it says.
+  const alreadyRuled = lines.some((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) return false;
+    const pattern = trimmed.split(/\s+/)[0];
+    return pattern === `/${rel}` || pattern === rel;
+  });
+  if (alreadyRuled) return 'unchanged';
+
+  const next = [...lines];
+  if (next.length && next[next.length - 1].trim() !== '') next.push('');
+  next.push('# moflo team-shared learnings: LF so the artifact stays diffable and merge-friendly');
+  next.push(rule);
+
+  const content = next.join('\n').replace(/\n+$/, '') + '\n';
+  atomicWriteFileSync(attributesPath, content);
+  return existed ? 'updated' : 'created';
+}

--- a/src/cli/services/team-artifact-sync.ts
+++ b/src/cli/services/team-artifact-sync.ts
@@ -1,5 +1,5 @@
 /**
- * Git-tracked team learnings artifact (#1234, epic #1231).
+ * Git-tracked team learnings artifact (#1234, epic #1231; reconciling since #1463).
  *
  * Story 1 (#1232) shared a durable SQLite store between worktrees; Story 2
  * (#1233) carried a durable SQLite artifact between one user's machines. This
@@ -17,15 +17,41 @@
  * normal index pass (or `flo memory rebuild-index`), exactly as any other
  * unembedded row.
  *
- * Conflict policy: **first-write-wins**, applied two ways, both via the existing
- * `UNIQUE(namespace, key)` constraint:
- *   - on re-export, an entry already in the artifact keeps its original line
- *     (and original author/timestamp) — we never rewrite a teammate's row.
- *   - on import, `INSERT OR IGNORE` means a row already present locally wins,
- *     and within the file the first line for a key wins.
+ * ## Conflict policy: last-writer-wins on `updated_at` (#1463)
  *
- * Provenance: each exported entry is stamped with `author` (git user) + `source`
- * (hostname) so a learning's origin is visible in review and retained on import.
+ * This **replaces** the original first-write-wins policy, which was the #1463
+ * bug rather than a design: export skipped any key already in the artifact and
+ * import ran `INSERT OR IGNORE`, so a correction and a deletion were silently
+ * dropped in both directions. The artifact is the effective source of truth
+ * across machines, which made the two operations that most need to propagate
+ * the two the pair could not do.
+ *
+ * Both directions now run the same {@link planReconcile} rule with source and
+ * target swapped. Ties change nothing, and a key present only in the target is
+ * never touched — that is what protects work authored locally and not yet
+ * shared. See `durable-reconcile.ts` for the full matrix.
+ *
+ * ## Tombstones
+ *
+ * A deletion travels as its own line, marked with a namespace that is not
+ * durable:
+ *
+ * ```json
+ * {"namespace":"__moflo_tombstone__","key":"purged-key",
+ *  "deleted":{"namespace":"learnings","key":"purged-key","at":1787751507635},
+ *  "provenance":{...}}
+ * ```
+ *
+ * That marker buys backward compatibility for free. `importTeamArtifact` has
+ * always routed non-durable namespaces to `skippedNonDurable`, so 4.12.11 and
+ * every earlier version silently ignore tombstones — they do not act on
+ * deletions, which is exactly their behaviour today. An old client's *export*
+ * also preserves the lines verbatim, since it re-serialises whatever it read.
+ * No version gate and no artifact-schema field are required.
+ *
+ * Provenance now records who wrote a line **last** rather than first, because a
+ * line can now be rewritten. That is the more useful fact when reviewing a diff
+ * that changes an entry.
  *
  * Opt-in: inert unless `memory.team_artifact` (or `MOFLO_TEAM_ARTIFACT`) points
  * at a path. Solo users see byte-identical behaviour to today.
@@ -40,16 +66,24 @@ import { spawnSync } from 'child_process';
 import { createHash } from 'crypto';
 import { findProjectRoot } from './project-root.js';
 import { memoryDbPath } from './moflo-paths.js';
-import { MEMORY_SCHEMA_V3 } from '../memory/memory-initializer.js';
-import { openDaemonDatabase, type SqlJsLikeDatabase } from '../memory/daemon-backend.js';
+import { openDaemonDatabase } from '../memory/daemon-backend.js';
 import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
 import { loadMofloConfig, type MofloConfig } from '../config/moflo-config.js';
+import { isDurableNamespace } from './cherry-pick-learnings.js';
 import {
-  DURABLE_NAMESPACES,
-  DURABLE_INSERT_OR_IGNORE_SQL,
-  hasMemoryEntriesTable,
-  isDurableNamespace,
-} from './cherry-pick-learnings.js';
+  planReconcile,
+  reconcileId,
+  splitReconcileId,
+  isPrunableTombstone,
+  recordStamp,
+  TOMBSTONE_TTL_MS,
+  type ReconcileRecord,
+} from './durable-reconcile.js';
+import {
+  readDurableSnapshot,
+  applyDurableActions,
+  type DurablePayload,
+} from './durable-store-io.js';
 
 /** Allowed `type` values — the schema CHECK set. An out-of-set value would make
  *  INSERT OR IGNORE silently drop a hand-edited artifact row, so we coerce. */
@@ -65,13 +99,22 @@ const coerceType = (t: string | undefined): string => (t && VALID_TYPES.has(t) ?
 /** Default artifact path, relative to the project root. POSIX-joined parts. */
 export const DEFAULT_TEAM_ARTIFACT_REL = path.join('.moflo', 'shared', 'learnings.jsonl');
 
+/**
+ * Namespace marker on a tombstone line. MUST stay outside
+ * {@link isDurableNamespace} — that is the entire backward-compatibility
+ * mechanism (old clients skip it as non-durable). Renaming it silently breaks
+ * deletion propagation for every client that hasn't upgraded, which is why
+ * `imports a tombstone-bearing artifact the way 4.12.11 does` pins it.
+ */
+export const TOMBSTONE_NAMESPACE = '__moflo_tombstone__';
+
 /** Provenance stamped onto each shared entry so its origin survives review. */
 export interface TeamProvenance {
   /** `git config user.name <user.email>`, or the OS user as a fallback. */
   author: string;
   /** Hostname of the machine that first shared the entry. */
   source: string;
-  /** ISO timestamp the entry was first written to the artifact. */
+  /** ISO timestamp the entry was last written to the artifact. */
   sharedAt: string;
 }
 
@@ -84,31 +127,80 @@ export interface TeamArtifactEntry {
   tags?: string[];
   /** Epoch-ms creation time (the `created_at` column is INTEGER NOT NULL). */
   created_at?: number;
+  /**
+   * Epoch-ms of the last edit — the basis for last-writer-wins (#1463). Absent
+   * on lines written before #1463; those are treated as timestamp 0 so they can
+   * still seed a store that lacks the key but can never overwrite one that has
+   * it. Export backfills the field on any such line this machine also holds
+   * (timestamp only — provenance stays with the original author), so the
+   * ambiguity retires after one export per line rather than persisting.
+   */
+  updated_at?: number;
   provenance: TeamProvenance;
+}
+
+/** A deletion, carried as a line so it can propagate. See the module header. */
+export interface TeamTombstone {
+  namespace: string;
+  key: string;
+  deleted: { namespace: string; key: string; at: number };
+  provenance: TeamProvenance;
+}
+
+export type TeamArtifactLine = TeamArtifactEntry | TeamTombstone;
+
+/** True when a parsed line is a tombstone rather than a live entry. */
+export function isTombstoneLine(line: TeamArtifactLine): line is TeamTombstone {
+  return line.namespace === TOMBSTONE_NAMESPACE;
 }
 
 export interface ExportReport {
   artifactPath: string;
-  /** Entries newly added to the artifact this run (excludes ones already present). */
+  /** Entries newly added to the artifact this run. */
   added: number;
-  /** Total entries in the artifact after the merge. */
+  /** Entries whose artifact text was corrected from the local DB. */
+  updated: number;
+  /** Entries tombstoned this run because they were archived locally. */
+  deleted: number;
+  /** Entries re-created locally after a purge, restored over their tombstone. */
+  resurrected: number;
+  /** Entries already in agreement. */
+  unchanged: number;
+  /** Local changes NOT propagated because the artifact's version is newer. */
+  keptRemote: number;
+  /** Expired tombstones dropped from the artifact this run. */
+  prunedTombstones: number;
+  /** Pre-#1463 lines given an `updated_at` this run, so they stop stamping 0. */
+  backfilled: number;
+  /** Malformed JSONL lines skipped while reading the artifact. */
+  skippedMalformed: number;
+  /** Live entries in the artifact after the merge. */
   total: number;
+  /** Tombstone lines retained in the artifact after the merge. */
+  tombstones: number;
+  /** False when nothing changed and the file was left untouched. */
+  wrote: boolean;
 }
 
 export interface ImportReport {
   artifactPath: string;
-  /** Rows actually inserted into the local DB (excludes duplicates). */
+  /** Rows newly inserted into the local DB. */
   imported: number;
-  /** Durable rows read from the artifact (well-formed, durable-namespace lines). */
+  /** Local rows corrected from the artifact. */
+  updated: number;
+  /** Local rows archived because the artifact carries a newer tombstone. */
+  deleted: number;
+  /** Local rows restored from an archive because the artifact has a newer entry. */
+  resurrected: number;
+  /** Artifact changes NOT applied because the local row is newer. */
+  keptLocal: number;
+  /** Durable records read from the artifact (live entries + tombstones). */
   considered: number;
   /** Malformed JSONL lines skipped (bad JSON or missing namespace/key). */
   skippedMalformed: number;
   /** Well-formed lines skipped for being outside the durable namespaces. */
   skippedNonDurable: number;
 }
-
-const KEY_SEP = String.fromCharCode(0); // in-memory dedup separator (collision-proof, kept out of source as a literal NUL)
-const entryMapKey = (namespace: string, key: string): string => `${namespace}${KEY_SEP}${key}`;
 
 /**
  * Resolve the configured team-artifact path to an absolute path, or `null` when
@@ -158,127 +250,313 @@ function resolveSource(): string {
   }
 }
 
-/** Read + parse an existing artifact into a (namespace,key) → entry map. Missing file → empty. */
-function readArtifact(artifactPath: string): { entries: Map<string, TeamArtifactEntry>; malformed: number } {
-  const entries = new Map<string, TeamArtifactEntry>();
+/** The (namespace, key) a line is *about* — its inner target for a tombstone. */
+function lineId(line: TeamArtifactLine): string {
+  return isTombstoneLine(line)
+    ? reconcileId(line.deleted.namespace, line.deleted.key)
+    : reconcileId(line.namespace, line.key);
+}
+
+/** A parsed line as the merge rule sees it. See {@link TeamArtifactEntry.updated_at}. */
+function lineToRecord(line: TeamArtifactLine): ReconcileRecord {
+  if (isTombstoneLine(line)) {
+    return {
+      namespace: line.deleted.namespace,
+      key: line.deleted.key,
+      updatedAt: 0,
+      deletedAt: line.deleted.at,
+    };
+  }
+  return {
+    namespace: line.namespace,
+    key: line.key,
+    updatedAt: typeof line.updated_at === 'number' ? line.updated_at : 0,
+    content: line.content ?? '',
+  };
+}
+
+/** Parse one JSONL line, or `null` when it is malformed. */
+function parseLine(trimmed: string): TeamArtifactLine | null {
+  let obj: Record<string, unknown> | null = null;
+  try {
+    obj = JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  if (!obj || typeof obj.namespace !== 'string' || typeof obj.key !== 'string') return null;
+
+  if (obj.namespace === TOMBSTONE_NAMESPACE) {
+    const deleted = obj.deleted as { namespace?: unknown; key?: unknown; at?: unknown } | undefined;
+    // A marker line whose payload is unusable is malformed, NOT a silent
+    // no-op: swallowing it would drop a deletion with no diagnostic.
+    if (
+      !deleted ||
+      typeof deleted.namespace !== 'string' ||
+      typeof deleted.key !== 'string' ||
+      typeof deleted.at !== 'number'
+    ) {
+      return null;
+    }
+    return obj as unknown as TeamTombstone;
+  }
+  return obj as unknown as TeamArtifactEntry;
+}
+
+/**
+ * Read + parse an existing artifact, keyed by the (namespace, key) each line is
+ * *about* — so a tombstone and the entry it retires occupy one slot and cannot
+ * both survive. Missing file → empty.
+ *
+ * Duplicates within one file are settled by timestamp, newest wins, ties keep
+ * the first. That is not hypothetical: an old client re-appends a live line for
+ * a key we tombstoned (it keys tombstones under the marker namespace, so the
+ * live key looks absent to it). Those re-appended lines carry no `updated_at`,
+ * so they stamp 0 and the tombstone stands — while a genuine re-creation from
+ * an upgraded client carries a real timestamp and wins.
+ */
+function readArtifact(artifactPath: string): {
+  lines: Map<string, TeamArtifactLine>;
+  records: Map<string, ReconcileRecord>;
+  malformed: number;
+  existed: boolean;
+} {
+  const lines = new Map<string, TeamArtifactLine>();
+  const records = new Map<string, ReconcileRecord>();
   let malformed = 0;
-  if (!fs.existsSync(artifactPath)) return { entries, malformed };
+  if (!fs.existsSync(artifactPath)) return { lines, records, malformed, existed: false };
   const raw = fs.readFileSync(artifactPath, 'utf-8');
   for (const line of raw.split(/\r?\n/)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
-    let obj: TeamArtifactEntry | null = null;
-    try {
-      obj = JSON.parse(trimmed) as TeamArtifactEntry;
-    } catch {
+    const parsed = parseLine(trimmed);
+    if (!parsed) {
       malformed++;
       continue;
     }
-    if (!obj || typeof obj.namespace !== 'string' || typeof obj.key !== 'string') {
-      malformed++;
-      continue;
-    }
-    const mapKey = entryMapKey(obj.namespace, obj.key);
-    // First line for a key wins (first-write-wins inside the file).
-    if (!entries.has(mapKey)) entries.set(mapKey, obj);
+    const id = lineId(parsed);
+    const record = lineToRecord(parsed);
+    const existing = records.get(id);
+    // Newest wins, ties keep the first. Built on the merge rule's own
+    // comparison basis so the two cannot disagree about which of a live line
+    // and a tombstone is later.
+    if (existing && recordStamp(existing) >= recordStamp(record)) continue;
+    lines.set(id, parsed);
+    records.set(id, record);
   }
-  return { entries, malformed };
+  return { lines, records, malformed, existed: true };
 }
 
-/** Serialise entries to JSONL, sorted by (namespace, key) for deterministic, reviewable diffs. */
-function serializeArtifact(entries: Iterable<TeamArtifactEntry>): string {
-  const sorted = [...entries].sort((a, b) =>
-    a.namespace === b.namespace ? a.key.localeCompare(b.key) : a.namespace.localeCompare(b.namespace),
-  );
-  return sorted.map((e) => JSON.stringify(e)).join('\n') + (sorted.length ? '\n' : '');
+/**
+ * Serialise lines to JSONL, sorted by the (namespace, key) each line is about —
+ * so a tombstone sorts exactly where the entry it retires used to sit, keeping
+ * the git diff line-local and reviewable.
+ */
+function serializeArtifact(lines: Iterable<[string, TeamArtifactLine]>): string {
+  const sorted = [...lines].sort((a, b) => {
+    const left = splitReconcileId(a[0]);
+    const right = splitReconcileId(b[0]);
+    return left.namespace === right.namespace
+      ? left.key.localeCompare(right.key)
+      : left.namespace.localeCompare(right.namespace);
+  });
+  return sorted.map(([, line]) => JSON.stringify(line)).join('\n') + (sorted.length ? '\n' : '');
 }
 
-/** SELECT the local durable rows (learnings, knowledge) to be shared. */
-function readLocalDurableRows(localDbPath: string): TeamArtifactEntry[] {
-  if (!fs.existsSync(localDbPath)) return [];
-  let db: SqlJsLikeDatabase;
-  try {
-    db = openDaemonDatabase(localDbPath);
-  } catch {
-    return [];
-  }
-  try {
-    if (!hasMemoryEntriesTable(db)) return [];
-    const placeholders = DURABLE_NAMESPACES.map(() => '?').join(',');
-    const stmt = db.prepare(
-      `SELECT namespace, key, content, type, tags, created_at FROM memory_entries ` +
-        `WHERE namespace IN (${placeholders})`,
-    );
-    stmt.bind(DURABLE_NAMESPACES.slice());
-    const rows: TeamArtifactEntry[] = [];
-    while (stmt.step()) {
-      const r = stmt.getAsObject();
-      rows.push({
-        namespace: String(r.namespace),
-        key: String(r.key),
-        content: r.content == null ? '' : String(r.content),
-        type: r.type == null ? 'semantic' : String(r.type),
-        tags: parseTags(r.tags),
-        created_at: r.created_at == null ? undefined : Number(r.created_at),
-        // Provenance is filled by the caller (export) — placeholder here.
-        provenance: { author: '', source: '', sharedAt: '' },
-      });
-    }
-    stmt.free();
-    return rows;
-  } finally {
-    db.close();
-  }
-}
-
-function parseTags(raw: unknown): string[] | undefined {
+/** Parse the DB's JSON-encoded tags column back to the artifact's array form. */
+function parseTags(raw: string | null): string[] | undefined {
   if (raw == null) return undefined;
-  if (Array.isArray(raw)) return raw.map(String);
   try {
-    const parsed = JSON.parse(String(raw));
+    const parsed = JSON.parse(raw);
     return Array.isArray(parsed) ? parsed.map(String) : undefined;
   } catch {
     return undefined;
   }
 }
 
+/** Build the artifact line for a local row that is winning the merge. */
+function entryFromPayload(payload: DurablePayload, provenance: TeamProvenance): TeamArtifactEntry {
+  return {
+    namespace: payload.namespace,
+    key: payload.key,
+    content: payload.content,
+    type: payload.type,
+    tags: parseTags(payload.tags),
+    created_at: payload.createdAt,
+    updated_at: payload.updatedAt,
+    provenance,
+  };
+}
+
+/** Build the tombstone line for a locally archived row. */
+function tombstoneFromRecord(record: ReconcileRecord, provenance: TeamProvenance): TeamTombstone {
+  return {
+    namespace: TOMBSTONE_NAMESPACE,
+    // Informational for old clients, which key this line under the marker
+    // namespace and skip it; the authoritative target is `deleted`.
+    key: record.key,
+    deleted: { namespace: record.namespace, key: record.key, at: record.deletedAt as number },
+    provenance,
+  };
+}
+
+/** Build the DB row an artifact line becomes. Embeddings are never carried. */
+function payloadFromLine(id: string, line: TeamArtifactEntry): DurablePayload {
+  return {
+    id: createHash('sha1').update(id).digest('hex'),
+    namespace: line.namespace,
+    key: line.key,
+    content: line.content ?? '',
+    // An out-of-CHECK-set type would be silently dropped by INSERT OR IGNORE.
+    type: coerceType(line.type),
+    tags: line.tags ? JSON.stringify(line.tags) : null,
+    metadata: JSON.stringify({ provenance: line.provenance, sharedFrom: 'team-artifact' }),
+    ownerId: line.provenance?.author || null,
+    // created_at/updated_at are INTEGER NOT NULL — never bind null.
+    createdAt: typeof line.created_at === 'number' ? line.created_at : Date.now(),
+    // The row gets the best timestamp available even when the RECORD compared
+    // as 0 (a pre-#1463 line): 0 governs only who wins the merge, while the row
+    // itself should carry the most accurate time we have.
+    updatedAt:
+      typeof line.updated_at === 'number'
+        ? line.updated_at
+        : typeof line.created_at === 'number'
+          ? line.created_at
+          : Date.now(),
+    embedding: null,
+    embeddingModel: null,
+    embeddingDimensions: null,
+  };
+}
+
 /**
- * Export the local durable slice into the team artifact (merge, not overwrite).
- * Existing artifact entries keep their original line/provenance (first-write-wins);
- * only local durable rows whose key is absent are appended, stamped with this
- * machine's provenance. The artifact is rewritten sorted + atomically.
+ * Export the local durable slice into the team artifact by **reconciling**, not
+ * appending: corrections overwrite the artifact line, local archives become
+ * tombstones, and entries the artifact has but this machine does not are left
+ * strictly alone (they may be a teammate's, or ours-not-yet-imported).
+ *
+ * The file is rewritten sorted + atomically, and only when something changed —
+ * a git-tracked file should not churn its mtime for a no-op run.
  */
 export function exportTeamArtifact(opts: {
   projectRoot?: string;
   artifactPath: string;
   sharedAt: string;
   config?: MofloConfig;
+  /** Epoch-ms used for tombstone pruning. Defaults to `sharedAt`, then now. */
+  now?: number;
+  /** Tombstone retention window. Exposed for tests; see {@link TOMBSTONE_TTL_MS}. */
+  tombstoneTtlMs?: number;
 }): ExportReport {
   const projectRoot = opts.projectRoot ?? findProjectRoot();
   const localDbPath = memoryDbPath(projectRoot);
-  const { entries } = readArtifact(opts.artifactPath);
-  const author = resolveAuthor(projectRoot);
-  const source = resolveSource();
+  const parsedSharedAt = Date.parse(opts.sharedAt);
+  const now = opts.now ?? (Number.isNaN(parsedSharedAt) ? Date.now() : parsedSharedAt);
+  const ttlMs = opts.tombstoneTtlMs ?? TOMBSTONE_TTL_MS;
 
-  let added = 0;
-  for (const row of readLocalDurableRows(localDbPath)) {
-    const mapKey = entryMapKey(row.namespace, row.key);
-    if (entries.has(mapKey)) continue; // never rewrite an existing (teammate's) entry
-    entries.set(mapKey, { ...row, provenance: { author, source, sharedAt: opts.sharedAt } });
-    added++;
+  const { lines, records: target, malformed, existed } = readArtifact(opts.artifactPath);
+  const provenance: TeamProvenance = {
+    author: resolveAuthor(projectRoot),
+    source: resolveSource(),
+    sharedAt: opts.sharedAt,
+  };
+
+  // Local DB is the source, the artifact the target.
+  let records = new Map<string, ReconcileRecord>();
+  let payloads = new Map<string, DurablePayload>();
+  if (fs.existsSync(localDbPath)) {
+    let db;
+    try {
+      db = openDaemonDatabase(localDbPath);
+    } catch {
+      db = null;
+    }
+    if (db) {
+      try {
+        // The local DB is the SOURCE here, so it is the side that needs full
+        // payloads. Archive retention is applied by the session-start sync, not
+        // here: pruning before the artifact write could destroy the evidence
+        // for a deletion the write then failed to publish.
+        ({ records, payloads } = readDurableSnapshot(db, undefined, { withPayloads: true }));
+      } finally {
+        db.close();
+      }
+    }
   }
 
-  fs.mkdirSync(path.dirname(opts.artifactPath), { recursive: true });
-  atomicWriteFileSync(opts.artifactPath, serializeArtifact(entries.values()));
-  return { artifactPath: opts.artifactPath, added, total: entries.size };
+  const { actions, summary } = planReconcile(records, target);
+  for (const action of actions) {
+    if (action.op === 'delete') {
+      lines.set(action.id, tombstoneFromRecord(action.record, provenance));
+      continue;
+    }
+    const payload = payloads.get(action.id);
+    if (payload) lines.set(action.id, entryFromPayload(payload, provenance));
+  }
+
+  // Backfill the timestamp on lines this machine holds but that predate #1463.
+  // Content-equal lines are never rewritten, so without this they would keep a
+  // stamp of 0 forever and lose every future comparison to any real timestamp.
+  // Only the timestamp moves — provenance stays with whoever authored the line.
+  let backfilled = 0;
+  for (const [id, line] of lines) {
+    if (isTombstoneLine(line) || typeof line.updated_at === 'number') continue;
+    const payload = payloads.get(id);
+    if (!payload) continue;
+    lines.set(id, { ...line, updated_at: payload.updatedAt });
+    backfilled++;
+  }
+
+  const expired: string[] = [];
+  for (const [id, line] of lines) {
+    if (isTombstoneLine(line) && isPrunableTombstone(lineToRecord(line), now, ttlMs)) expired.push(id);
+  }
+  for (const id of expired) lines.delete(id);
+  const prunedTombstones = expired.length;
+
+  let live = 0;
+  let tombstones = 0;
+  for (const line of lines.values()) {
+    if (isTombstoneLine(line)) tombstones++;
+    else live++;
+  }
+
+  // Skip the write when the merge changed nothing AND the file already exists:
+  // a git-tracked artifact should not show up as modified after a no-op run.
+  const changed = actions.length > 0 || prunedTombstones > 0 || backfilled > 0;
+  const wrote = changed || !existed;
+  if (wrote) {
+    fs.mkdirSync(path.dirname(opts.artifactPath), { recursive: true });
+    atomicWriteFileSync(opts.artifactPath, serializeArtifact(lines));
+  }
+
+  return {
+    artifactPath: opts.artifactPath,
+    added: summary.inserted,
+    updated: summary.updated,
+    deleted: summary.deleted,
+    resurrected: summary.resurrected,
+    unchanged: summary.unchanged,
+    keptRemote: summary.keptTargetNewer,
+    prunedTombstones,
+    backfilled,
+    skippedMalformed: malformed,
+    total: live,
+    tombstones,
+    wrote,
+  };
 }
 
 /**
- * Import-merge the team artifact into the local durable namespaces. `INSERT OR
- * IGNORE` on `UNIQUE(namespace, key)` makes this idempotent and first-write-wins
- * (existing local rows survive). Embeddings are left null — the daemon's index
- * pass fills them. No-op (zero rows) when the artifact is absent. Never throws on
- * a malformed line; those are counted and skipped.
+ * Import-merge the team artifact into the local durable namespaces, applying
+ * the same reconciliation rule with the artifact as source. Corrections update
+ * the local row, tombstones archive it, and local-only rows are never touched.
+ *
+ * Embeddings are left null on insert and cleared on update — the artifact
+ * carries no vectors, so keeping the old one would leave a corrected row
+ * findable under its previous meaning. The daemon's index pass refills them.
+ *
+ * No-op (zero rows) when the artifact is absent. Never throws on a malformed
+ * line; those are counted and skipped.
  */
 export function importTeamArtifact(opts: { projectRoot?: string; artifactPath: string }): ImportReport {
   const projectRoot = opts.projectRoot ?? findProjectRoot();
@@ -286,78 +564,57 @@ export function importTeamArtifact(opts: { projectRoot?: string; artifactPath: s
   const report: ImportReport = {
     artifactPath: opts.artifactPath,
     imported: 0,
+    updated: 0,
+    deleted: 0,
+    resurrected: 0,
+    keptLocal: 0,
     considered: 0,
     skippedMalformed: 0,
     skippedNonDurable: 0,
   };
 
-  const { entries, malformed } = readArtifact(opts.artifactPath);
+  const { lines, records: parsed, malformed } = readArtifact(opts.artifactPath);
   report.skippedMalformed = malformed;
-  if (entries.size === 0) return report;
+  if (lines.size === 0) return report;
+
+  const source = new Map<string, ReconcileRecord>();
+  for (const [id, line] of lines) {
+    const record = parsed.get(id) as ReconcileRecord;
+    // The artifact is hand-editable by design — only durable namespaces belong
+    // in the local durable slice. A tombstone resolves to its inner namespace,
+    // so it passes this check while its marker namespace keeps old clients from
+    // acting on it.
+    if (!isDurableNamespace(record.namespace)) {
+      report.skippedNonDurable++;
+      continue;
+    }
+    report.considered++;
+    source.set(id, record);
+  }
+  if (source.size === 0) return report;
 
   fs.mkdirSync(path.dirname(localDbPath), { recursive: true });
   const db = openDaemonDatabase(localDbPath);
-  let insertStmt: ReturnType<SqlJsLikeDatabase['prepare']> | null = null;
   try {
-    db.run(MEMORY_SCHEMA_V3);
-    // Shared column list with the cherry-pick writer — single source of truth so
-    // the two can't drift (a mismatch would mis-bind under INSERT OR IGNORE).
-    insertStmt = db.prepare(DURABLE_INSERT_OR_IGNORE_SQL);
-    // One transaction for the whole batch → a single fsync instead of one per
-    // row on the (enabled) session-start hot path.
-    db.run('BEGIN');
-    try {
-      for (const entry of entries.values()) {
-        // The artifact is hand-editable by design — only durable namespaces
-        // belong in the local durable slice; skip anything else rather than
-        // polluting the DB (and so it isn't mis-counted as a duplicate).
-        if (!isDurableNamespace(entry.namespace)) {
-          report.skippedNonDurable++;
-          continue;
-        }
-        report.considered++;
-        const id = createHash('sha1').update(entryMapKey(entry.namespace, entry.key)).digest('hex');
-        const metadata = JSON.stringify({ provenance: entry.provenance, sharedFrom: 'team-artifact' });
-        // created_at/updated_at are INTEGER NOT NULL — never bind null (INSERT OR
-        // IGNORE would silently drop the row on the constraint violation).
-        const ts = typeof entry.created_at === 'number' ? entry.created_at : Date.now();
-        insertStmt.bind([
-          id,
-          entry.key,
-          entry.namespace,
-          entry.content ?? '',
-          coerceType(entry.type), // out-of-CHECK-set type would be silently dropped otherwise
-          null, // embedding — regenerated by the daemon's index pass
-          null, // embedding_model
-          null, // embedding_dimensions
-          entry.tags ? JSON.stringify(entry.tags) : null,
-          metadata,
-          entry.provenance?.author || null,
-          ts,
-          ts,
-          'active',
-        ]);
-        insertStmt.step();
-        if (db.getRowsModified() > 0) report.imported++;
-        insertStmt.reset();
-      }
-      db.run('COMMIT');
-    } catch (e) {
-      try {
-        db.run('ROLLBACK');
-      } catch {
-        /* best-effort — the close() below also discards an open transaction */
-      }
-      throw e;
+    const { records: target } = readDurableSnapshot(db);
+    const { actions, summary } = planReconcile(source, target);
+    // Payloads are built only for the actions that need one. In the steady
+    // state the plan is empty, and hashing + re-encoding every line of a
+    // 1,300-entry artifact on every session start would be pure waste.
+    const payloads = new Map<string, DurablePayload>();
+    for (const action of actions) {
+      if (action.op === 'delete') continue;
+      const line = lines.get(action.id);
+      if (!line || isTombstoneLine(line)) continue;
+      payloads.set(action.id, payloadFromLine(action.id, line));
     }
+    const applied = applyDurableActions(db, actions, payloads);
+    report.imported = applied.inserted;
+    report.updated = applied.updated;
+    report.deleted = applied.archived;
+    report.resurrected = applied.resurrected;
+    report.keptLocal = summary.keptTargetNewer;
   } finally {
-    if (insertStmt) {
-      try {
-        insertStmt.free();
-      } catch {
-        /* best-effort cleanup */
-      }
-    }
     db.close();
   }
   return report;

--- a/tests/system/fixtures/writer-audit-whitelist.json
+++ b/tests/system/fixtures/writer-audit-whitelist.json
@@ -218,6 +218,11 @@
       "notes": "One-time launcher pre-boot cherry-pick"
     },
     {
+      "file": "src/cli/services/durable-store-io.ts",
+      "classification": "daemon-offline",
+      "notes": "Shared DB half of durable-learning reconciliation (#1463): reads the durable slice and applies the merge plan for the team artifact and the worktree durable sync. Both callers run pre-boot at session-start or from a CLI command, the same offline shape as cherry-pick-learnings and team-artifact-sync."
+    },
+    {
       "file": "src/cli/services/team-artifact-sync.ts",
       "classification": "daemon-offline",
       "notes": "Imports the git-tracked team JSONL artifact into local moflo.db at session-start before the daemon spawns (#1234); same pre-boot writer shape as cherry-pick. The team-import CLI path matches restore-learnings' offline usage."


### PR DESCRIPTION
Closes #1463.

Every path that synced durable learnings was additive on keys, so a correction
and a deletion were dropped in every direction. A purge could not be made to
stick: `bin/session-start-launcher.mjs` auto-imports the artifact at **every
session start**, and the worktree sync seeds on the same hook — so entries came
back on the operator's own machine within minutes, with a clean-looking local
store and no signal that it had been undone.

## Three sites, one rule

The ticket named two sites. There were three: the worktree/cross-install durable
sync ran the same `INSERT OR IGNORE` in both directions, and it needs **no
configuration** to be active (`worktree_sharing` defaults on), so the defect
reached every user with a linked worktree — not just teams who opted into a team
artifact.

- **`durable-reconcile.ts`** — the pure merge plan (insert / update / delete /
  resurrect). No fs, no sqlite, no clock, so the conflict matrix is directly
  testable in both orderings.
- **`durable-store-io.ts`** — the SQLite half: snapshot, apply, prune.
- Team export, team import, and **both** worktree directions route through them.
  `cherryPickLearningsFromLegacy` deliberately keeps its `INSERT OR IGNORE` for
  the legacy upgrade path, where reconciling could archive rows on the word of a
  store that predates tombstones entirely.

The central invariant: **a key present only in the target is never touched.** The
naive alternative — delete anything the source lacks — cannot tell a remote
deletion from local work never exported, and would destroy the latter. Only an
explicit tombstone deletes. Ties change nothing.

## Deletions need something to travel as

Deleting a `learnings`/`knowledge` row now archives it (`status = 'archived'`)
instead of dropping it, in **both** delete paths — a rule enforced only in the
offline path would hold only until the daemon starts. Nothing else had to
change: every read path in moflo already filters `status = 'active'`.

This narrows story #728 rather than reverting it. #728 retired a soft-delete
that nothing read and nothing bounded; these rows are read by every sync
direction and by a later re-creation that must beat their timestamp, and they
are bounded by a 90-day retention window. Non-durable namespaces still
hard-delete — a tombstone there would be exactly the write-only kind #728
removed.

## Backward compatibility

Tombstones ride the artifact as `__moflo_tombstone__` lines. `importTeamArtifact`
has always routed non-durable namespaces to `skippedNonDurable`, so 4.12.11 and
earlier ignore deletions exactly as they do today, and an old client's export
preserves the lines verbatim.

One interop case the ticket did not anticipate: an old client keys tombstones
under the marker namespace, so a retired key looks *absent* to it and its export
re-appends a live line beside the tombstone. Those lines carry no `updated_at`,
so the tombstone still wins — pinned with a test.

## Bugs the review passes caught in this work

- **Resurrection.** Retention pruning ran inside each sync direction. A worktree
  dormant past the window flushes its stale live row first, the shared tombstone
  correctly wins — and was then pruned as expired in that same flush, before the
  seed could apply the deletion locally. The next session re-inserted the purged
  entry into every workspace. Pruning now runs after **both** directions, and the
  regression test was confirmed to fail against the old placement.
- **Write-through cost.** Every durable write triggered a full two-store
  reconciliation. The flush now reconciles only the key that changed; the full
  reconciliation stays at session start.
- **EOL clobber in the fix itself.** The `.gitattributes`/`.gitignore` writers
  read with `/\r?\n/` and re-joined with `\n`, silently converting every
  unrelated line of a CRLF file — the exact full-file Windows diff the LF pin
  exists to prevent. Both now preserve the style they were given.

Payload materialisation (including JSON embeddings) is also now opt-in, so the
target side of a sync no longer allocates and discards tens of MB.

## Cross-platform (Rule #1)

The artifact is a git-tracked file in the **consumer's** repo, and moflo always
writes it with `\n`. On a Windows checkout with `core.autocrlf` git hands back
CRLF, so a merge of two divergent artifacts conflicts on every line — destroying
the merge-friendliness that made JSONL the format. `team-export` now pins the
artifact to LF in `.gitattributes`, the same way it already ensures `.gitignore`
tracks it. Idempotent; a consumer's own rule for that path is left as written;
the pattern is glob-escaped and quoted, since `--to` is caller-supplied and
`team notes.jsonl` would otherwise parse as the pattern `team`. Duplicate
detection folds case on win32/darwin only — there a differently-cased rule names
the same file, while on a case-sensitive filesystem it names a different one and
skipping ours would leave the artifact unpinned.

Otherwise: no new path-identity comparisons (the self-reference guard reuses
`stableAbsolute`, which realpaths — the #1145 class), no shell-outs, no new
`bin/` files, tests use `os.tmpdir()` + `path.join` throughout. The smoke
harness does not exercise `team-export`, so the cross-platform evidence here is
the vitest suite, which CI runs on ubuntu, macOS and Windows.

## Consumer surface and round-trip

`team-artifact-sync.ts`, `durable-sync.ts`, `cherry-pick-learnings.ts`, both
delete paths, `flo memory team-export|team-import|delete`, and the session-start
launcher — the highest-blast-radius set in this area. New modules live under
`src/cli/services/`, so they ship via the existing `dist/**` glob with no
manifest edit (`npm pack --dry-run` confirmed); the new DB writer is registered
in the writer-audit whitelist; the launcher's dogfood copy under
`.claude/scripts/` is synced.

Failure mode for a consumer on 4.12.11: an old client reading a new artifact
ignores tombstones and otherwise behaves exactly as today. A new client reading
an old artifact treats a missing `updated_at` as 0 — which loses every
comparison, so a stale line can never overwrite a corrected local row, while a
local row with a real timestamp still pushes its correction out. Export then
backfills the timestamp on legacy lines this machine holds (timestamp only —
provenance stays with the original author), so the ambiguity retires after one
export per line. No `.moflo/` migration. Runtime layers need publish + reinstall
to take effect.

## Verification

- Full suite **11,022 passed / 0 failed**; lint, `tsc`, and `npm run build` clean.
- `/verify` recorded PASS against all 9 acceptance criteria (`verify:1463`). The
  summary *rendering* initially had no covering test — that gap is closed, since
  a summary naming only appends is precisely why this sat unnoticed for weeks.

## Follow-ups (filed, not in scope here)

- #1464 — search records no usage and `memory_cleanup --older-than` has no
  durable exemption, so the only purge tool moflo ships deletes learnings by age.
- #1466 — `flo memory audit-learnings`, the curation pass this unblocks.
- #1465 — `moflodb_batch delete`/`update` report success while changing nothing.
