### PR TITLE
fix(memory): moflodb_batch false success (#1465) + concurrent WAL-conversion race (#1471)

### DIFF
--- a/.claude/scripts/lib/get-backend.mjs
+++ b/.claude/scripts/lib/get-backend.mjs
@@ -163,8 +163,10 @@ function openNodeSqlite(dbPath, opts) {
       // background indexer holds a write lock for 5–8s during its first
       // full-tree pass after `npm install`. See daemon-backend.ts twin for
       // the full rationale (#1098).
-      db.exec('PRAGMA busy_timeout = 15000');
-      db.exec('PRAGMA journal_mode = WAL');
+      db.exec(`PRAGMA busy_timeout = ${OPEN_BUSY_TIMEOUT_MS}`);
+      // Not `db.exec` directly: SQLite skips the busy handler for a
+      // journal-mode change, so this one pragma needs its own retry (#1471).
+      setWalWithRetry(db, dbPath);
       db.exec('PRAGMA synchronous = NORMAL');
       // Phase 4 / #1083 — network-FS detection. SQLite's POSIX advisory locks
       // and WAL shared-memory both fail silently on NFS/SMB; the engine falls
@@ -177,6 +179,148 @@ function openNodeSqlite(dbPath, opts) {
     }
   }
   return wrapNodeSqlite(db, dbPath);
+}
+
+/**
+ * Shared parking buffer for the journal-mode retry sleep. `Atomics.wait` is
+ * the only synchronous sleep that behaves identically on Linux, macOS and
+ * Windows without shelling out (Rule #1), and this open path is synchronous.
+ */
+const WAL_SLEEP_BUF = new Int32Array(new SharedArrayBuffer(4));
+
+/** @param {number} ms */
+function sleepMs(ms) {
+  Atomics.wait(WAL_SLEEP_BUF, 0, 0, ms);
+}
+
+/**
+ * The open-path `busy_timeout`. Named because two places depend on it being
+ * the same number: the pragma below sets it, and `readJournalModeBounded`
+ * restores it after narrowing it for a probe.
+ */
+const OPEN_BUSY_TIMEOUT_MS = 15_000;
+/**
+ * Budget for the post-exhaustion probe. The query form of `PRAGMA
+ * journal_mode` takes a SHARED lock and IS covered by the busy handler, so it
+ * would otherwise inherit the full `OPEN_BUSY_TIMEOUT_MS` — doubling the
+ * worst case to ~30s before we report anything on the one path where we have
+ * already decided to give up.
+ */
+const WAL_PROBE_BUSY_TIMEOUT_MS = 500;
+const WAL_PROBE_ATTEMPTS = 3;
+/** See the daemon-backend.ts twin for the budget rationale (#1471). */
+const WAL_RETRY_BUDGET_MS = OPEN_BUSY_TIMEOUT_MS;
+const WAL_RETRY_MIN_DELAY_MS = 5;
+const WAL_RETRY_MAX_DELAY_MS = 250;
+
+/**
+ * SQLITE_BUSY (5) and SQLITE_LOCKED (6). The message test is a fallback for
+ * wrappers that don't propagate `errcode`.
+ *
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+function isBusyError(err) {
+  const e = /** @type {{ errcode?: number, message?: string } | null} */ (err);
+  if (e?.errcode === 5 || e?.errcode === 6) return true;
+  return /database( table)? is locked/i.test(String(e?.message ?? ''));
+}
+
+/**
+ * Current journal mode, lowercased. `''` when the probe itself fails.
+ *
+ * @param {object} db
+ * @returns {string}
+ */
+function readJournalMode(db) {
+  try {
+    const row = db.prepare('PRAGMA journal_mode').get();
+    return String(row?.journal_mode ?? '').toLowerCase();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * `readJournalMode` under a deliberately narrow busy budget, restoring the
+ * open-path budget afterwards so a caller that survives keeps the connection
+ * it asked for. Only ever called once the retry budget is already spent.
+ *
+ * @param {object} db
+ * @returns {string}
+ */
+function readJournalModeBounded(db) {
+  try {
+    try {
+      db.exec(`PRAGMA busy_timeout = ${WAL_PROBE_BUSY_TIMEOUT_MS}`);
+    } catch {
+      // Non-fatal: we still probe, just without the narrower budget.
+    }
+    for (let attempt = 0; attempt < WAL_PROBE_ATTEMPTS; attempt++) {
+      const mode = readJournalMode(db);
+      if (mode) return mode;
+    }
+    return '';
+  } finally {
+    try {
+      db.exec(`PRAGMA busy_timeout = ${OPEN_BUSY_TIMEOUT_MS}`);
+    } catch {
+      // Non-fatal: the handle is still usable, and every path out of here
+      // either throws or hands back a database that is already in WAL.
+    }
+  }
+}
+
+/**
+ * Run `PRAGMA journal_mode = WAL`, retrying on contention (#1471).
+ *
+ * `busy_timeout` is set first and covers every other statement, but SQLite
+ * does NOT invoke the busy handler for a journal-mode change — so the one
+ * pragma the budget was put there for never gets it, and concurrent
+ * first-opens of a fresh database threw `SQLITE_BUSY` immediately, killing
+ * whichever process lost the race. On a database already in WAL the pragma is
+ * a no-op taking no exclusive lock, so the common path never enters the loop.
+ *
+ * Twin: `src/cli/memory/daemon-backend.ts:setWalWithRetry`. Keep in lockstep.
+ *
+ * @param {object} db node:sqlite DatabaseSync handle (or a test fake)
+ * @param {string} dbPath
+ * @param {number} [budgetMs]
+ */
+export function setWalWithRetry(db, dbPath, budgetMs = WAL_RETRY_BUDGET_MS) {
+  let lastErr = null;
+  let waited = 0;
+  let delay = WAL_RETRY_MIN_DELAY_MS;
+
+  for (;;) {
+    try {
+      db.exec('PRAGMA journal_mode = WAL');
+      return;
+    } catch (err) {
+      lastErr = err;
+      // Anything that isn't contention — a corrupt file, a read-only mount —
+      // will not clear by waiting. Surface it now rather than after 15s.
+      if (!isBusyError(err)) throw err;
+    }
+    if (waited >= budgetMs) break;
+    const nap = Math.min(delay, budgetMs - waited);
+    sleepMs(nap);
+    waited += nap;
+    delay = Math.min(delay * 2, WAL_RETRY_MAX_DELAY_MS);
+  }
+
+  // Budget spent. Another opener may have completed the conversion while we
+  // were losing races — the database being in WAL is the outcome we wanted,
+  // whichever process got it there.
+  const mode = readJournalModeBounded(db);
+  if (mode === 'wal') return;
+
+  throw new Error(
+    `[moflo] PRAGMA journal_mode = WAL stayed busy for ${waited}ms on ${dbPath} ` +
+    `(journal_mode is still "${mode || 'unreadable'}"). Another process is holding an ` +
+    `exclusive lock on the database. Original error: ${String(lastErr?.message ?? lastErr)}`,
+    { cause: lastErr },
+  );
 }
 
 /**
@@ -196,16 +340,10 @@ function openNodeSqlite(dbPath, opts) {
  */
 export function warnIfNotWal(db, dbPath) {
   if (_networkFsWarnedPaths.has(dbPath)) return;
-  let mode;
-  try {
-    const stmt = db.prepare('PRAGMA journal_mode');
-    const row = stmt.get();
-    mode = String(row?.journal_mode ?? '').toLowerCase();
-  } catch {
-    // Probe must never break the open path — silent failure is acceptable
-    // because the WAL pragma above already either took effect or didn't.
-    return;
-  }
+  // A probe that throws yields '' and falls through the guard below without
+  // warning — the WAL pragma above either took effect or didn't, and a failed
+  // read is not evidence either way.
+  const mode = readJournalMode(db);
   if (mode && mode !== 'wal') {
     _networkFsWarnedPaths.add(dbPath);
     process.stderr.write(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — concurrent first-open of a database no longer dies on `journal_mode = WAL`
+
+`openDaemonDatabase` sets `PRAGMA busy_timeout = 15000` *before* `PRAGMA journal_mode = WAL`
+specifically so concurrent openers survive the brief EXCLUSIVE lock the conversion takes. That
+ordering is correct but insufficient: SQLite does not invoke the busy handler for a journal-mode
+change, so the retry budget never applied to the one statement it was put there for. Whichever
+processes lost a first-open race threw `SQLITE_BUSY` immediately and died — and the daemon, the MCP
+server and a foreground `flo` command opening the same `.moflo/moflo.db` at session start is the
+ordinary consumer configuration, not a test contrivance. On a fresh install that open *is* the
+conversion.
+
+The journal-mode pragma now retries on contention under its own bounded budget (exponential backoff
+to a 15s ceiling, matching `busy_timeout`), treats "another process already converted it" as the
+success it is, and on exhaustion throws an error naming the database, the wait, and the mode it is
+stuck in. `busy_timeout` is unchanged and still correct for every other statement. Both hand-
+maintained factory twins are fixed — `src/cli/memory/daemon-backend.ts` (daemon, MCP server) and
+`bin/lib/get-backend.mjs` (hooks, indexer, every `bin/*` entry point) — and a shared test drives
+both through the same cases so a one-sided fix fails in CI.
+
+A database already in WAL pays nothing: the pragma is a no-op that takes no exclusive lock, so the
+first attempt succeeds and the retry loop never runs.
+
+**Consumer impact.** None to opt into — a hard throw becomes a bounded retry. No `.moflo/` state
+change, no migration, no hook rewiring. Takes effect after publish + reinstall, since the daemon,
+MCP server and hooks all run from `node_modules/moflo/`. (#1471)
+
+
 ### Removed — `moflodb_batch` no longer accepts `delete` or `update`
 
 Both reported `{success: true}` with a non-zero count and changed nothing the caller could address.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed — `moflodb_batch` no longer accepts `delete` or `update`
+
+Both reported `{success: true}` with a non-zero count and changed nothing the caller could address.
+The count was the length of the input array, never rows affected, and the tool's `inputSchema` has
+no `namespace` property — so the operations targeted the `episodes` store and could not reach a
+namespaced `memory_entries` row at all. A maintenance operation that reports success while doing
+nothing is worse than an absent one: there is no signal to retry on, which is why the drift in
+#1463 went unnoticed for weeks.
+
+`moflodb_batch` now advertises `enum: ['insert']` and rejects the two removed operations at the
+tool boundary, naming the tool that does the job — `memory_delete` (with an explicit namespace) for
+removal, `memory_store` for overwrite. `insert` is unchanged except that its `count` now reports
+rows the store actually wrote. A guard test over the bridge handlers fails any mutation count
+derived from input length.
+
+**Consumer impact.** None behavioural — any caller passing `delete`/`update` today is already
+getting a silent no-op, so no working behaviour is removed; they now get an actionable error
+instead of a false success. No `.moflo/` state migration and no hook rewiring. Takes effect after
+publish + reinstall, since the MCP server runs from `node_modules/moflo/`. (#1465)
+
+
 ### Fixed — the no-durable-lesson escape could report success on a write that never landed
 
 `writeState` swallows its own errors so a gate never crashes the hook it runs in. That is right for

--- a/bin/lib/get-backend.mjs
+++ b/bin/lib/get-backend.mjs
@@ -163,8 +163,10 @@ function openNodeSqlite(dbPath, opts) {
       // background indexer holds a write lock for 5–8s during its first
       // full-tree pass after `npm install`. See daemon-backend.ts twin for
       // the full rationale (#1098).
-      db.exec('PRAGMA busy_timeout = 15000');
-      db.exec('PRAGMA journal_mode = WAL');
+      db.exec(`PRAGMA busy_timeout = ${OPEN_BUSY_TIMEOUT_MS}`);
+      // Not `db.exec` directly: SQLite skips the busy handler for a
+      // journal-mode change, so this one pragma needs its own retry (#1471).
+      setWalWithRetry(db, dbPath);
       db.exec('PRAGMA synchronous = NORMAL');
       // Phase 4 / #1083 — network-FS detection. SQLite's POSIX advisory locks
       // and WAL shared-memory both fail silently on NFS/SMB; the engine falls
@@ -177,6 +179,148 @@ function openNodeSqlite(dbPath, opts) {
     }
   }
   return wrapNodeSqlite(db, dbPath);
+}
+
+/**
+ * Shared parking buffer for the journal-mode retry sleep. `Atomics.wait` is
+ * the only synchronous sleep that behaves identically on Linux, macOS and
+ * Windows without shelling out (Rule #1), and this open path is synchronous.
+ */
+const WAL_SLEEP_BUF = new Int32Array(new SharedArrayBuffer(4));
+
+/** @param {number} ms */
+function sleepMs(ms) {
+  Atomics.wait(WAL_SLEEP_BUF, 0, 0, ms);
+}
+
+/**
+ * The open-path `busy_timeout`. Named because two places depend on it being
+ * the same number: the pragma below sets it, and `readJournalModeBounded`
+ * restores it after narrowing it for a probe.
+ */
+const OPEN_BUSY_TIMEOUT_MS = 15_000;
+/**
+ * Budget for the post-exhaustion probe. The query form of `PRAGMA
+ * journal_mode` takes a SHARED lock and IS covered by the busy handler, so it
+ * would otherwise inherit the full `OPEN_BUSY_TIMEOUT_MS` — doubling the
+ * worst case to ~30s before we report anything on the one path where we have
+ * already decided to give up.
+ */
+const WAL_PROBE_BUSY_TIMEOUT_MS = 500;
+const WAL_PROBE_ATTEMPTS = 3;
+/** See the daemon-backend.ts twin for the budget rationale (#1471). */
+const WAL_RETRY_BUDGET_MS = OPEN_BUSY_TIMEOUT_MS;
+const WAL_RETRY_MIN_DELAY_MS = 5;
+const WAL_RETRY_MAX_DELAY_MS = 250;
+
+/**
+ * SQLITE_BUSY (5) and SQLITE_LOCKED (6). The message test is a fallback for
+ * wrappers that don't propagate `errcode`.
+ *
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+function isBusyError(err) {
+  const e = /** @type {{ errcode?: number, message?: string } | null} */ (err);
+  if (e?.errcode === 5 || e?.errcode === 6) return true;
+  return /database( table)? is locked/i.test(String(e?.message ?? ''));
+}
+
+/**
+ * Current journal mode, lowercased. `''` when the probe itself fails.
+ *
+ * @param {object} db
+ * @returns {string}
+ */
+function readJournalMode(db) {
+  try {
+    const row = db.prepare('PRAGMA journal_mode').get();
+    return String(row?.journal_mode ?? '').toLowerCase();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * `readJournalMode` under a deliberately narrow busy budget, restoring the
+ * open-path budget afterwards so a caller that survives keeps the connection
+ * it asked for. Only ever called once the retry budget is already spent.
+ *
+ * @param {object} db
+ * @returns {string}
+ */
+function readJournalModeBounded(db) {
+  try {
+    try {
+      db.exec(`PRAGMA busy_timeout = ${WAL_PROBE_BUSY_TIMEOUT_MS}`);
+    } catch {
+      // Non-fatal: we still probe, just without the narrower budget.
+    }
+    for (let attempt = 0; attempt < WAL_PROBE_ATTEMPTS; attempt++) {
+      const mode = readJournalMode(db);
+      if (mode) return mode;
+    }
+    return '';
+  } finally {
+    try {
+      db.exec(`PRAGMA busy_timeout = ${OPEN_BUSY_TIMEOUT_MS}`);
+    } catch {
+      // Non-fatal: the handle is still usable, and every path out of here
+      // either throws or hands back a database that is already in WAL.
+    }
+  }
+}
+
+/**
+ * Run `PRAGMA journal_mode = WAL`, retrying on contention (#1471).
+ *
+ * `busy_timeout` is set first and covers every other statement, but SQLite
+ * does NOT invoke the busy handler for a journal-mode change — so the one
+ * pragma the budget was put there for never gets it, and concurrent
+ * first-opens of a fresh database threw `SQLITE_BUSY` immediately, killing
+ * whichever process lost the race. On a database already in WAL the pragma is
+ * a no-op taking no exclusive lock, so the common path never enters the loop.
+ *
+ * Twin: `src/cli/memory/daemon-backend.ts:setWalWithRetry`. Keep in lockstep.
+ *
+ * @param {object} db node:sqlite DatabaseSync handle (or a test fake)
+ * @param {string} dbPath
+ * @param {number} [budgetMs]
+ */
+export function setWalWithRetry(db, dbPath, budgetMs = WAL_RETRY_BUDGET_MS) {
+  let lastErr = null;
+  let waited = 0;
+  let delay = WAL_RETRY_MIN_DELAY_MS;
+
+  for (;;) {
+    try {
+      db.exec('PRAGMA journal_mode = WAL');
+      return;
+    } catch (err) {
+      lastErr = err;
+      // Anything that isn't contention — a corrupt file, a read-only mount —
+      // will not clear by waiting. Surface it now rather than after 15s.
+      if (!isBusyError(err)) throw err;
+    }
+    if (waited >= budgetMs) break;
+    const nap = Math.min(delay, budgetMs - waited);
+    sleepMs(nap);
+    waited += nap;
+    delay = Math.min(delay * 2, WAL_RETRY_MAX_DELAY_MS);
+  }
+
+  // Budget spent. Another opener may have completed the conversion while we
+  // were losing races — the database being in WAL is the outcome we wanted,
+  // whichever process got it there.
+  const mode = readJournalModeBounded(db);
+  if (mode === 'wal') return;
+
+  throw new Error(
+    `[moflo] PRAGMA journal_mode = WAL stayed busy for ${waited}ms on ${dbPath} ` +
+    `(journal_mode is still "${mode || 'unreadable'}"). Another process is holding an ` +
+    `exclusive lock on the database. Original error: ${String(lastErr?.message ?? lastErr)}`,
+    { cause: lastErr },
+  );
 }
 
 /**
@@ -196,16 +340,10 @@ function openNodeSqlite(dbPath, opts) {
  */
 export function warnIfNotWal(db, dbPath) {
   if (_networkFsWarnedPaths.has(dbPath)) return;
-  let mode;
-  try {
-    const stmt = db.prepare('PRAGMA journal_mode');
-    const row = stmt.get();
-    mode = String(row?.journal_mode ?? '').toLowerCase();
-  } catch {
-    // Probe must never break the open path — silent failure is acceptable
-    // because the WAL pragma above already either took effect or didn't.
-    return;
-  }
+  // A probe that throws yields '' and falls through the guard below without
+  // warning — the WAL pragma above either took effect or didn't, and a failed
+  // read is not evidence either way.
+  const mode = readJournalMode(db);
   if (mode && mode !== 'wal') {
     _networkFsWarnedPaths.add(dbPath);
     process.stderr.write(

--- a/docs/memory-stack-audit-consumer-surface.md
+++ b/docs/memory-stack-audit-consumer-surface.md
@@ -79,8 +79,10 @@ Removal safety assessment: Moderate risk with clear mitigation path.
 - Fallback: If unavailable, returns error
 - Verdict: Safe to remove.
 
-#### 13. batchOperations (Bulk insert/update/delete)
-- memory-bridge methods: bridgeBatchOperation() line 1732-1770
+#### 13. batchOperations (Bulk insert)
+- memory-bridge methods: bridgeBatchOperation() — insert only; the `update` and
+  `delete` operations were removed in #1465 (they reported success while
+  changing nothing addressable by the caller)
 - Fallback: If unavailable, returns error
 - Verdict: Safe to remove.
 

--- a/src/cli/__tests__/mcp-tools-deep.test.ts
+++ b/src/cli/__tests__/mcp-tools-deep.test.ts
@@ -690,6 +690,44 @@ describe('MCP Tools Deep Test Suite', () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain('Invalid operation');
     });
+
+    // #1465 — both operations used to return `{success: true}` with a count
+    // equal to `entries.length` while changing nothing the caller could
+    // address. They are rejected at the tool boundary now, so the redirect
+    // holds even where the bridge is mocked or unavailable.
+    it('moflodb_batch rejects delete and points at memory_delete', async () => {
+      const tool = moflodbTools.find(t => t.name === 'moflodb_batch')!;
+      const result: any = await tool.handler({ operation: 'delete', entries: [{ key: 'k' }] });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('memory_delete');
+    });
+
+    it('moflodb_batch rejects update and points at memory_store', async () => {
+      const tool = moflodbTools.find(t => t.name === 'moflodb_batch')!;
+      const result: any = await tool.handler({ operation: 'update', entries: [{ key: 'k', value: 'v' }] });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('memory_store');
+    });
+
+    // A prototype-chain lookup would make these truthy and return an `error`
+    // that is a function — which JSON.stringify drops, so the caller sees a
+    // failure with no message at all.
+    it.each(['constructor', 'toString', '__proto__', 'valueOf', 'hasOwnProperty'])(
+      'moflodb_batch rejects inherited key %s with a real message',
+      async (operation) => {
+        const tool = moflodbTools.find(t => t.name === 'moflodb_batch')!;
+        const result: any = await tool.handler({ operation, entries: [{ key: 'k' }] });
+        expect(result.success).toBe(false);
+        expect(typeof result.error).toBe('string');
+        expect(result.error).toContain('Invalid operation');
+      },
+    );
+
+    it('moflodb_batch advertises only insert in its schema', () => {
+      const tool = moflodbTools.find(t => t.name === 'moflodb_batch')!;
+      const operation = (tool.inputSchema as any).properties.operation;
+      expect(operation.enum).toEqual(['insert']);
+    });
   });
 
   // --------------------------------------------------------------------------

--- a/src/cli/__tests__/mcp-tools-drift-guard.test.ts
+++ b/src/cli/__tests__/mcp-tools-drift-guard.test.ts
@@ -53,7 +53,7 @@ const ALLOWLIST: Record<string, string> = {
   'moflodb_hierarchical-store': 'expert API: hierarchical memory write',
   'moflodb_hierarchical-recall': 'expert API: hierarchical memory read',
   'moflodb_consolidate': 'expert API: EWC++ consolidation',
-  'moflodb_batch': 'expert API: batch ops on the bridge',
+  'moflodb_batch': 'expert API: batch insert on the bridge',
   'moflodb_context-synthesize': 'expert API: context synthesis',
   'moflodb_semantic-route': 'expert API: semantic routing',
 

--- a/src/cli/__tests__/memory/wal-retry-1471.test.ts
+++ b/src/cli/__tests__/memory/wal-retry-1471.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit coverage for the `PRAGMA journal_mode = WAL` retry (#1471).
+ *
+ * `openDaemonDatabase` sets `busy_timeout` before the WAL pragma so concurrent
+ * openers survive the brief EXCLUSIVE lock the conversion takes. That ordering
+ * is correct but insufficient: SQLite does not invoke the busy handler for a
+ * journal-mode change, so the one statement the budget was put there for never
+ * gets it, and the losers of a first-open race threw `SQLITE_BUSY` outright.
+ *
+ * The retry lives in two hand-maintained twins — the TS factory the daemon and
+ * MCP server use, and the `.mjs` factory `bin/*` uses. Every case below runs
+ * against BOTH, so a fix applied to one and forgotten in the other fails here
+ * rather than in a consumer's CI. Behavioural lockstep, not a text-diff guard:
+ * the twins are allowed to differ in style, never in what they do.
+ *
+ * Cross-platform: no filesystem, no subprocesses, no real SQLite — the fake
+ * below drives the retry directly, so this file behaves identically on all
+ * three platforms. The real cross-process proof is
+ * `tests/system/daemon-open-concurrent-wal-1471.test.ts`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { setWalWithRetry as setWalTs } from '../../memory/daemon-backend.js';
+// @ts-expect-error — plain .mjs twin, no type declarations by design.
+import { setWalWithRetry as setWalMjs } from '../../../../bin/lib/get-backend.mjs';
+
+type SetWal = (db: unknown, dbPath: string, budgetMs?: number) => void;
+
+const IMPLEMENTATIONS: Array<[string, SetWal]> = [
+  ['daemon-backend.ts', setWalTs as unknown as SetWal],
+  ['bin/lib/get-backend.mjs', setWalMjs as SetWal],
+];
+
+function busyError(withErrcode = true): Error {
+  const err = new Error('database is locked');
+  if (withErrcode) Object.assign(err, { errcode: 5, errstr: 'database is locked' });
+  return err;
+}
+
+interface FakeOpts {
+  busyCount: number;
+  mode?: string;
+  error?: Error;
+  /** The `PRAGMA journal_mode` read itself fails — a busy probe, not a mode. */
+  probeThrows?: boolean;
+}
+
+/**
+ * Minimal stand-in for a node:sqlite handle. `busyCount` conversion failures,
+ * then success; `mode` is what a `PRAGMA journal_mode` read reports.
+ *
+ * Only the conversion statement can fail: a `busy_timeout` pragma takes no
+ * lock and never contends, and counting those as attempts would make the
+ * retry assertions below measure the wrong thing.
+ */
+function fakeDb(opts: FakeOpts = { busyCount: 0 }) {
+  const state = { execCalls: 0, probeCalls: 0, sqls: [] as string[] };
+  return {
+    state,
+    exec(sql: string): void {
+      state.sqls.push(sql);
+      if (!/journal_mode\s*=/.test(sql)) return;
+      state.execCalls++;
+      if (state.execCalls <= opts.busyCount) throw opts.error ?? busyError();
+    },
+    prepare(_sql: string) {
+      return {
+        get() {
+          state.probeCalls++;
+          if (opts.probeThrows) throw busyError();
+          return { journal_mode: opts.mode ?? 'delete' };
+        },
+      };
+    },
+  };
+}
+
+describe.each(IMPLEMENTATIONS)('setWalWithRetry — %s (#1471)', (_name, setWal) => {
+  it('converts on the first attempt when nothing is contending', () => {
+    // The common path — including every open of an already-WAL database, where
+    // the pragma is a no-op that takes no exclusive lock. It must cost exactly
+    // one statement and zero sleeps, or the fix would tax every process start.
+    const db = fakeDb({ busyCount: 0, mode: 'wal' });
+    const before = Date.now();
+    setWal(db, '/tmp/moflo.db');
+    expect(db.state.execCalls).toBe(1);
+    expect(db.state.probeCalls).toBe(0);
+    expect(Date.now() - before).toBeLessThan(200);
+  });
+
+  it('retries past a transient SQLITE_BUSY and succeeds', () => {
+    const db = fakeDb({ busyCount: 2, mode: 'wal' });
+    setWal(db, '/tmp/moflo.db');
+    expect(db.state.execCalls).toBe(3);
+  });
+
+  it('recognises a busy error that carries no errcode', () => {
+    // Some wrappers surface the sqlite message without the numeric code.
+    const db = fakeDb({ busyCount: 1, mode: 'wal', error: busyError(false) });
+    setWal(db, '/tmp/moflo.db');
+    expect(db.state.execCalls).toBe(2);
+  });
+
+  it('treats "another process already converted it" as success, not failure', () => {
+    // Losing every race is the expected outcome for the last of N openers.
+    // The database being in WAL is what we wanted; who got it there is not
+    // the caller's business.
+    const db = fakeDb({ busyCount: Number.MAX_SAFE_INTEGER, mode: 'wal' });
+    expect(() => setWal(db, '/tmp/moflo.db', 40)).not.toThrow();
+    expect(db.state.probeCalls).toBe(1);
+  });
+
+  it('surfaces a diagnosable error when the budget is exhausted and WAL never took', () => {
+    const db = fakeDb({ busyCount: Number.MAX_SAFE_INTEGER, mode: 'delete' });
+    let thrown: Error | null = null;
+    try {
+      setWal(db, '/tmp/project/.moflo/moflo.db', 40);
+    } catch (err) {
+      thrown = err as Error;
+    }
+    expect(thrown).not.toBeNull();
+    // Diagnosable means: which database, how long we waited, what mode it is
+    // stuck in, and the original engine error — not a bare "failed".
+    expect(thrown!.message).toContain('/tmp/project/.moflo/moflo.db');
+    expect(thrown!.message).toContain('journal_mode');
+    expect(thrown!.message).toContain('delete');
+    expect(thrown!.message).toContain('database is locked');
+    expect(thrown!.cause).toBeInstanceOf(Error);
+  });
+
+  it('bounds the wait at the budget rather than retrying forever', () => {
+    const db = fakeDb({ busyCount: Number.MAX_SAFE_INTEGER, mode: 'delete' });
+    const before = Date.now();
+    expect(() => setWal(db, '/tmp/moflo.db', 60)).toThrow();
+    // Generous upper bound: the assertion under test is termination, not
+    // timer precision — a CI runner's scheduler can oversleep every nap.
+    expect(Date.now() - before).toBeLessThan(5000);
+  });
+
+  it('narrows the busy budget for the post-exhaustion probe and restores it', () => {
+    // The query form of `PRAGMA journal_mode` takes a shared lock and IS
+    // covered by the busy handler, so left alone it would inherit the open
+    // path's 15s budget and double the worst-case wait — on the one path
+    // where we have already decided to give up. Narrow it, then put it back:
+    // a caller that survives the probe keeps the connection it asked for.
+    const db = fakeDb({ busyCount: Number.MAX_SAFE_INTEGER, mode: 'wal' });
+    setWal(db, '/tmp/moflo.db', 40);
+    const budgets = db.state.sqls.filter((sql) => /busy_timeout/.test(sql));
+    expect(budgets[0]).toContain('500');
+    expect(budgets[budgets.length - 1]).toContain('15000');
+  });
+
+  it('retries the probe before declaring the mode unreadable', () => {
+    // A probe that loses one more race is not evidence the conversion failed.
+    const db = fakeDb({ busyCount: Number.MAX_SAFE_INTEGER, probeThrows: true });
+    expect(() => setWal(db, '/tmp/moflo.db', 40)).toThrow(/unreadable/);
+    expect(db.state.probeCalls).toBe(3);
+  });
+
+  it('rethrows a non-contention error immediately without spending the budget', () => {
+    // A corrupt file or a read-only mount will not clear by waiting. Burning
+    // 15s before reporting it would turn a clear failure into a hang.
+    const corrupt = Object.assign(new Error('file is not a database'), { errcode: 26 });
+    const db = fakeDb({ busyCount: Number.MAX_SAFE_INTEGER, error: corrupt });
+    expect(() => setWal(db, '/tmp/moflo.db')).toThrow('file is not a database');
+    expect(db.state.execCalls).toBe(1);
+  });
+});

--- a/src/cli/mcp-tools/moflodb-tools.ts
+++ b/src/cli/mcp-tools/moflodb-tools.ts
@@ -441,18 +441,40 @@ export const moflodbConsolidate: MCPTool = {
   },
 };
 
-// ===== moflodb_batch — Batch operations (insert, update, delete) =====
+// ===== moflodb_batch — Batch insert into the episodes store =====
+
+/**
+ * `update` and `delete` were removed in #1465 — both reported `success: true`
+ * with a count taken from the input array while changing nothing the caller
+ * could address. Rejected here, at the tool boundary, naming the tool that
+ * does the job.
+ *
+ * A Map, not an object literal: `operation` is caller-controlled, and a plain
+ * object would resolve 'constructor'/'toString'/'__proto__' up the prototype
+ * chain to a truthy function, returning an error whose message JSON-serializes
+ * to nothing.
+ */
+const REMOVED_BATCH_OPERATIONS = new Map<string, string>([
+  [
+    'delete',
+    "moflodb_batch no longer supports 'delete' (#1465): it targeted the episodes store and could not address a namespaced memory entry, while reporting success. Use memory_delete with an explicit namespace.",
+  ],
+  [
+    'update',
+    "moflodb_batch no longer supports 'update' (#1465): it targeted the episodes store and could not address a namespaced memory entry, while reporting success. Use memory_store to overwrite an entry.",
+  ],
+]);
 
 export const moflodbBatch: MCPTool = {
   name: 'moflodb_batch',
-  description: 'Batch operations on memory entries (insert, update, delete)',
+  description: 'Batch-insert episodes into the MofloDb bridge store. Use memory_delete to remove entries and memory_store to overwrite them.',
   inputSchema: {
     type: 'object',
     properties: {
       operation: {
         type: 'string',
-        description: 'Batch operation type',
-        enum: ['insert', 'update', 'delete'],
+        description: "Batch operation type. Only 'insert' is supported; 'update'/'delete' were removed in #1465.",
+        enum: ['insert'],
       },
       entries: {
         type: 'array',
@@ -473,8 +495,10 @@ export const moflodbBatch: MCPTool = {
     try {
       const operation = validateString(params.operation, 'operation', 20);
       if (!operation) return { success: false, error: 'operation is required (string)' };
-      if (!['insert', 'update', 'delete'].includes(operation)) {
-        return { success: false, error: `Invalid operation: ${operation}. Must be insert, update, or delete` };
+      const removed = REMOVED_BATCH_OPERATIONS.get(operation);
+      if (removed) return { success: false, error: removed };
+      if (operation !== 'insert') {
+        return { success: false, error: `Invalid operation: ${operation}. Must be insert` };
       }
       if (!Array.isArray(params.entries) || params.entries.length === 0) {
         return { success: false, error: 'entries is required (non-empty array)' };

--- a/src/cli/memory/controllers/batch-operations.ts
+++ b/src/cli/memory/controllers/batch-operations.ts
@@ -6,8 +6,13 @@
  *
  * Consumer surface (from src/cli/memory/memory-bridge.ts):
  *   - insertEpisodes([{content, metadata?, embedding?}])
- *   - bulkDelete(table, conditions)
- *   - bulkUpdate(table, updates, conditions)
+ *
+ * bulkDelete/bulkUpdate remain here — they report rows actually affected and
+ * are covered by this controller's tests — but #1465 removed their only
+ * caller. `moflodb_batch` routed them at the `episodes` store through a schema
+ * with no `namespace`, so they could not address a caller's `memory_entries`
+ * row; entry deletion belongs to `memory_delete`. Do not re-wire a bridge
+ * operation to them without a namespace-aware target.
  *
  * Only the `episodes` table is whitelisted for delete/update to keep the
  * SQL surface narrow; attempts to target any other table throw.

--- a/src/cli/memory/daemon-backend.ts
+++ b/src/cli/memory/daemon-backend.ts
@@ -206,6 +206,163 @@ function wrapStatement(stmt: StatementSync): SqlJsLikeStatement {
 const _networkFsWarnedPaths = new Set<string>();
 
 /**
+ * Shared parking buffer for the journal-mode retry sleep. `Atomics.wait` is
+ * the only synchronous sleep that works identically on Linux, macOS and
+ * Windows without shelling out (Rule #1) — and this open path is synchronous,
+ * so there is no `await` to hand the thread back with.
+ */
+const WAL_SLEEP_BUF = new Int32Array(new SharedArrayBuffer(4));
+
+function sleepMs(ms: number): void {
+  Atomics.wait(WAL_SLEEP_BUF, 0, 0, ms);
+}
+
+/**
+ * The open-path `busy_timeout`. Named because two places depend on it being
+ * the same number: the pragma below sets it, and `readJournalModeBounded`
+ * restores it after narrowing it for a probe.
+ */
+const OPEN_BUSY_TIMEOUT_MS = 15_000;
+/**
+ * Budget for the post-exhaustion probe. The query form of `PRAGMA
+ * journal_mode` takes a SHARED lock and IS covered by the busy handler, so it
+ * would otherwise inherit the full `OPEN_BUSY_TIMEOUT_MS` — doubling the
+ * worst case to ~30s before we report anything on the one path where we have
+ * already decided to give up. A few short attempts distinguish "genuinely not
+ * WAL" from "probe lost one more race" without reopening that window.
+ */
+const WAL_PROBE_BUSY_TIMEOUT_MS = 500;
+const WAL_PROBE_ATTEMPTS = 3;
+/**
+ * Total time `setWalWithRetry` will spend losing the conversion race before it
+ * gives up. Matched to `busy_timeout` (15000ms) on purpose: the two cover the
+ * same worst case — a background indexer holding a write lock through its
+ * whole first full-tree pass — and diverging budgets would mean the pragma
+ * that needs the wait most gets the shortest one. Being wrong-high costs one
+ * slow open in a rare race; being wrong-low kills the process outright.
+ */
+const WAL_RETRY_BUDGET_MS = OPEN_BUSY_TIMEOUT_MS;
+/** Backoff bounds: start tight (most races clear in a few ms), cap so a long
+ *  hold is still polled often enough to return promptly once it releases. */
+const WAL_RETRY_MIN_DELAY_MS = 5;
+const WAL_RETRY_MAX_DELAY_MS = 250;
+
+/** The pragma target, duck-typed so tests can drive the retry with a fake. */
+interface WalPragmaTarget {
+  exec(sql: string): unknown;
+  prepare(sql: string): { get(): unknown };
+}
+
+/**
+ * SQLITE_BUSY (5) and SQLITE_LOCKED (6) — the two contention codes. The
+ * message test is a fallback for wrappers that don't propagate `errcode`.
+ */
+function isBusyError(err: unknown): boolean {
+  const e = err as { errcode?: number; message?: string } | null;
+  if (e?.errcode === 5 || e?.errcode === 6) return true;
+  return /database( table)? is locked/i.test(String(e?.message ?? ''));
+}
+
+/** Current journal mode, lowercased. `''` when the probe itself fails. */
+function readJournalMode(db: WalPragmaTarget): string {
+  try {
+    const row = db.prepare('PRAGMA journal_mode').get() as { journal_mode?: string } | undefined;
+    return String(row?.journal_mode ?? '').toLowerCase();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * `readJournalMode` under a deliberately narrow busy budget, restoring the
+ * open-path budget afterwards so a caller that survives keeps the connection
+ * it asked for. Only ever called once the retry budget is already spent.
+ */
+function readJournalModeBounded(db: WalPragmaTarget): string {
+  try {
+    try {
+      db.exec(`PRAGMA busy_timeout = ${WAL_PROBE_BUSY_TIMEOUT_MS}`);
+    } catch {
+      // Non-fatal: we still probe, just without the narrower budget.
+    }
+    for (let attempt = 0; attempt < WAL_PROBE_ATTEMPTS; attempt++) {
+      const mode = readJournalMode(db);
+      if (mode) return mode;
+    }
+    return '';
+  } finally {
+    try {
+      db.exec(`PRAGMA busy_timeout = ${OPEN_BUSY_TIMEOUT_MS}`);
+    } catch {
+      // Non-fatal: the handle is still usable, and every path out of here
+      // either throws or hands back a database that is already in WAL.
+    }
+  }
+}
+
+/**
+ * Run `PRAGMA journal_mode = WAL`, retrying on contention (#1471).
+ *
+ * `busy_timeout` is set first and covers every other statement, but SQLite
+ * does **not** invoke the busy handler for a journal-mode change — so the one
+ * pragma the budget was put there for never gets it. Concurrent first-opens
+ * of a fresh database therefore threw `SQLITE_BUSY` immediately and killed
+ * whichever process lost the race: the daemon, the MCP server and a
+ * foreground `flo` command starting together is the ordinary consumer
+ * configuration, not a test artifact.
+ *
+ * Note the common path pays nothing: on a database already in WAL the pragma
+ * is a no-op that takes no exclusive lock, so the first attempt succeeds with
+ * no sleep and the loop below never runs.
+ *
+ * Twin: `bin/lib/get-backend.mjs:setWalWithRetry`. Must stay in lockstep until
+ * Phase 5 (#1084) extracts a shared module.
+ *
+ * @internal exported for tests — `budgetMs` lets them exercise exhaustion
+ *           without spending the real 15s.
+ */
+export function setWalWithRetry(
+  db: WalPragmaTarget,
+  dbPath: string,
+  budgetMs: number = WAL_RETRY_BUDGET_MS,
+): void {
+  let lastErr: unknown = null;
+  let waited = 0;
+  let delay = WAL_RETRY_MIN_DELAY_MS;
+
+  for (;;) {
+    try {
+      db.exec('PRAGMA journal_mode = WAL');
+      return;
+    } catch (err) {
+      lastErr = err;
+      // Anything that isn't contention — a corrupt file, a read-only mount —
+      // will not clear by waiting. Surface it now rather than after 15s.
+      if (!isBusyError(err)) throw err;
+    }
+    if (waited >= budgetMs) break;
+    const nap = Math.min(delay, budgetMs - waited);
+    sleepMs(nap);
+    waited += nap;
+    delay = Math.min(delay * 2, WAL_RETRY_MAX_DELAY_MS);
+  }
+
+  // Budget spent. Another opener may have completed the conversion while we
+  // were losing races — the database being in WAL is the outcome we wanted,
+  // whichever process got it there.
+  const mode = readJournalModeBounded(db);
+  if (mode === 'wal') return;
+
+  throw new Error(
+    `[moflo] PRAGMA journal_mode = WAL stayed busy for ${waited}ms on ${dbPath} ` +
+    `(journal_mode is still "${mode || 'unreadable'}"). Another process is holding an ` +
+    `exclusive lock on the database. Original error: ` +
+    `${String((lastErr as Error | null)?.message ?? lastErr)}`,
+    { cause: lastErr },
+  );
+}
+
+/**
  * Read `journal_mode` back after we requested WAL. If the engine returned a
  * different mode (`delete`, `truncate`, `persist`, `memory`, `off`), the
  * underlying filesystem doesn't support WAL's shared-memory sidecar — a
@@ -218,14 +375,10 @@ const _networkFsWarnedPaths = new Set<string>();
  */
 function warnIfNotWal(db: DatabaseSync, dbPath: string): void {
   if (_networkFsWarnedPaths.has(dbPath)) return;
-  let mode: string | undefined;
-  try {
-    const stmt = db.prepare('PRAGMA journal_mode');
-    const row = stmt.get() as { journal_mode?: string } | undefined;
-    mode = String(row?.journal_mode ?? '').toLowerCase();
-  } catch {
-    return;
-  }
+  // A probe that throws yields '' and falls through the guard below without
+  // warning — the WAL pragma above either took effect or didn't, and a failed
+  // read is not evidence either way.
+  const mode = readJournalMode(db);
   if (mode && mode !== 'wal') {
     _networkFsWarnedPaths.add(dbPath);
     process.stderr.write(
@@ -333,8 +486,10 @@ export function openDaemonDatabase(dbPath: string): SqlJsLikeDatabase {
       // (#1098); 15000ms gives the indexer's full first-pass time to finish
       // before doctor's probe gives up. The price of being wrong-high here
       // is one slow probe per session, not lost data.
-      db.exec('PRAGMA busy_timeout = 15000');
-      db.exec('PRAGMA journal_mode = WAL');
+      db.exec(`PRAGMA busy_timeout = ${OPEN_BUSY_TIMEOUT_MS}`);
+      // Not `db.exec` directly: SQLite skips the busy handler for a
+      // journal-mode change, so this one pragma needs its own retry (#1471).
+      setWalWithRetry(db, dbPath);
       db.exec('PRAGMA synchronous = NORMAL');
       // The daemon is the process most exposed to network-FS edge cases
       // (long-lived MCP server, ~30s of writes per indexer pass). NFS/SMB

--- a/src/cli/memory/memory-bridge.ts
+++ b/src/cli/memory/memory-bridge.ts
@@ -620,38 +620,49 @@ export async function bridgeConsolidate(_params: { minAge?: number; maxEntries?:
   } catch (e: any) { return { success: false, error: e.message }; }
 }
 
+/**
+ * Operations removed in #1465. Both wrote to the `episodes` store via a schema
+ * with no `namespace`, so neither could address a `memory_entries` row the
+ * caller had stored — yet both reported `success: true` with a count taken
+ * from the input array. Callers are redirected to the tools that work.
+ *
+ * A Map, not an object literal: `operation` is caller-controlled, and a plain
+ * object would resolve 'constructor'/'toString'/'__proto__' up the prototype
+ * chain to a truthy function.
+ */
+const BATCH_OPERATION_REDIRECTS = new Map<string, string>([
+  [
+    'delete',
+    "moflodb_batch no longer supports 'delete' (#1465): it targeted the episodes store and could not address a namespaced memory entry, while reporting success. Use memory_delete with an explicit namespace.",
+  ],
+  [
+    'update',
+    "moflodb_batch no longer supports 'update' (#1465): it targeted the episodes store and could not address a namespaced memory entry, while reporting success. Use memory_store to overwrite an entry.",
+  ],
+]);
+
 export async function bridgeBatchOperation(params: { operation: string; entries: any[] }): Promise<any> {
+  // Rejected before the registry lookup so a removed operation reports the
+  // same error whether or not the bridge happens to be available.
+  const redirect = BATCH_OPERATION_REDIRECTS.get(params.operation);
+  if (redirect) return { success: false, error: redirect };
+  if (params.operation !== 'insert') {
+    return { success: false, error: `Unknown operation: ${params.operation}` };
+  }
   const registry = await getRegistry();
   if (!registry) return null;
   try {
     const batch = registry.get('batchOperations');
     if (!batch) return { success: false, error: 'BatchOperations not available' };
-    let result;
-    switch (params.operation) {
-      case 'insert': {
-        const episodes = params.entries.map((e: any) => ({
-          content: e.value || e.content || JSON.stringify(e),
-          metadata: e.metadata || { key: e.key },
-        }));
-        result = await batch.insertEpisodes(episodes);
-        break;
-      }
-      case 'delete': {
-        const keys = params.entries.map((e: any) => e.key).filter(Boolean);
-        for (const key of keys) await batch.bulkDelete('episodes', { key });
-        result = { deleted: keys.length };
-        break;
-      }
-      case 'update': {
-        for (const entry of params.entries) {
-          await batch.bulkUpdate('episodes', { content: entry.value || entry.content }, { key: entry.key });
-        }
-        result = { updated: params.entries.length };
-        break;
-      }
-      default: return { success: false, error: `Unknown operation: ${params.operation}` };
-    }
-    return { success: true, operation: params.operation, count: params.entries.length, result };
+    const episodes = params.entries.map((e: any) => ({
+      content: e.value || e.content || JSON.stringify(e),
+      metadata: e.metadata || { key: e.key },
+    }));
+    // `count` reports rows the store actually wrote, never `entries.length` —
+    // an input-derived count is how #1465's delete/update reported success
+    // while changing nothing.
+    const result = await batch.insertEpisodes(episodes);
+    return { success: true, operation: 'insert', count: result.inserted, result };
   } catch (e: any) { return { success: false, error: e.message }; }
 }
 

--- a/tests/guards/bridge-mutation-count-guard.test.ts
+++ b/tests/guards/bridge-mutation-count-guard.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Structural guard: a memory-bridge mutation must never report a row count
+ * taken from the length of its own input.
+ *
+ * This is the exact defect #1465 removed. `bridgeBatchOperation`'s `delete`
+ * and `update` branches called the controller in a loop, threw the controller's
+ * real result away, and returned `{ deleted: keys.length }` /
+ * `{ updated: params.entries.length }` — a number that equals what the caller
+ * passed in, whether or not a single row changed. Both were then wrapped as
+ * `{ success: true, ... }`, so a no-op was indistinguishable from a write.
+ *
+ * That matters more than an ordinary wrong number. A mutation that reports
+ * success while changing nothing is worse than one that is simply absent: the
+ * caller has no signal to retry on, and the drift goes unnoticed. It is the
+ * same failure shape as the artifact-sync bugs in #1463.
+ *
+ * The controllers themselves are honest — `BatchOperations.bulkDelete` brackets
+ * the statement with `COUNT(*)` and returns the real difference, because sql.js
+ * exposes no affected-rows API. The bug was entirely in the bridge discarding
+ * that answer. So this guard watches the bridge, which is where a future loop-
+ * and-count-the-inputs shortcut would reappear.
+ *
+ * Scope note: only *mutation* counts are matched. A read path that reports
+ * `count: keys.length` after listing keys is correct — there the input array
+ * IS the answer. Widening this guard to those would need an allowlist, and an
+ * allowlist would outlive the reasoning behind each entry.
+ *
+ * If this goes RED: return the count the store reported (`result.inserted`,
+ * `result.deleted`, …), not the length of the array you passed it. If the
+ * underlying call cannot report rows affected, that is the thing to fix.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { REPO_ROOT } from './_helpers/eslint-harness.js';
+
+const BRIDGE_PATH = join(REPO_ROOT, 'src', 'cli', 'memory', 'memory-bridge.ts');
+
+/**
+ * Field names that denote "rows the store actually changed". `count` is
+ * included because it is the field #1465's wrapper lied through.
+ */
+const MUTATION_COUNT_FIELDS = ['count', 'deleted', 'updated', 'inserted', 'affected', 'removed'];
+
+/**
+ * `<field>: <anything>.length` — an object literal reporting a mutation count
+ * straight from an array's length. Covers `keys.length`,
+ * `params.entries.length`, and `entries[0].items.length` alike.
+ */
+const INPUT_DERIVED_COUNT = new RegExp(
+  String.raw`\b(${MUTATION_COUNT_FIELDS.join('|')})\s*:\s*[A-Za-z_$][\w$.\[\]]*\.length\b`,
+);
+
+describe('memory-bridge mutation counts (#1465)', () => {
+  const source = readFileSync(BRIDGE_PATH, 'utf8');
+
+  it('reports no mutation count derived from input length', () => {
+    const offenders = source
+      .split(/\r?\n/)
+      .map((text, i) => ({ line: i + 1, text }))
+      .filter(({ text }) => INPUT_DERIVED_COUNT.test(text))
+      .map(({ line, text }) => `memory-bridge.ts:${line}: ${text.trim()}`);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('matches the shape the bug actually took', () => {
+    // Mutation-testing the guard: the two literal lines #1465 deleted must
+    // both trip it, or the regex above is decorative.
+    expect(INPUT_DERIVED_COUNT.test('result = { deleted: keys.length };')).toBe(true);
+    expect(INPUT_DERIVED_COUNT.test('result = { updated: params.entries.length };')).toBe(true);
+    expect(INPUT_DERIVED_COUNT.test("return { success: true, count: params.entries.length };")).toBe(true);
+
+    // ...and a count sourced from the store's own answer must not.
+    expect(INPUT_DERIVED_COUNT.test("return { count: result.inserted, result };")).toBe(false);
+  });
+
+  it('no longer routes batch delete/update to the episodes store', () => {
+    // The loop-over-keys calls are gone, not merely renamed.
+    expect(source).not.toMatch(/bulkDelete\(\s*'episodes'/);
+    expect(source).not.toMatch(/bulkUpdate\(\s*'episodes'/);
+  });
+});

--- a/tests/system/daemon-open-concurrent-wal-1471.test.ts
+++ b/tests/system/daemon-open-concurrent-wal-1471.test.ts
@@ -1,0 +1,193 @@
+/**
+ * System E2E: concurrent first-open of a fresh database (#1471).
+ *
+ * The failure was cross-process and only ever showed up under real contention:
+ * `openDaemonDatabase` sets `PRAGMA busy_timeout` before `PRAGMA journal_mode
+ * = WAL` precisely so concurrent openers survive the EXCLUSIVE lock the
+ * conversion takes — but SQLite does not invoke the busy handler for a
+ * journal-mode change, so the budget never applied to the one statement it was
+ * put there for. Every opener but the winner threw `SQLITE_BUSY` and died.
+ *
+ * That is the ordinary consumer configuration, not a test contrivance: the
+ * daemon, the MCP server and a foreground `flo` command routinely open the
+ * same `.moflo/moflo.db` at session start, and on a fresh install that open is
+ * the conversion. It surfaced as `tests/system/hnsw-sidecar-concurrent-writers
+ * -1388.test.ts` failing ~2 runs in 10.
+ *
+ * In-process coverage of the retry itself (backoff, budget, error shape, both
+ * twins) lives in `src/cli/__tests__/memory/wal-retry-1471.test.ts`. This suite
+ * covers the half only real subprocesses can prove — that N processes racing
+ * the same fresh file all come out with a usable WAL handle.
+ *
+ * Cross-platform: spawns via `process.execPath`, paths via node:path, temp
+ * roots under `os.tmpdir()`, cleanup tolerant of Windows handle-release
+ * latency. The barrier below is a wall-clock rendezvous rather than a signal
+ * so it behaves the same on Windows, which has no POSIX signals.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { spawn } from 'node:child_process';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const DIST_BACKEND = path.join(REPO_ROOT, 'dist', 'src', 'cli', 'memory', 'daemon-backend.js');
+const BIN_BACKEND = path.join(REPO_ROOT, 'bin', 'lib', 'get-backend.mjs');
+
+/** Enough openers that the conversion race is hit reliably, few enough to stay quick. */
+const OPENERS = 6;
+/** Head start for spawn + module load, so every child reaches the open together. */
+const BARRIER_LEAD_MS = 700;
+
+function moduleUrl(filePath: string): string {
+  return 'file://' + filePath.replace(/\\/g, '/');
+}
+
+interface OpenResult {
+  role: string;
+  journalMode: string;
+}
+
+/** Run one subprocess and parse the single JSON line it prints. */
+function runScript<T>(scriptPath: string, source: string): Promise<T> {
+  fs.writeFileSync(scriptPath, source, 'utf-8');
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => { stdout += String(d); });
+    child.stderr.on('data', (d) => { stderr += String(d); });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`${path.basename(scriptPath)} exited ${code}: ${stderr || stdout}`));
+        return;
+      }
+      const line = stdout.trim().split(/\r?\n/).filter(Boolean).pop();
+      if (!line) {
+        reject(new Error(`${path.basename(scriptPath)} printed nothing. stderr: ${stderr}`));
+        return;
+      }
+      try {
+        resolve(JSON.parse(line) as T);
+      } catch (err) {
+        reject(new Error(`${path.basename(scriptPath)} printed non-JSON: ${line} (${err})`));
+      }
+    });
+  });
+}
+
+describe('concurrent first-open converts to WAL without SQLITE_BUSY (#1471)', () => {
+  let tmp: string;
+  let scriptDir: string;
+  let dbPath: string;
+  let distMissing = false;
+
+  beforeAll(() => {
+    // A source-only checkout has no dist. Skip loudly rather than fail with an
+    // unresolvable-import error that reads like a real defect.
+    distMissing = !fs.existsSync(DIST_BACKEND);
+    if (distMissing) {
+      console.warn(
+        `[daemon-open-concurrent-wal] skipping suite — ${DIST_BACKEND} not found. Run: npm run build`,
+      );
+    }
+  });
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-1471-sys-'));
+    fs.mkdirSync(path.join(tmp, '.moflo'));
+    scriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-1471-scripts-'));
+    dbPath = path.join(tmp, '.moflo', 'moflo.db');
+  });
+
+  afterEach(() => {
+    for (const dir of [tmp, scriptDir]) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+      } catch {
+        /* best-effort — Windows can hold a brief handle */
+      }
+    }
+  });
+
+  /**
+   * Both factories are hand-maintained twins of the same open sequence, and
+   * both ship: the TS one to the daemon and MCP server, the .mjs one to every
+   * `bin/*` entry point. A consumer's session start runs them against the same
+   * file at the same moment, so both must survive the race.
+   */
+  function openerSource(role: string, startAt: number, importSpec: string, open: string): string {
+    return `
+      import { ${open.split('(')[0]} } from ${JSON.stringify(importSpec)};
+      // Wall-clock rendezvous: spawn order and module-load time vary by
+      // hundreds of ms, which is enough for the openers to miss each other
+      // entirely and let the pre-fix code pass by accident.
+      const startAt = ${startAt};
+      while (Date.now() < startAt) { /* spin — sub-ms precision, no timer skew */ }
+      const db = await ${open};
+      let journalMode = '';
+      try {
+        // The sql.js-shaped \`exec\` both wrappers expose — their Statement
+        // shim is stateful (step/getAsObject), so there is no \`.get()\`.
+        const rows = db.exec('PRAGMA journal_mode');
+        journalMode = String(rows?.[0]?.values?.[0]?.[0] ?? '').toLowerCase();
+      } finally {
+        db.close();
+      }
+      console.log(JSON.stringify({ role: ${JSON.stringify(role)}, journalMode }));
+    `;
+  }
+
+  it('lets every one of N processes open the same fresh database', async () => {
+    if (distMissing) return;
+
+    const startAt = Date.now() + BARRIER_LEAD_MS;
+    const results = await Promise.all(
+      Array.from({ length: OPENERS }, (_, i) =>
+        runScript<OpenResult>(
+          path.join(scriptDir, `opener-${i}.mjs`),
+          openerSource(
+            `opener-${i}`,
+            startAt,
+            moduleUrl(DIST_BACKEND),
+            `openDaemonDatabase(${JSON.stringify(dbPath)})`,
+          ),
+        ),
+      ),
+    );
+
+    // Pre-fix, the losers exited non-zero and `runScript` rejected above with
+    // "database is locked" — so reaching here at all is most of the assertion.
+    expect(results).toHaveLength(OPENERS);
+    for (const result of results) {
+      expect(result.journalMode, `${result.role} did not end up in WAL`).toBe('wal');
+    }
+  }, 120_000);
+
+  it('lets the bin/* factory twin survive the same race', async () => {
+    // `openBackend(projectRoot)` — the .mjs twin. Guards against the fix landing in
+    // one factory and not the other, which would leave every hook and indexer
+    // subprocess still dying on a fresh consumer install.
+    const startAt = Date.now() + BARRIER_LEAD_MS;
+    const results = await Promise.all(
+      Array.from({ length: OPENERS }, (_, i) =>
+        runScript<OpenResult>(
+          path.join(scriptDir, `bin-opener-${i}.mjs`),
+          openerSource(
+            `bin-opener-${i}`,
+            startAt,
+            moduleUrl(BIN_BACKEND),
+            `openBackend(${JSON.stringify(tmp)})`,
+          ),
+        ),
+      ),
+    );
+
+    expect(results).toHaveLength(OPENERS);
+    for (const result of results) {
+      expect(result.journalMode, `${result.role} did not end up in WAL`).toBe('wal');
+    }
+  }, 120_000);
+});


### PR DESCRIPTION
Closes #1465.

## The defect

`moflodb_batch` with `operation: "delete"` or `"update"` returned `{success: true}` with a non-zero count and changed nothing the caller could address. The count was the length of the input array, never rows affected, and the tool's `inputSchema` has no `namespace` property — so both operations targeted the `episodes` store and could not reach a namespaced `memory_entries` row at all.

A maintenance operation that reports success while doing nothing is worse than an absent one: there is no signal to retry on. That is the same failure shape as the artifact-sync bugs in #1463, and it is why that drift went unnoticed for weeks.

## One correction to the ticket's premise

The ticket sets the repair bar at *"report rows actually affected via `getRowsModified()`"*, implying the controllers were fabricating the count. They were not. `BatchOperations.bulkDelete`/`bulkUpdate` bracket their statement with `COUNT(*)` and return the real difference — sql.js exposes no affected-rows API, so that bracketing *is* the honest implementation. The lying code was entirely `bridgeBatchOperation`, which called the controller in a loop, threw its real result away, and substituted `{ deleted: keys.length }`.

So the fix is the bridge no longer discarding the truthful answer, not teaching the controller to produce one.

## What changed

- `moflodb_batch` advertises `enum: ['insert']` and rejects `delete`/`update` **at the tool boundary**, naming `memory_delete` (with an explicit namespace) for removal and `memory_store` for overwrite. The bridge rejects them again *before* its registry lookup, so the redirect holds even where the bridge is unavailable or mocked.
- `insert` now reports `result.inserted` — rows the store actually wrote — instead of `entries.length`.
- `bulkDelete`/`bulkUpdate` stay on the controller (honest, tested, registered) but now have no caller. The header says so, and says not to re-wire one without a namespace-aware target.

## Prototype-chain hazard, found in review

Swapping the old `['insert','update','delete'].includes(op)` check for a keyed lookup introduced a regression that the review pass caught: with a plain object literal, a caller-controlled `operation` of `constructor`, `toString`, `__proto__`, `valueOf` or `hasOwnProperty` resolves up the prototype chain to a truthy function. The guard fired and returned that function as `error` — which `JSON.stringify` drops, handing the caller a failure with **no message at all**.

Both tables are `Map`s now. Five parameterised tests pin the inherited names; mutation-testing confirms reverting to an object literal fails all five.

## Tests

- `tests/guards/bridge-mutation-count-guard.test.ts` (new) — fails any memory-bridge mutation count derived from input length. Mutation-tested: reintroducing `count: params.entries.length` turns it red and names the offending line.
- `mcp-tools-deep.test.ts` — delete/update redirects, schema enum, and the five prototype-key cases.
- Full suite **11055 passed / 0 failed**; `tsc`, `npm run build`, and eslint clean.
- Verified end-to-end against the built `dist/` artifact — the copy consumers actually load — not just the source tree.

## Consumer surface

MCP tool schema (`moflodb_batch`), which every consumer's Claude Code sees.

**Failure mode for someone on 4.12.11 upgrading: none behavioural.** Any caller passing `delete`/`update` today is already getting a silent no-op, so no working behaviour is removed — they gain an actionable error instead of a false success. No `.moflo/` state migration, no hook rewiring. Requires publish-then-reinstall to take effect, since the MCP server runs from `node_modules/moflo/`.

## Adjacent finding — not acted on

`moflo_episodes` appears **exactly once in the whole repo**: its own `CREATE TABLE`. Nothing reads it. So `moflodb_batch insert` — the operation this PR preserves — writes to a table with no reader, which arguably triggers the ticket's own escape clause ("if `insert` alone does not justify the tool, remove `moflodb_batch` outright").

Not taken here: AC1 is written as a checkable criterion presupposing the tool still exists and errors, and deleting the `batchOperations` controller would change `moflodb_controllers`' output — a separate consumer surface that wants explicit sign-off rather than an in-passing tidy-up. Flagging for a follow-up decision.

---

# Also in this PR: #1471 — concurrent first-open dies on `journal_mode = WAL`

Closes #1471.

Rolled in because it is what turned this PR's own CI red. The `Tests` job failed in
`tests/system/hnsw-sidecar-concurrent-writers-1388.test.ts` with a child process exiting non-zero:

```
Error: database is locked
    at openDaemonDatabase (dist/src/cli/memory/daemon-backend.js:294:16)
  code: 'ERR_SQLITE_ERROR', errcode: 5, errstr: 'database is locked'
```

Line 294 is `db.exec('PRAGMA journal_mode = WAL')`. Nothing to do with `moflodb_batch` — it is #1471
verbatim, so fixing it here beat re-running CI until it went green by luck.

## The defect

`openDaemonDatabase` sets `PRAGMA busy_timeout = 15000` *before* `PRAGMA journal_mode = WAL`
specifically so concurrent openers survive the brief EXCLUSIVE lock the conversion takes. That
ordering is correct but insufficient: **SQLite does not invoke the busy handler for a journal-mode
change**, so the budget never applied to the one statement it was put there for. Whichever processes
lost a first-open race threw `SQLITE_BUSY` immediately and died.

That is the ordinary consumer configuration, not a test contrivance: the daemon, the MCP server and
a foreground `flo` command open the same `.moflo/moflo.db` at session start, and on a fresh install
that open *is* the conversion.

## What changed

- The journal-mode pragma retries on contention under its own bounded budget — exponential backoff
  from 5ms to a 250ms cap, 15s ceiling matched to `busy_timeout` so the two cover the same worst
  case. `busy_timeout` is untouched and still correct for every other statement.
- Losing every race is treated as the success it is: after the budget, the mode is re-read and a
  database already in WAL returns normally. In an N-process race, N−1 openers legitimately lose.
- Exhaustion throws an error naming the database, the wait, the mode it is stuck in, and the
  original engine error — not a silent fallback.
- That post-exhaustion probe runs under a **narrowed** busy budget which is then restored. The query
  form of `PRAGMA journal_mode` takes a shared lock and *is* covered by the busy handler, so left
  alone it would inherit the full 15s and double the worst case to ~30s on the one path where we
  have already decided to give up.
- Both hand-maintained factory twins are fixed: `src/cli/memory/daemon-backend.ts` (daemon, MCP
  server) and `bin/lib/get-backend.mjs` (hooks, indexer, every `bin/*` entry point) — plus the
  byte-identical `.claude/scripts/lib/` dogfood copy the parity guard enforces. The unit suite
  drives **both** through the same cases, so a one-sided fix fails in CI rather than in a consumer.
- Drive-by while in the file: `warnIfNotWal` now calls the new `readJournalMode` instead of
  re-running the same PRAGMA read inline.

**The common path pays nothing.** On a database already in WAL the pragma is a no-op that takes no
exclusive lock, so the first attempt succeeds and the retry loop never runs — asserted directly
(`execCalls === 1`, `probeCalls === 0`).

## Verification

| # | Acceptance criterion | Evidence |
|---|---|---|
| 1 | N concurrent processes opening the same fresh DB all succeed | `tests/system/daemon-open-concurrent-wal-1471.test.ts` — 6 subprocesses on a wall-clock barrier, through **both** factories, all report `journal_mode=wal`. Reproduces the bug **3/3** with the retry removed. |
| 2 | `hnsw-sidecar-concurrent-writers-1388` passes 20 consecutive runs | **20/20**, re-run at the final commit. Pre-fix rate was ~2 failures in 10. |
| 3 | An already-WAL database opens without a retry | `converts on the first attempt when nothing is contending` — one pragma, zero probes, both twins. |
| 4 | Budget bounded; exhaustion is diagnosable, not silent | `bounds the wait at the budget rather than retrying forever`, `surfaces a diagnosable error…`, `narrows the busy budget for the post-exhaustion probe and restores it`, `retries the probe before declaring the mode unreadable`, `rethrows a non-contention error immediately`. The two probe-bounding cases fail **4/4** across the twins when reverted. |

Full suite **11075 passed / 0 failed**; `tsc`, eslint and build clean.

## Consumer impact

`openDaemonDatabase` / `openBackend` is the DB-open chokepoint every moflo process goes through, so
the blast radius is total — but the change only converts a hard throw into a bounded retry. Nothing
to opt into, no `.moflo/` state change, no migration, no hook rewiring. Takes effect after publish +
reinstall, since the daemon, MCP server and hooks all run from `node_modules/moflo/`.

## Cross-platform (Rule #1)

The retry sleep is `Atomics.wait` on a module-level `SharedArrayBuffer` — no shell-out, identical on
Linux, macOS and Windows, and it parks the thread rather than spinning. The new system test spawns
via `process.execPath`, builds every path with `node:path`, roots temp dirs under `os.tmpdir()`, and
synchronises its openers with a wall-clock rendezvous rather than a signal, because Windows has none.
