### PR TITLE
fix(memory): record search usage for durable rows and exempt them from age-based cleanup

### DIFF
--- a/src/cli/__tests__/commands/memory-cleanup-heldback-1464.test.ts
+++ b/src/cli/__tests__/commands/memory-cleanup-heldback-1464.test.ts
@@ -1,0 +1,97 @@
+/**
+ * `flo memory cleanup` reports the durable rows the exemption withheld (#1464).
+ *
+ * The number matters more than it looks. Durable namespaces are skipped by the
+ * age-based buckets, so a store full of ancient learnings reports zero
+ * candidates — and an operator reads that as "learnings are already tidy" when
+ * the truth is "learnings were never examined". Printing the held-back count is
+ * what keeps the clean result honest, so it gets a test rather than resting on
+ * the MCP field being populated.
+ *
+ * The MCP call is mocked: what is under test here is the command's rendering of
+ * the result, not the handler that produces it — that half is covered by
+ * `mcp-tools/memory-cleanup-durable-exemption-1464.test.ts`.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  result: {} as Record<string, unknown>,
+  calls: [] as Array<{ tool: string; args: unknown }>,
+}));
+
+vi.mock('../../mcp-client.js', () => ({
+  callMCPTool: (tool: string, args: unknown) => {
+    hoisted.calls.push({ tool, args });
+    return Promise.resolve(hoisted.result);
+  },
+  MCPClientError: class MCPClientError extends Error {},
+}));
+
+import { memoryCommand } from '../../commands/memory.js';
+import { output } from '../../output.js';
+import type { Command, CommandContext } from '../../types.js';
+
+const cleanup = memoryCommand.subcommands!.find(c => c.name === 'cleanup') as Command;
+
+afterEach(() => vi.restoreAllMocks());
+
+function cleanupResult(overrides: Record<string, unknown> = {}) {
+  return {
+    dryRun: true,
+    candidates: { expired: 0, stale: 0, lowQuality: 0, total: 0 },
+    deleted: { entries: 0 },
+    freed: { bytes: 0, formatted: '0 B' },
+    duration: 1,
+    ...overrides,
+  };
+}
+
+/** Runs the command and returns everything it printed, in order. */
+async function run(result: Record<string, unknown>): Promise<string[]> {
+  hoisted.result = result;
+  hoisted.calls = [];
+  const lines: string[] = [];
+  const record = (v: unknown) => { lines.push(String(v)); };
+  vi.spyOn(output, 'printInfo').mockImplementation(record);
+  vi.spyOn(output, 'printSuccess').mockImplementation(record);
+  vi.spyOn(output, 'printWarning').mockImplementation(record);
+  vi.spyOn(output, 'writeln').mockImplementation((v?: unknown) => { if (v != null) lines.push(String(v)); });
+  vi.spyOn(output, 'printList').mockImplementation((items: string[]) => { lines.push(...items); });
+  vi.spyOn(output, 'printTable').mockImplementation(() => { /* rendering is not under test */ });
+
+  const ctx: CommandContext = {
+    args: [], flags: { _: [], dryRun: true, olderThan: '1d' }, cwd: process.cwd(), interactive: false,
+  };
+  await cleanup.action!(ctx);
+  return lines;
+}
+
+describe('flo memory cleanup — held-back reporting (#1464)', () => {
+  it('states how many durable entries were held back', async () => {
+    const lines = await run(cleanupResult({ durableHeldBack: 3 }));
+
+    const held = lines.find(l => l.includes('held back'));
+    expect(held).toBeDefined();
+    expect(held).toContain('3 durable entries');
+    // And it must say what to do about it, or the number is just a puzzle.
+    expect(lines.some(l => l.includes('--namespace learnings'))).toBe(true);
+  });
+
+  it('uses the singular for one entry', async () => {
+    const lines = await run(cleanupResult({ durableHeldBack: 1 }));
+    expect(lines.find(l => l.includes('held back'))).toContain('1 durable entry');
+  });
+
+  it('says nothing when nothing was held back', async () => {
+    const lines = await run(cleanupResult({ durableHeldBack: 0 }));
+    expect(lines.some(l => l.includes('held back'))).toBe(false);
+  });
+
+  it('says nothing against an older server that never sends the field', async () => {
+    // The CLI ships independently of the MCP server a consumer may still be
+    // running; an absent field must render as "none", never "undefined".
+    const lines = await run(cleanupResult());
+    expect(lines.some(l => l.includes('held back'))).toBe(false);
+    expect(lines.some(l => l.includes('undefined'))).toBe(false);
+  });
+});

--- a/src/cli/__tests__/mcp-tools/memory-cleanup-durable-exemption-1464.test.ts
+++ b/src/cli/__tests__/mcp-tools/memory-cleanup-durable-exemption-1464.test.ts
@@ -1,0 +1,217 @@
+/**
+ * #1464 — `memory_cleanup` exempts durable namespaces from its AGE-based
+ * buckets unless the caller names one explicitly.
+ *
+ * The defect these pin down: `COALESCE(last_accessed_at, updated_at, created_at)`
+ * collapses to `created_at` for any row nothing has ever bumped, and nothing on
+ * the search path — the path learnings are actually read through — bumped
+ * anything. So the "stale (unused)" bucket meant "old", and the only purge
+ * surface moflo ships deleted the most-consulted learnings alongside the dead
+ * ones. Age is not evidence of worthlessness for a durable row.
+ *
+ * The exemption is a DEFAULT, not a prohibition, and it must never reach the
+ * TTL bucket — a caller who set an explicit expiry asked for that deletion.
+ *
+ * @module v3/cli/__tests__/mcp-tools/memory-cleanup-durable-exemption-1464
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { memoryAdminTools } from '../../mcp-tools/memory-admin-tools.js';
+import { memoryDbPath } from '../../services/moflo-paths.js';
+import { _resetStateRootCacheForTest } from '../../services/project-root.js';
+import { shutdownBridge, _resetProjectRootForTest } from '../../memory/bridge-core.js';
+import { MEMORY_SCHEMA_V3 } from '../../memory/schema.js';
+import { DURABLE_NAMESPACES } from '../../services/cherry-pick-learnings.js';
+
+const cleanup = memoryAdminTools.find(t => t.name === 'memory_cleanup')!;
+
+type CleanupResult = {
+  candidates: { expired: number; stale: number; lowQuality: number; total: number };
+  durableHeldBack: number;
+  deleted: { entries: number };
+};
+
+/** Rule #1: os.tmpdir() + path.join only — never a hardcoded /tmp. */
+let root: string;
+let originalCwd: string;
+let originalProjectDir: string | undefined;
+
+/** Rows are seeded a year old so every age cutoff below catches them. */
+const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+function seed(rows: Array<{ key: string; namespace: string; expiresAt?: number; embedding?: string }>): void {
+  const db = new DatabaseSync(memoryDbPath(root));
+  try {
+    db.exec(MEMORY_SCHEMA_V3);
+    const old = Date.now() - YEAR_MS;
+    for (const [i, r] of rows.entries()) {
+      db.prepare(
+        `INSERT INTO memory_entries
+           (id, key, namespace, content, embedding, created_at, updated_at, expires_at, access_count, status)
+         VALUES (?, ?, ?, 'content', ?, ?, ?, ?, 0, 'active')`
+      ).run(`e${i}`, r.key, r.namespace, r.embedding ?? null, old, old, r.expiresAt ?? null);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+function activeKeys(): string[] {
+  const db = new DatabaseSync(memoryDbPath(root));
+  try {
+    return (db.prepare("SELECT key FROM memory_entries WHERE status = 'active' ORDER BY key")
+      .all() as Array<{ key: string }>).map(r => r.key);
+  } finally {
+    db.close();
+  }
+}
+
+beforeEach(async () => {
+  originalCwd = process.cwd();
+  originalProjectDir = process.env.CLAUDE_PROJECT_DIR;
+
+  // realpath both sides (Rule #1 §2): macOS os.tmpdir() is /var/folders/... while
+  // resolveStateRoot canonicalizes to /private/var/folders/..., and these
+  // assertions must read the same file the handler writes.
+  root = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-1464-cleanup-')));
+  mkdirSync(join(root, '.moflo'), { recursive: true });
+
+  // Safety interlock, not boilerplate: resolveStateRoot treats
+  // CLAUDE_PROJECT_DIR as authoritative, so without this an `apply: true` case
+  // would delete rows from the developer's own .moflo/moflo.db.
+  process.env.CLAUDE_PROJECT_DIR = root;
+  writeFileSync(memoryDbPath(root), '');
+  _resetStateRootCacheForTest();
+
+  process.chdir(root);
+
+  // The bridge registry is module-level and binds to whichever db path first
+  // resolved it. Without this teardown the second test's deletes are issued
+  // against the FIRST test's temp database — every row reads as missing and
+  // `deleted: 0` comes back while the candidate counts (which open the db path
+  // directly) look right. Same reason the #1402 harness does it.
+  await shutdownBridge();
+  _resetProjectRootForTest();
+});
+
+afterEach(async () => {
+  await shutdownBridge();
+  _resetProjectRootForTest();
+  process.chdir(originalCwd);
+  if (originalProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+  else process.env.CLAUDE_PROJECT_DIR = originalProjectDir;
+  _resetStateRootCacheForTest();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('memory_cleanup durable exemption (#1464)', () => {
+  it('collects no durable rows by age, however old they are', async () => {
+    seed([
+      { key: 'decision', namespace: 'learnings' },
+      { key: 'fact', namespace: 'knowledge' },
+    ]);
+
+    const result = await cleanup.handler({ olderThan: '1d' }) as CleanupResult;
+
+    expect(result.candidates.stale).toBe(0);
+    expect(result.candidates.lowQuality).toBe(0);
+    expect(result.candidates.total).toBe(0);
+  });
+
+  it('still collects non-durable rows by age in the same call', async () => {
+    seed([
+      { key: 'decision', namespace: 'learnings' },
+      { key: 'chunk', namespace: 'code-map' },
+    ]);
+
+    const result = await cleanup.handler({ olderThan: '1d' }) as CleanupResult;
+
+    // Exactly one candidate, and it is the structural row.
+    expect(result.candidates.total).toBe(1);
+
+    const applied = await cleanup.handler({ olderThan: '1d', apply: true }) as CleanupResult;
+    expect(applied.deleted.entries).toBe(1);
+    expect(activeKeys()).toEqual(['decision']);
+  });
+
+  it('reports how many durable rows were held back', async () => {
+    seed([
+      { key: 'a', namespace: 'learnings' },
+      { key: 'b', namespace: 'learnings' },
+      { key: 'c', namespace: 'knowledge' },
+      { key: 'd', namespace: 'code-map' },
+    ]);
+
+    const result = await cleanup.handler({ olderThan: '1d' }) as CleanupResult;
+
+    // A row can match both age buckets; the count is of ROWS withheld, not of
+    // bucket matches, so all three durable rows count exactly once each.
+    expect(result.durableHeldBack).toBe(3);
+  });
+
+  it('counts nothing as held back when there is no durable row to withhold', async () => {
+    seed([{ key: 'd', namespace: 'code-map' }]);
+
+    const result = await cleanup.handler({ olderThan: '1d' }) as CleanupResult;
+
+    expect(result.durableHeldBack).toBe(0);
+  });
+
+  it('reports no held-back count when no age cutoff was given', async () => {
+    // Without `olderThan` the age buckets never run, so there is nothing to
+    // withhold and reporting a number would be misleading.
+    seed([{ key: 'a', namespace: 'learnings' }]);
+
+    const result = await cleanup.handler({}) as CleanupResult;
+
+    expect(result.candidates.total).toBe(0);
+    expect(result.durableHeldBack).toBe(0);
+  });
+
+  it('collects durable rows when the caller names the namespace explicitly', async () => {
+    seed([
+      { key: 'a', namespace: 'learnings' },
+      { key: 'b', namespace: 'learnings' },
+    ]);
+
+    const result = await cleanup.handler({ olderThan: '1d', namespace: 'learnings' }) as CleanupResult;
+
+    expect(result.candidates.total).toBe(2);
+    // The exemption is a default, so naming the namespace also means there is
+    // nothing left being withheld.
+    expect(result.durableHeldBack).toBe(0);
+
+    const applied = await cleanup.handler({ olderThan: '1d', namespace: 'learnings', apply: true }) as CleanupResult;
+    expect(applied.deleted.entries).toBe(2);
+    expect(activeKeys()).toEqual([]);
+  });
+
+  it('still collects TTL-expired rows in a durable namespace', async () => {
+    // A TTL is an explicit instruction from whoever wrote the row. The
+    // exemption covers the age heuristic, never an expiry the caller set.
+    seed([
+      { key: 'ephemeral', namespace: 'learnings', expiresAt: Date.now() - 60_000 },
+      { key: 'permanent', namespace: 'learnings' },
+    ]);
+
+    const result = await cleanup.handler({ olderThan: '1d' }) as CleanupResult;
+
+    expect(result.candidates.expired).toBe(1);
+    expect(result.candidates.stale).toBe(0);
+
+    const applied = await cleanup.handler({ olderThan: '1d', apply: true }) as CleanupResult;
+    expect(applied.deleted.entries).toBe(1);
+    expect(activeKeys()).toEqual(['permanent']);
+  });
+
+  it('exempts every namespace the durable list names', () => {
+    // The exemption is generated from DURABLE_NAMESPACES rather than a literal,
+    // so a namespace added to that list is covered without touching this file.
+    // Pinned so a silent narrowing of the list shows up here.
+    expect([...DURABLE_NAMESPACES].sort()).toEqual(['knowledge', 'learnings']);
+  });
+});

--- a/src/cli/__tests__/mcp-tools/memory-cleanup-durable-exemption-1464.test.ts
+++ b/src/cli/__tests__/mcp-tools/memory-cleanup-durable-exemption-1464.test.ts
@@ -208,6 +208,18 @@ describe('memory_cleanup durable exemption (#1464)', () => {
     expect(activeKeys()).toEqual(['permanent']);
   });
 
+  it('does not report a TTL-expired durable row as held back while deleting it', async () => {
+    // `lowQualityCond` does not test `expires_at`, so an expired durable row
+    // matches it — and would be counted as withheld in the same call that
+    // removes it through the expired bucket.
+    seed([{ key: 'ephemeral', namespace: 'learnings', expiresAt: Date.now() - 60_000 }]);
+
+    const result = await cleanup.handler({ olderThan: '1d' }) as CleanupResult;
+
+    expect(result.candidates.expired).toBe(1);
+    expect(result.durableHeldBack).toBe(0);
+  });
+
   it('exempts every namespace the durable list names', () => {
     // The exemption is generated from DURABLE_NAMESPACES rather than a literal,
     // so a namespace added to that list is covered without touching this file.

--- a/src/cli/__tests__/memory/search-access-recording-1464.test.ts
+++ b/src/cli/__tests__/memory/search-access-recording-1464.test.ts
@@ -29,7 +29,6 @@ import { DatabaseSync } from 'node:sqlite';
 
 import { _resetProjectRootForTest, shutdownBridge } from '../../memory/bridge-core.js';
 import { bridgeStoreEntry, bridgeSearchEntries } from '../../memory/memory-bridge.js';
-import { _resetSearchAccessForTest } from '../../memory/bridge-entries.js';
 
 /** Must match ACCESS_FLUSH_INTERVAL_MS in bridge-entries.ts. */
 const FLUSH_INTERVAL_MS = 30_000;
@@ -70,18 +69,17 @@ describe('search access recording (#1464)', () => {
     process.env.CLAUDE_PROJECT_DIR = tempDir;
     process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
 
+    // The throttle state is keyed by the database handle, so tearing the bridge
+    // down here is also what gives each case a clean flush stamp — there is no
+    // module-global to reset.
     await shutdownBridge();
     _resetProjectRootForTest();
-    // Module-level throttle state — without this each case inherits the
-    // previous one's flush stamp and its first search silently defers.
-    _resetSearchAccessForTest();
   });
 
   afterEach(async () => {
     vi.useRealTimers();
     await shutdownBridge();
     _resetProjectRootForTest();
-    _resetSearchAccessForTest();
     if (originalProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
     else process.env.CLAUDE_PROJECT_DIR = originalProjectDir;
     delete process.env.MOFLO_DISABLE_DAEMON_ROUTING;
@@ -161,6 +159,65 @@ describe('search access recording (#1464)', () => {
     expect(persisted('c', 'knowledge').count).toBe(1);
   });
 
+  it('never flushes one database\'s pending deltas into another', async () => {
+    // The deltas are entry ids, which only mean anything inside the store that
+    // issued them. Held module-globally they would be flushed against whatever
+    // database this process reached next — matching no row there, then cleared
+    // as though written. That is a silent loss of exactly the counts this
+    // feature exists to record.
+    await seed([{ key: 'decision', namespace: 'learnings' }]);
+    await search();
+    expect(persisted('decision', 'learnings').count).toBe(1);
+
+    // Accumulate a delta that is deliberately left unflushed.
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 1000);
+    await search();
+    expect(persisted('decision', 'learnings').count).toBe(1);
+
+    // A second store, reached by the same process well past the interval.
+    const otherDir = fs.mkdtempSync(path.join(tmpdir(), 'moflo-1464-other-'));
+    try {
+      fs.mkdirSync(path.join(otherDir, '.moflo'), { recursive: true });
+      vi.setSystemTime(Date.now() + FLUSH_INTERVAL_MS + 1);
+      process.env.CLAUDE_PROJECT_DIR = otherDir;
+      await shutdownBridge();
+      _resetProjectRootForTest();
+
+      await bridgeStoreEntry({ key: 'elsewhere', value: BODY, namespace: 'learnings', upsert: true });
+      await search();
+
+      // The other store recorded its own row, and the first store's pending
+      // delta was never spent against it.
+      const otherDb = new DatabaseSync(path.join(otherDir, '.moflo', 'moflo.db'), { readOnly: true });
+      try {
+        const row = otherDb.prepare(
+          'SELECT access_count FROM memory_entries WHERE key = ?',
+        ).get('elsewhere') as { access_count: number };
+        expect(Number(row.access_count)).toBe(1);
+      } finally {
+        otherDb.close();
+      }
+    } finally {
+      vi.useRealTimers();
+      process.env.CLAUDE_PROJECT_DIR = tempDir;
+      await shutdownBridge();
+      _resetProjectRootForTest();
+      fs.rmSync(otherDir, { recursive: true, force: true });
+    }
+
+    // Back at the first store, on a bridge handle rebuilt from scratch. Its one
+    // unflushed delta died with the old handle — the same bounded residual
+    // #1402 documents for a cache eviction, and the deliberate trade against
+    // spending it on a store where it means nothing. The new handle has never
+    // flushed, so this search writes immediately: 1 (first search) + 1 (this
+    // one) = 2. Held module-globally the count would instead read 1, because
+    // the flush against the other database would have cleared the delta and
+    // left a flush stamp in the future.
+    await search();
+    expect(persisted('decision', 'learnings').count).toBe(2);
+  });
+
   it('skips the bookkeeping entirely for a namespace-scoped structural search', async () => {
     await seed([
       { key: 'chunk', namespace: 'code-map' },
@@ -227,9 +284,14 @@ describe('#1058 regression guard — the read path never writes back a whole-DB 
     const src = read('../../memory/bridge-entries.ts');
     const start = src.indexOf('function recordSearchAccess');
     expect(start).toBeGreaterThan(-1);
-    const body = src.slice(start, src.indexOf('\nexport function _resetSearchAccessForTest', start));
+    const body = src.slice(start, src.indexOf('\nexport function serialiseMetadata', start));
 
-    expect(body).toMatch(/UPDATE memory_entries SET access_count = access_count \+ \?/);
+    // The statement it issues is shared with the entry-cache throttle and adds
+    // a delta to one row by id — bounded work, whatever the store's size.
+    expect(body).toMatch(/ACCESS_BUMP_SQL/);
+    expect(src).toMatch(
+      /const ACCESS_BUMP_SQL =\s*`UPDATE memory_entries SET access_count = access_count \+ \?/,
+    );
     expect(body).not.toMatch(/\.export\(\)|persistBridgeDb|atomicWriteFileSync/);
   });
 });

--- a/src/cli/__tests__/memory/search-access-recording-1464.test.ts
+++ b/src/cli/__tests__/memory/search-access-recording-1464.test.ts
@@ -1,0 +1,235 @@
+/**
+ * #1464 — `memory_search` records usage for the durable rows it returns.
+ *
+ * CLAUDE.md routes every prompt through `memory_search` before any other read,
+ * so search IS the read path for learnings. Until this change nothing on that
+ * path touched `access_count` / `last_accessed_at` — those moved only on
+ * retrieve-by-key — so the most-consulted learning in the store looked
+ * untouched since the day it was written, and `memory_cleanup`'s
+ * `COALESCE(last_accessed_at, updated_at, created_at)` heuristic collapsed to
+ * "old" for every row.
+ *
+ * The contract pinned here is the same one #1402 established for the entry
+ * cache: **defer writes, never lose counts**, and never let the read path take
+ * on an unbounded write obligation (#1058).
+ *
+ * Time is driven with `vi.setSystemTime`, never a real sleep — a 30s interval
+ * tested by sleeping would be both slow and exactly the flakiness vector
+ * CLAUDE.md's broken-window rule calls out.
+ *
+ * @module v3/cli/__tests__/memory/search-access-recording-1464
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+
+import { _resetProjectRootForTest, shutdownBridge } from '../../memory/bridge-core.js';
+import { bridgeStoreEntry, bridgeSearchEntries } from '../../memory/memory-bridge.js';
+import { _resetSearchAccessForTest } from '../../memory/bridge-entries.js';
+
+/** Must match ACCESS_FLUSH_INTERVAL_MS in bridge-entries.ts. */
+const FLUSH_INTERVAL_MS = 30_000;
+
+/** Shared body so BM25 scores every seeded row against the same probe query. */
+const BODY = 'reconcile durable learnings across worktrees';
+const PROBE = 'reconcile durable learnings';
+
+describe('search access recording (#1464)', () => {
+  let tempDir: string;
+  let dbPath: string;
+  let originalProjectDir: string | undefined;
+
+  /** Reads the PERSISTED counters, bypassing the bridge entirely. */
+  function persisted(key: string, namespace: string): { count: number; accessedAt: number | null } {
+    const probe = new DatabaseSync(dbPath, { readOnly: true });
+    try {
+      const row = probe.prepare(
+        'SELECT access_count, last_accessed_at FROM memory_entries WHERE key = ? AND namespace = ?',
+      ).get(key, namespace) as { access_count: number; last_accessed_at: number | null } | undefined;
+      if (!row) return { count: -1, accessedAt: null };
+      return { count: Number(row.access_count), accessedAt: row.last_accessed_at };
+    } finally {
+      probe.close();
+    }
+  }
+
+  async function search(namespace = 'all') {
+    return bridgeSearchEntries({ query: PROBE, namespace, limit: 10, threshold: 0.01 });
+  }
+
+  beforeEach(async () => {
+    tempDir = fs.mkdtempSync(path.join(tmpdir(), 'moflo-1464-'));
+    fs.mkdirSync(path.join(tempDir, '.moflo'), { recursive: true });
+    dbPath = path.join(tempDir, '.moflo', 'moflo.db');
+
+    originalProjectDir = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = tempDir;
+    process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
+
+    await shutdownBridge();
+    _resetProjectRootForTest();
+    // Module-level throttle state — without this each case inherits the
+    // previous one's flush stamp and its first search silently defers.
+    _resetSearchAccessForTest();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await shutdownBridge();
+    _resetProjectRootForTest();
+    _resetSearchAccessForTest();
+    if (originalProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = originalProjectDir;
+    delete process.env.MOFLO_DISABLE_DAEMON_ROUTING;
+    try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  async function seed(rows: Array<{ key: string; namespace: string }>): Promise<void> {
+    for (const r of rows) {
+      await bridgeStoreEntry({ key: r.key, value: BODY, namespace: r.namespace, upsert: true });
+    }
+  }
+
+  it('advances access_count and last_accessed_at for a returned learnings row', async () => {
+    await seed([{ key: 'decision', namespace: 'learnings' }]);
+    expect(persisted('decision', 'learnings')).toEqual({ count: 0, accessedAt: null });
+
+    const before = Date.now();
+    const result = await search();
+    expect(result?.results.some(r => r.key === 'decision')).toBe(true);
+
+    const after = persisted('decision', 'learnings');
+    expect(after.count).toBe(1);
+    expect(after.accessedAt).not.toBeNull();
+    expect(after.accessedAt!).toBeGreaterThanOrEqual(before);
+  });
+
+  it('records the knowledge namespace too, and leaves structural namespaces alone', async () => {
+    await seed([
+      { key: 'fact', namespace: 'knowledge' },
+      { key: 'chunk', namespace: 'code-map' },
+    ]);
+
+    const result = await search();
+    // Both rows must actually come back, or "not recorded" would be vacuous.
+    expect(result?.results.map(r => r.key).sort()).toEqual(['chunk', 'fact']);
+
+    expect(persisted('fact', 'knowledge').count).toBe(1);
+    // Structural namespaces are re-indexed wholesale; their usage counts are
+    // noise, and paying a write for them would tax the hot path for nothing.
+    expect(persisted('chunk', 'code-map')).toEqual({ count: 0, accessedAt: null });
+  });
+
+  it('coalesces a burst of searches into a single write, losing no counts', async () => {
+    await seed([{ key: 'decision', namespace: 'learnings' }]);
+
+    // First search flushes immediately (this process has never flushed) and
+    // starts the interval.
+    await search();
+    expect(persisted('decision', 'learnings').count).toBe(1);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 1000);
+
+    // Four more searches well inside the interval — none may write. This is the
+    // throttle assertion: the hot path must not issue a write per hit.
+    for (let i = 0; i < 4; i++) await search();
+    expect(persisted('decision', 'learnings').count).toBe(1);
+
+    // Cross the interval; the next search flushes all five deferred accesses
+    // (the four above plus its own) in one write.
+    vi.setSystemTime(Date.now() + FLUSH_INTERVAL_MS + 1);
+    await search();
+    expect(persisted('decision', 'learnings').count).toBe(6);
+  });
+
+  it('flushes every durable row of a result set in one pass', async () => {
+    await seed([
+      { key: 'a', namespace: 'learnings' },
+      { key: 'b', namespace: 'learnings' },
+      { key: 'c', namespace: 'knowledge' },
+    ]);
+
+    await search();
+
+    expect(persisted('a', 'learnings').count).toBe(1);
+    expect(persisted('b', 'learnings').count).toBe(1);
+    expect(persisted('c', 'knowledge').count).toBe(1);
+  });
+
+  it('skips the bookkeeping entirely for a namespace-scoped structural search', async () => {
+    await seed([
+      { key: 'chunk', namespace: 'code-map' },
+      { key: 'decision', namespace: 'learnings' },
+    ]);
+
+    const result = await search('code-map');
+    expect(result?.results.map(r => r.key)).toEqual(['chunk']);
+
+    expect(persisted('chunk', 'code-map').count).toBe(0);
+    // The durable row was never in this result set, so it must be untouched —
+    // and the flush stamp must not have been spent on an empty pass either.
+    expect(persisted('decision', 'learnings').count).toBe(0);
+
+    await search('learnings');
+    expect(persisted('decision', 'learnings').count).toBe(1);
+  });
+});
+
+describe('#1058 regression guard — the read path never writes back a whole-DB snapshot', () => {
+  /**
+   * Read a source file with its comments removed.
+   *
+   * The banned shapes are named verbatim in the very comments that explain why
+   * they are banned — `entries-read.ts` documents the `atomicWriteFileSync(dbPath,
+   * db.export())` it deleted. Matching raw text would force those explanations
+   * out of the codebase to keep the guard green, which is backwards: the rule is
+   * about executable code, so strip prose before matching rather than weaken the
+   * pattern or carve out an exemption.
+   *
+   * Block comments go first; then any line that is *entirely* a `//` comment —
+   * never a trailing one, so a `//` inside a string literal is left alone.
+   */
+  const read = (rel: string): string =>
+    fs.readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .filter(line => !line.trimStart().startsWith('//'))
+      .join('\n');
+
+  it('entries-read.ts issues no db.export() writeback', () => {
+    const src = read('../../memory/entries-read.ts');
+    // #1058: this path used to `UPDATE access_count` and then dump the entire
+    // DB back to disk, clobbering anything another process wrote in between.
+    // #1464 restores the counter bump — it must never restore the dump with it.
+    expect(src).not.toMatch(/\.export\(\)/);
+    expect(src).not.toMatch(/atomicWriteFileSync/);
+  });
+
+  it('bridgeSearchEntries issues no whole-DB persist', () => {
+    const src = read('../../memory/bridge-entries.ts');
+    const start = src.indexOf('export async function bridgeSearchEntries');
+    expect(start).toBeGreaterThan(-1);
+    const end = src.indexOf('\nexport ', start + 1);
+    const body = src.slice(start, end === -1 ? undefined : end);
+
+    expect(body).not.toMatch(/\.export\(\)/);
+    expect(body).not.toMatch(/persistBridgeDb|tryPersist|atomicWriteFileSync/);
+    // What it MAY do is a bounded per-row UPDATE via the throttle.
+    expect(body).toMatch(/recordSearchAccess\(/);
+  });
+
+  it('the search access flush is a bounded UPDATE, not a snapshot', () => {
+    const src = read('../../memory/bridge-entries.ts');
+    const start = src.indexOf('function recordSearchAccess');
+    expect(start).toBeGreaterThan(-1);
+    const body = src.slice(start, src.indexOf('\nexport function _resetSearchAccessForTest', start));
+
+    expect(body).toMatch(/UPDATE memory_entries SET access_count = access_count \+ \?/);
+    expect(body).not.toMatch(/\.export\(\)|persistBridgeDb|atomicWriteFileSync/);
+  });
+});

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -816,6 +816,12 @@ const cleanupCommand: Command = {
           lowQuality: number;
           total: number;
         };
+        /**
+         * Durable rows the age-based buckets skipped (#1464). Optional so a CLI
+         * running against an older MCP server that never sends it renders the
+         * same as "none held back" rather than "undefined".
+         */
+        durableHeldBack?: number;
         deleted: {
           entries: number;
         };
@@ -872,6 +878,20 @@ const cleanupCommand: Command = {
           { category: output.bold('Total'), count: output.bold(String(result.candidates.total)) }
         ]
       });
+
+      // #1464 — say what was withheld. A zero-candidate result on a store full
+      // of old learnings is otherwise read as "already tidy" when the truth is
+      // "durable entries were never examined".
+      if (result.durableHeldBack) {
+        output.writeln();
+        output.printInfo(
+          `${result.durableHeldBack} durable ${result.durableHeldBack === 1 ? 'entry' : 'entries'} `
+          + `(learnings, knowledge) held back — age is not evidence of staleness there.`
+        );
+        output.printList([
+          'Include them deliberately: flo memory cleanup --older-than <age> --namespace learnings',
+        ]);
+      }
 
       if (dryRun) return { success: true, data: result };
 

--- a/src/cli/mcp-tools/memory-admin-tools.ts
+++ b/src/cli/mcp-tools/memory-admin-tools.ts
@@ -26,6 +26,7 @@ import { BACKEND_LABEL } from '../memory/database-provider.js';
 import { ensureInitialized } from './memory-tools.js';
 import { memoryDbPath } from '../services/moflo-paths.js';
 import { resolveStateRoot } from '../services/project-root.js';
+import { DURABLE_NAMESPACES } from '../services/cherry-pick-learnings.js';
 
 interface ExportedEntry {
   key: string;
@@ -307,7 +308,7 @@ export const memoryAdminTools: MCPTool[] = [
   },
   {
     name: 'memory_cleanup',
-    description: 'Find and optionally delete expired, stale, or unusable memory entries',
+    description: 'Find and optionally delete expired, stale, or unusable memory entries. Durable namespaces (learnings, knowledge) are exempt from the age-based buckets unless named via `namespace`; TTL-expired rows are collected everywhere.',
     category: 'memory',
     inputSchema: {
       type: 'object',
@@ -316,7 +317,7 @@ export const memoryAdminTools: MCPTool[] = [
         dryRun: { type: 'boolean', description: 'Ignored. Cleanup is dry unless apply:true is passed; accepted only so older callers do not error.' },
         olderThan: { type: 'string', description: 'Age cutoff for stale/unusable entries, e.g. "30d"' },
         expiredOnly: { type: 'boolean', description: 'Only consider TTL-expired entries' },
-        namespace: { type: 'string', description: 'Restrict cleanup to one namespace' },
+        namespace: { type: 'string', description: 'Restrict cleanup to one namespace. Naming a durable namespace (learnings, knowledge) also opts it back into the age-based buckets it is exempt from by default.' },
       },
     },
     handler: async (input) => {
@@ -337,13 +338,30 @@ export const memoryAdminTools: MCPTool[] = [
       const select = (cond: string): string =>
         `SELECT key, namespace FROM memory_entries WHERE status = 'active' AND ${cond}${nsClause}`;
 
+      // #1464 — durable namespaces are exempt from the two AGE-based buckets
+      // unless the caller names one explicitly.
+      //
+      // Age is not evidence of worthlessness for a learning: a two-year-old
+      // architectural decision is routinely the most valuable row in the store.
+      // Worse, `COALESCE(last_accessed_at, updated_at, created_at)` collapses to
+      // `created_at` for any row nothing has ever bumped — and until #1464 the
+      // search path, which is how learnings are actually read, bumped nothing.
+      // So "stale (unused)" silently meant "old", and the only purge surface
+      // moflo ships hit the most-consulted learnings exactly as hard as the dead
+      // ones.
+      //
+      // A DEFAULT, not a prohibition — `--namespace learnings` still collects
+      // them. TTL-expired rows stay in scope in every namespace; durable rows
+      // never set a TTL, so nothing durable is lost through that bucket.
+      const exemptDurable = !namespace;
+      const durableIn = DURABLE_NAMESPACES.map(sqlString).join(', ');
+      const durableClause = exemptDurable ? ` AND namespace NOT IN (${durableIn})` : '';
+
       const expired = await query(select(`expires_at IS NOT NULL AND expires_at < ${now}`));
 
-      const stale = !expiredOnly && staleMs != null
-        ? await query(select(
-            `expires_at IS NULL AND COALESCE(last_accessed_at, updated_at, created_at) < ${now - staleMs}`
-          ))
-        : [];
+      const ageCutoff = staleMs != null ? now - staleMs : null;
+      const staleCond = ageCutoff == null ? null
+        : `expires_at IS NULL AND COALESCE(last_accessed_at, updated_at, created_at) < ${ageCutoff}`;
 
       // "Unusable" = no embedding (so invisible to semantic search), never
       // read back, AND older than the caller's cutoff.
@@ -354,12 +372,26 @@ export const memoryAdminTools: MCPTool[] = [
       // selected the entire store for deletion by default. Requiring an
       // explicit cutoff means an unqualified cleanup can only ever remove
       // TTL-expired rows.
-      const lowQuality = !expiredOnly && staleMs != null
-        ? await query(select(
-            `embedding IS NULL AND COALESCE(access_count, 0) = 0 ` +
-            `AND COALESCE(last_accessed_at, updated_at, created_at) < ${now - staleMs}`
-          ))
+      const lowQualityCond = ageCutoff == null ? null
+        : `embedding IS NULL AND COALESCE(access_count, 0) = 0 `
+          + `AND COALESCE(last_accessed_at, updated_at, created_at) < ${ageCutoff}`;
+
+      const ageBuckets = !expiredOnly && staleCond != null && lowQualityCond != null;
+
+      const stale = ageBuckets ? await query(select(staleCond + durableClause)) : [];
+      const lowQuality = ageBuckets ? await query(select(lowQualityCond + durableClause)) : [];
+
+      // Count what the exemption withheld. Without this the operator reads a
+      // clean result as "learnings are already tidy" rather than "learnings were
+      // not examined" — the same class of quiet lie the missing usage signal was.
+      const heldBackRows = ageBuckets && exemptDurable
+        ? await query(
+            `SELECT COUNT(*) FROM memory_entries WHERE status = 'active'`
+            + ` AND namespace IN (${durableIn})`
+            + ` AND ((${staleCond}) OR (${lowQualityCond}))`
+          )
         : [];
+      const durableHeldBack = heldBackRows.length ? Number(heldBackRows[0][0] ?? 0) : 0;
 
       const seen = new Set<string>();
       const targets: Array<{ key: string; namespace: string }> = [];
@@ -385,6 +417,7 @@ export const memoryAdminTools: MCPTool[] = [
         return {
           dryRun: true,
           candidates,
+          durableHeldBack,
           deleted: { entries: 0 },
           freed: { bytes: 0, formatted: '0 B' },
           duration: Date.now() - started,
@@ -403,6 +436,7 @@ export const memoryAdminTools: MCPTool[] = [
       return {
         dryRun: false,
         candidates,
+        durableHeldBack,
         deleted: { entries: deleted },
         freed: { bytes: freedBytes, formatted: formatBytes(freedBytes) },
         duration: Date.now() - started,

--- a/src/cli/mcp-tools/memory-admin-tools.ts
+++ b/src/cli/mcp-tools/memory-admin-tools.ts
@@ -384,10 +384,16 @@ export const memoryAdminTools: MCPTool[] = [
       // Count what the exemption withheld. Without this the operator reads a
       // clean result as "learnings are already tidy" rather than "learnings were
       // not examined" — the same class of quiet lie the missing usage signal was.
+      //
+      // The TTL exclusion is not cosmetic: `lowQualityCond` does not test
+      // `expires_at`, so without it a durable row with an elapsed TTL would be
+      // reported as held back in the same call that deletes it through the
+      // expired bucket.
       const heldBackRows = ageBuckets && exemptDurable
         ? await query(
             `SELECT COUNT(*) FROM memory_entries WHERE status = 'active'`
             + ` AND namespace IN (${durableIn})`
+            + ` AND NOT (expires_at IS NOT NULL AND expires_at < ${now})`
             + ` AND ((${staleCond}) OR (${lowQualityCond}))`
           )
         : [];

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -12,6 +12,7 @@ import { cosineSim, execRows, generateId, logBridgeError, persistBridgeDb, refre
 import { embeddingResponseFrom, getBridgeEmbedder, resolveBridgeEmbedding } from './bridge-embedder.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import { archiveDurableRow, isDurableNamespace } from '../services/durable-store-io.js';
+import type { SqlJsLikeDatabase } from './daemon-backend.js';
 
 /**
  * Run `persistBridgeDb` and convert any throw into a `persist failed:`
@@ -112,6 +113,101 @@ interface CachedEntryRecord extends CachedEntry {
  * trade; a systematic undercount of HOT keys — the #1396 defect — is not.
  */
 const ACCESS_FLUSH_INTERVAL_MS = 30_000;
+
+/**
+ * Deferred `access_count` deltas for rows returned by SEARCH, keyed by entry id.
+ *
+ * #1464 — `memory_search` is the read path for durable learnings (CLAUDE.md
+ * routes every prompt through it before any other read), but nothing on that
+ * path recorded usage: `access_count` / `last_accessed_at` moved only on
+ * retrieve-by-key. The most-consulted learning in the store looked untouched
+ * since the day it was written, which in turn made every age-based cleanup
+ * heuristic a guess dressed up as a measurement.
+ *
+ * Scoped to DURABLE namespaces on purpose. Structural namespaces (code-map,
+ * patterns, tests) are re-indexed wholesale on a schedule and their usage
+ * counts are noise — paying a write for them would tax the hot path to record
+ * nothing anyone reads.
+ *
+ * Same trade as the per-key entry-cache throttle above: defer writes, never
+ * lose counts. The flush stamp is GLOBAL rather than per key because a search
+ * touches a whole result set at once — the unit being coalesced here is the
+ * search, not the key.
+ */
+const pendingSearchAccess = new Map<string, number>();
+let lastSearchAccessFlushAt = 0;
+
+/**
+ * Hard bound on {@link pendingSearchAccess}. Durable namespaces are small, so
+ * this is a backstop rather than a working limit — but an unbounded map inside
+ * a daemon that lives for days is a leak regardless of how unlikely it is to
+ * fill. Reaching the cap forces a flush; it never drops deltas.
+ */
+const SEARCH_ACCESS_PENDING_CAP = 1_000;
+
+/**
+ * Accumulate one access per returned durable hit, flushing at most once per
+ * {@link ACCESS_FLUSH_INTERVAL_MS}.
+ *
+ * Best-effort by construction: a throw leaves the deltas pending for the next
+ * attempt and search results are returned either way. Usage is observability,
+ * not correctness — #1058 is the standing proof of what happens when the read
+ * path takes on a write obligation it cannot honour safely.
+ *
+ * The UPDATE adds the accumulated delta and is evaluated by SQLite, so the
+ * stored counter stays correct under concurrency and never depends on a
+ * client-computed absolute. It is a bounded per-row UPDATE — never a whole-DB
+ * `db.export()` writeback, which is the specific #1058 regression.
+ */
+function recordSearchAccess(
+  db: SqlJsLikeDatabase,
+  hits: ReadonlyArray<{ id: string; namespace: string }>,
+  now: number,
+): void {
+  for (const hit of hits) {
+    if (!isDurableNamespace(hit.namespace)) continue;
+    pendingSearchAccess.set(hit.id, (pendingSearchAccess.get(hit.id) ?? 0) + 1);
+  }
+  if (pendingSearchAccess.size === 0) return;
+
+  // A process that has never flushed writes immediately rather than waiting out
+  // the interval — moflo's CLI processes are short-lived and would otherwise
+  // exit with every access still pending, reintroducing the silent undercount
+  // this exists to remove.
+  const forced = pendingSearchAccess.size >= SEARCH_ACCESS_PENDING_CAP;
+  if (!forced && now - lastSearchAccessFlushAt < ACCESS_FLUSH_INTERVAL_MS) return;
+
+  try {
+    const stmt = db.prepare(
+      `UPDATE memory_entries SET access_count = access_count + ?, last_accessed_at = ? WHERE id = ?`,
+    );
+    db.run('BEGIN');
+    try {
+      for (const [id, delta] of pendingSearchAccess) stmt.run([delta, now, id]);
+      db.run('COMMIT');
+    } catch (err) {
+      try { db.run('ROLLBACK'); } catch { /* a failed COMMIT already ended the txn */ }
+      throw err;
+    }
+    // Clear ONLY after the commit lands. Clearing on a throw would discard the
+    // accumulated hits outright — the throttle defers writes, it does not drop
+    // them.
+    pendingSearchAccess.clear();
+    lastSearchAccessFlushAt = now;
+  } catch (err) {
+    logBridgeError('search access flush failed', err);
+  }
+}
+
+/**
+ * @internal Test hook — clears the deferred search-access state so each case
+ * starts from "this process has never flushed". Module-level state otherwise
+ * leaks the previous test's flush stamp into the next one's first search.
+ */
+export function _resetSearchAccessForTest(): void {
+  pendingSearchAccess.clear();
+  lastSearchAccessFlushAt = 0;
+}
 
 /** Normalise `metadata` for the `metadata` TEXT column; `undefined` → `'{}'` (#1064). */
 export function serialiseMetadata(metadata: Record<string, unknown> | string | undefined): string {
@@ -706,6 +802,15 @@ export async function bridgeSearchEntries(options: {
 
     const results: { id: string; key: string; content: string; score: number; namespace: string; provenance?: string; metadata?: string }[] = [];
 
+    // #1464 — usage recording needs the FULL row id; the emitted `id` above is
+    // truncated to 12 chars for the envelope and would match no row. Keyed by
+    // the result object rather than by index because `results` is sorted and
+    // sliced before the returned set is known. Never spread into the response.
+    const fullIdByResult = new Map<object, string>();
+    // A namespace-scoped search of a structural namespace can skip the
+    // bookkeeping entirely — nothing it returns is durable.
+    const trackAccess = namespace === 'all' || isDurableNamespace(namespace);
+
     for (const row of rows) {
       let semanticScore = 0;
       let bm25ScoreVal = 0;
@@ -735,7 +840,7 @@ export async function bridgeSearchEntries(options: {
 
         const metadataStr = row.metadata != null ? String(row.metadata) : undefined;
 
-        results.push({
+        const hit = {
           id: String(row.id).substring(0, 12),
           // The substring is a fallback id-prefix when key is missing —
           // applying it to the full expression truncates valid keys (#845).
@@ -745,15 +850,33 @@ export async function bridgeSearchEntries(options: {
           namespace: String(row.namespace || 'default'),
           provenance,
           metadata: metadataStr,
-        });
+        };
+        results.push(hit);
+        if (trackAccess) fullIdByResult.set(hit, String(row.id));
       }
     }
 
     results.sort((a, b) => b.score - a.score);
 
+    const returned = results.slice(0, limit);
+
+    // #1464 — record usage for the durable rows this search actually returned.
+    // Placed after the slice so an over-fetched candidate the caller never sees
+    // does not count as a read.
+    if (trackAccess) {
+      recordSearchAccess(
+        ctx.db,
+        returned.flatMap(r => {
+          const id = fullIdByResult.get(r);
+          return id ? [{ id, namespace: r.namespace }] : [];
+        }),
+        Date.now(),
+      );
+    }
+
     return {
       success: true,
-      results: results.slice(0, limit),
+      results: returned,
       searchTime: Date.now() - startTime,
       searchMethod: queryEmbedding ? 'hybrid-bm25-semantic' : 'bm25-only',
     };

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -115,7 +115,23 @@ interface CachedEntryRecord extends CachedEntry {
 const ACCESS_FLUSH_INTERVAL_MS = 30_000;
 
 /**
- * Deferred `access_count` deltas for rows returned by SEARCH, keyed by entry id.
+ * The access bump, shared by the two throttles that issue it. Adding the
+ * accumulated delta in SQL — rather than writing a client-computed absolute —
+ * is what keeps the counter correct under concurrency, so the statement is
+ * written once and reused rather than retyped per call site.
+ */
+const ACCESS_BUMP_SQL =
+  `UPDATE memory_entries SET access_count = access_count + ?, last_accessed_at = ? WHERE id = ?`;
+
+/** Deferred access deltas for one database handle. */
+interface SearchAccessState {
+  /** Entry id → accesses recorded but not yet written. */
+  deltas: Map<string, number>;
+  lastFlushAt: number;
+}
+
+/**
+ * Deferred `access_count` deltas for rows returned by SEARCH, per database.
  *
  * #1464 — `memory_search` is the read path for durable learnings (CLAUDE.md
  * routes every prompt through it before any other read), but nothing on that
@@ -129,16 +145,25 @@ const ACCESS_FLUSH_INTERVAL_MS = 30_000;
  * counts are noise — paying a write for them would tax the hot path to record
  * nothing anyone reads.
  *
- * Same trade as the per-key entry-cache throttle above: defer writes, never
- * lose counts. The flush stamp is GLOBAL rather than per key because a search
- * touches a whole result set at once — the unit being coalesced here is the
- * search, not the key.
+ * KEYED BY THE DATABASE HANDLE, not module-global. Entry ids are only
+ * meaningful inside the store that issued them, so a process that reaches a
+ * second database — a `dbPath` override, or a bridge rebuilt against a
+ * different project root — must not carry the first one's deltas across.
+ * Module-global state would flush ids that match nothing in the new store and
+ * then clear them, silently discarding counts against the "defer, never lose"
+ * rule below. A WeakMap also means a torn-down bridge's state is collected with
+ * its handle rather than accumulating for the life of the daemon, and each test
+ * gets clean state from its own database with no reset hook to remember.
+ *
+ * Same trade as the per-key entry-cache throttle below: defer writes, never
+ * lose counts. The flush stamp is per DATABASE rather than per key because a
+ * search touches a whole result set at once — the unit being coalesced here is
+ * the search, not the key.
  */
-const pendingSearchAccess = new Map<string, number>();
-let lastSearchAccessFlushAt = 0;
+const searchAccessByDb = new WeakMap<SqlJsLikeDatabase, SearchAccessState>();
 
 /**
- * Hard bound on {@link pendingSearchAccess}. Durable namespaces are small, so
+ * Hard bound on one database's pending deltas. Durable namespaces are small, so
  * this is a backstop rather than a working limit — but an unbounded map inside
  * a daemon that lives for days is a leak regardless of how unlikely it is to
  * fill. Reaching the cap forces a flush; it never drops deltas.
@@ -146,44 +171,49 @@ let lastSearchAccessFlushAt = 0;
 const SEARCH_ACCESS_PENDING_CAP = 1_000;
 
 /**
- * Accumulate one access per returned durable hit, flushing at most once per
+ * Accumulate one access per returned durable row, flushing at most once per
  * {@link ACCESS_FLUSH_INTERVAL_MS}.
+ *
+ * `ids` are already filtered to durable rows by the caller, which is also where
+ * the per-row namespace test happens — a structural hit never reaches this map.
+ * Call with an empty array to give a pending set its chance to flush.
  *
  * Best-effort by construction: a throw leaves the deltas pending for the next
  * attempt and search results are returned either way. Usage is observability,
  * not correctness — #1058 is the standing proof of what happens when the read
- * path takes on a write obligation it cannot honour safely.
- *
- * The UPDATE adds the accumulated delta and is evaluated by SQLite, so the
- * stored counter stays correct under concurrency and never depends on a
- * client-computed absolute. It is a bounded per-row UPDATE — never a whole-DB
- * `db.export()` writeback, which is the specific #1058 regression.
+ * path takes on a write obligation it cannot honour safely. What it issues is a
+ * bounded per-row UPDATE, never the whole-DB `db.export()` writeback that
+ * clobbered concurrent writers.
  */
 function recordSearchAccess(
   db: SqlJsLikeDatabase,
-  hits: ReadonlyArray<{ id: string; namespace: string }>,
+  ids: ReadonlyArray<string>,
   now: number,
 ): void {
-  for (const hit of hits) {
-    if (!isDurableNamespace(hit.namespace)) continue;
-    pendingSearchAccess.set(hit.id, (pendingSearchAccess.get(hit.id) ?? 0) + 1);
+  let state = searchAccessByDb.get(db);
+  if (!state) {
+    // Nothing to record and nothing pending — don't allocate state for a
+    // database whose searches never return a durable row.
+    if (ids.length === 0) return;
+    state = { deltas: new Map(), lastFlushAt: 0 };
+    searchAccessByDb.set(db, state);
   }
-  if (pendingSearchAccess.size === 0) return;
 
-  // A process that has never flushed writes immediately rather than waiting out
-  // the interval — moflo's CLI processes are short-lived and would otherwise
-  // exit with every access still pending, reintroducing the silent undercount
-  // this exists to remove.
-  const forced = pendingSearchAccess.size >= SEARCH_ACCESS_PENDING_CAP;
-  if (!forced && now - lastSearchAccessFlushAt < ACCESS_FLUSH_INTERVAL_MS) return;
+  for (const id of ids) state.deltas.set(id, (state.deltas.get(id) ?? 0) + 1);
+  if (state.deltas.size === 0) return;
+
+  // A database this process has never flushed writes immediately rather than
+  // waiting out the interval — moflo's CLI processes are short-lived and would
+  // otherwise exit with every access still pending, reintroducing the silent
+  // undercount this exists to remove.
+  const forced = state.deltas.size >= SEARCH_ACCESS_PENDING_CAP;
+  if (!forced && now - state.lastFlushAt < ACCESS_FLUSH_INTERVAL_MS) return;
 
   try {
-    const stmt = db.prepare(
-      `UPDATE memory_entries SET access_count = access_count + ?, last_accessed_at = ? WHERE id = ?`,
-    );
+    const stmt = db.prepare(ACCESS_BUMP_SQL);
     db.run('BEGIN');
     try {
-      for (const [id, delta] of pendingSearchAccess) stmt.run([delta, now, id]);
+      for (const [id, delta] of state.deltas) stmt.run([delta, now, id]);
       db.run('COMMIT');
     } catch (err) {
       try { db.run('ROLLBACK'); } catch { /* a failed COMMIT already ended the txn */ }
@@ -192,21 +222,11 @@ function recordSearchAccess(
     // Clear ONLY after the commit lands. Clearing on a throw would discard the
     // accumulated hits outright — the throttle defers writes, it does not drop
     // them.
-    pendingSearchAccess.clear();
-    lastSearchAccessFlushAt = now;
+    state.deltas.clear();
+    state.lastFlushAt = now;
   } catch (err) {
     logBridgeError('search access flush failed', err);
   }
-}
-
-/**
- * @internal Test hook — clears the deferred search-access state so each case
- * starts from "this process has never flushed". Module-level state otherwise
- * leaks the previous test's flush stamp into the next one's first search.
- */
-export function _resetSearchAccessForTest(): void {
-  pendingSearchAccess.clear();
-  lastSearchAccessFlushAt = 0;
 }
 
 /** Normalise `metadata` for the `metadata` TEXT column; `undefined` → `'{}'` (#1064). */
@@ -806,10 +826,12 @@ export async function bridgeSearchEntries(options: {
     // truncated to 12 chars for the envelope and would match no row. Keyed by
     // the result object rather than by index because `results` is sorted and
     // sliced before the returned set is known. Never spread into the response.
-    const fullIdByResult = new Map<object, string>();
-    // A namespace-scoped search of a structural namespace can skip the
-    // bookkeeping entirely — nothing it returns is durable.
-    const trackAccess = namespace === 'all' || isDurableNamespace(namespace);
+    //
+    // Null for a namespace-scoped search of a structural namespace: nothing it
+    // returns can be durable, so it skips the bookkeeping outright rather than
+    // testing every row against a set that will never match.
+    const durableIdByResult: Map<object, string> | null =
+      namespace === 'all' || isDurableNamespace(namespace) ? new Map() : null;
 
     for (const row of rows) {
       let semanticScore = 0;
@@ -852,7 +874,12 @@ export async function bridgeSearchEntries(options: {
           metadata: metadataStr,
         };
         results.push(hit);
-        if (trackAccess) fullIdByResult.set(hit, String(row.id));
+        // Per row, not per search: an `all`-namespace search returns mostly
+        // structural hits, and storing an id only to discard it at flush time
+        // is work every prompt in every consumer project would pay.
+        if (durableIdByResult && isDurableNamespace(hit.namespace)) {
+          durableIdByResult.set(hit, String(row.id));
+        }
       }
     }
 
@@ -862,16 +889,15 @@ export async function bridgeSearchEntries(options: {
 
     // #1464 — record usage for the durable rows this search actually returned.
     // Placed after the slice so an over-fetched candidate the caller never sees
-    // does not count as a read.
-    if (trackAccess) {
-      recordSearchAccess(
-        ctx.db,
-        returned.flatMap(r => {
-          const id = fullIdByResult.get(r);
-          return id ? [{ id, namespace: r.namespace }] : [];
-        }),
-        Date.now(),
-      );
+    // does not count as a read. Called even when this search returned none, so
+    // a set left pending by an earlier search still gets its flush.
+    if (durableIdByResult) {
+      const durableIds: string[] = [];
+      for (const r of returned) {
+        const id = durableIdByResult.get(r);
+        if (id) durableIds.push(id);
+      }
+      recordSearchAccess(ctx.db, durableIds, Date.now());
     }
 
     return {
@@ -1038,9 +1064,8 @@ export async function bridgeGetEntry(options: {
       const lastFlushAt = cached.lastAccessFlushAt ?? 0;
       if (now - lastFlushAt >= ACCESS_FLUSH_INTERVAL_MS) {
         try {
-          ctx.db.prepare(
-            `UPDATE memory_entries SET access_count = access_count + ?, last_accessed_at = ? WHERE id = ?`,
-          ).run([cached.pendingAccessDelta, now, String(cached.id || '')]);
+          ctx.db.prepare(ACCESS_BUMP_SQL)
+            .run([cached.pendingAccessDelta, now, String(cached.id || '')]);
           // Clear ONLY after the write lands. Clearing on a throw would discard
           // the accumulated hits outright — the throttle defers writes, it does
           // not drop them.


### PR DESCRIPTION
Closes #1464.

Two coupled defects made `flo memory cleanup --older-than` dangerous for durable
learnings: nothing recorded usage on the path learnings are actually read
through, and cleanup applied its age heuristic to every namespace. Together,
`--older-than 30d` deleted durable learnings by age, hitting the most-consulted
ones exactly as hard as the dead ones.

## Search recorded no usage

`access_count` / `last_accessed_at` moved only on retrieve-by-key. But CLAUDE.md
routes every prompt through `memory_search` before any other read, so search
**is** the read path for learnings — the most-consulted row in the store looked
untouched since the day it was written.

`bridgeSearchEntries` now accumulates one access per returned durable row and
flushes them in a single batched `UPDATE` at most once per 30s, reusing the
defer-never-drop shape #1402 established for the entry cache. Specifics:

- **Durable namespaces only.** Structural namespaces are re-indexed wholesale on
  a schedule; their usage counts are noise, and paying a write for them would tax
  the hot path to record nothing anyone reads. The filter is per row, so an
  `all`-namespace search never stores an id it will discard at flush time, and a
  namespace-scoped structural search skips the bookkeeping entirely.
- **Keyed by the database handle**, not module-global. Entry ids only mean
  something inside the store that issued them; module-global state would flush
  one store's ids against another, match nothing, and clear them — a silent loss
  of exactly the counts this records. A `WeakMap` also collects a torn-down
  bridge's state with its handle rather than growing for the life of a daemon.
- **Never a whole-DB writeback.** #1058 removed a read path that dumped the
  entire database to disk to bump a counter, clobbering concurrent writers. This
  restores the counter without restoring the dump — three guards pin that.
- A store this process has never flushed writes immediately, so short-lived CLI
  processes do not exit with every access still pending.

## Cleanup applied age to durable namespaces

With no usage signal, `COALESCE(last_accessed_at, updated_at, created_at)`
collapses to `created_at` for essentially every learning, so "stale (unused)"
silently meant "old". Age is not evidence of worthlessness for a durable row — a
two-year-old architectural decision is routinely the most valuable entry in the
store.

Both age-based buckets now skip `DURABLE_NAMESPACES` by default. It is a
default, not a prohibition: `--namespace learnings` still collects them. The TTL
bucket is untouched everywhere, since an expiry is an explicit instruction from
whoever wrote the row. `memory_cleanup` returns `durableHeldBack` and the CLI
prints it with the remedy, so a clean result is not misread as "learnings are
already tidy" when the truth is "learnings were never examined".

## Consumer surface

`memory_search`'s bridge read path (executed on every prompt in every consumer
project), the `memory_cleanup` MCP tool, and `flo memory cleanup`.

**Failure mode for a consumer upgrading from 4.12.11: none.** The change only
*narrows* what cleanup deletes and adds a write that was previously absent.
Existing `.moflo/` state parses unchanged, no migration, hooks wire identically.
An older CLI against a newer server ignores the new field; a newer CLI against an
older server renders the absent field as "nothing held back", never `undefined` —
both directions are covered by tests.

**Round-trip cost:** runtime layer — takes effect after publish + reinstall +
Claude Code restart, not from the source edit.

## Cross-platform (Rule #1)

No paths, shell-outs, or process introspection added. The time-sensitive
behaviour is driven with `vi.setSystemTime`, never a sleep, so a 30s interval
cannot flake on a slower macOS or Windows runner; test databases use
`os.tmpdir()` + `path.join`, with `realpathSync` on both sides where a handler
and its assertions must agree on the same file.

## Verification

`/verify` PASS on all 7 acceptance criteria at `786ad509b`, 22 tests
re-executed against a clean tree. Full suite green (11,043 passing). One scope
note recorded: usage recording lives on the bridge search path — what
`memory_search` reaches in every configuration that has a bridge, directly or
inside the daemon when routed. The degraded no-bridge fallback in
`entries-read.ts` deliberately still records nothing, because that path is where
#1058's writeback-clobber lived.

Review findings from the simplify pass were fixed in `c7aca787f` (the
module-global state, the per-row filter, the duplicated `UPDATE` statement).

## Drive-by fixes

- `durableHeldBack` counted a TTL-expired durable row as withheld in the same
  call that deleted it through the expired bucket — `lowQualityCond` does not
  test `expires_at`. Excluded, with a test that discriminates.

## Not in this PR

`tests/system/hnsw-sidecar-concurrent-writers-1388.test.ts` fails ~2 in 10 runs
with `SQLITE_BUSY` from `PRAGMA journal_mode = WAL`. Unrelated to this change —
that test never touches the search path — and reproducible on `main`. Filed as
#1471 rather than fixed here: different subsystem, needs its own concurrency
test, and it changes the database-open chokepoint every moflo process goes
through.