### PR TITLE
feat(memory): flo memory audit-learnings (#1466) + ten silent --no-* flags (#1474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — ten `--no-*` flags were silent no-ops
+
+The parser treats `--no-<x>` as boolean negation: it writes `flags[camelCase(x)] = false` and never
+produces a `noX` key. Ten flags were read as `flags.noX` anyway, so they parsed fine, set nothing the
+handler looked at, and did nothing at all. Eight were also *declared* as `no-<x>`, which put their
+declared default under a key nothing reads either.
+
+**These flags begin taking effect on upgrade.** If a script or CI job passes one, its behaviour
+changes — in every case to the thing the flag has always claimed to do:
+
+| Flag | Was | Now |
+|---|---|---|
+| `flo daemon start --no-dashboard` | dashboard HTTP server started anyway | no dashboard |
+| `flo memory index-guidance --no-embeddings` | embeddings generated anyway | generation skipped |
+| `flo memory code-map --no-embeddings` | embeddings generated anyway | generation skipped |
+| `flo hooks coverage-route --no-movector` | native backend used anyway | movector integration off |
+| `flo hooks statusline --no-color` | ANSI colours emitted anyway | plain output |
+| `flo spell schedule --no-autostart` | daemon registered as a login service anyway | registration skipped |
+| `flo hive-mind spawn --no-auto-permissions` | permissions handled automatically anyway | Claude prompts per action |
+| `flo epic run <n> --no-merge` | ran the auto-merge strategy | forces `single-branch` |
+| `--no-color` (global) | coloured output anyway | colour disabled |
+| `--no-update` (global) | startup update check ran anyway | check suppressed |
+
+`flo epic --no-merge` is the one worth reading twice: it is documented as an alias for
+`--strategy single-branch`, and while it was a no-op an epic asked for single-branch silently ran
+auto-merge instead. Anyone who relied on `--no-merge` was not getting it.
+
+Two guards keep this from returning. The first forbids any option — command-level or global — from
+being declared `no-*`. The second forbids any source read of `flags.no<Something>`: with the first
+guard in force the parser can never emit such a key, so every one of those reads is a permanent
+`undefined`. The second guard is the load-bearing one — renaming a declaration changes no parsed key,
+so a test over parser output passes equally before and after the fix. It found two of the ten on its
+first run.
+
+Note for anyone adding a flag: a command-level `default` is only applied when the option shadows a
+global one, so an unset flag arrives as `undefined`, not its declared default. Read `!== false` for
+"is it on" and `=== false` for "was it turned off" rather than testing truthiness.
+
+**Consumer impact:** behavioural. No migration and no state change, but a consumer whose automation
+passes any flag above gets the documented behaviour where it previously got none.
+
 ### Added — `flo memory audit-learnings`, a curation pass for durable learnings
 
 Durable learnings accumulate and go stale — decisions get reversed, vocabulary gets renamed, a rule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `flo memory audit-learnings`, a curation pass for durable learnings
+
+Durable learnings accumulate and go stale — decisions get reversed, vocabulary gets renamed, a rule
+gets promoted into a machine gate — and until now moflo shipped no surface for evaluating them. The
+only purge available was `flo memory cleanup`, which ranks by age; #1464 correctly exempted durable
+namespaces from it, which left `learnings` with no evaluation surface at all. A consumer store
+reached 1,582 entries with no way to tell which of them were still true.
+
+`flo memory audit-learnings` runs mechanical filters first and a model last, which is what makes it
+affordable at that size rather than a full-store LLM sweep. Three cheap passes nominate: near-
+duplicate clustering over the embeddings already on the row (the default path performs no
+re-embedding), a least-used-and-old ranking built on #1464's usage signal, and a retired-vocabulary
+match. Only the nominated entries — typically a few dozen out of a few thousand — are sent to a
+bounded headless Haiku for a KEEP / RETIRE / COMPRESS / MERGE verdict, reusing the decision table
+moflo already documents for auto-memory files rather than inventing a second vocabulary for the same
+judgement. The number sent is always reported.
+
+The run is dry by default. `--apply` **archives** rather than deletes, and it does so by going
+through the same `deleteEntry` chokepoint `flo memory delete` uses rather than opening its own handle
+on the store — the command runs in the foreground while the user's daemon is very likely holding
+`.moflo/moflo.db`, and a raw cross-process write there is the single-writer violation epic #1054
+exists to prevent. Routing means the archive semantics are inherited rather than restated: a delete
+in a durable namespace already archives, so the removal carries a tombstone #1463's reconciler can
+propagate instead of the entry being re-imported from the team artifact at the next session start.
+Archived rows are already invisible to `memory_search`, `flo memory list`, `memory_stats` and the
+HNSW index build.
+
+**Only RETIRE removes anything.** MERGE and COMPRESS both describe work that preserves content —
+fold this into that one, rewrite this shorter — and the audit performs neither, so archiving on them
+would delete the signal the verdict just said to keep. MERGE is the sharper edge: "restates another
+entry listed here" is honestly true of *both* members of a pair, so a model answering it twice would
+take the rule with it. Both are reported for an author to act on. For the same reason a cluster's
+surviving statement is never archived even when a different pass nominates it independently.
+
+Verdicts are recorded in a local `.moflo/learnings-audit.json`, keyed by content hash, so an
+immediate re-run is quiet and a rewritten entry is judged again; `--recheck` forces a fresh look
+without discarding the verdicts it bypasses. Thresholds are tunable —
+`--duplicate-threshold`, `--unused-min-age-days`, `--unused-limit`, `--judge-limit` — and when the
+unused cap holds entries back, the run says how many it matched rather than reporting the cap as
+full coverage.
+
+The retired-vocabulary table **ships empty**, and a guard test keeps it that way. A rename belongs to
+the one project that made it: shipping a row would flag innocent entries in every other consumer's
+store, and the row itself would carry that project's internal vocabulary into a public repository.
+
+**Consumer impact:** additive and opt-in. A new `flo memory` subcommand and one new module; no
+migration, no change to existing `.moflo/` state, and nothing runs unless the command is invoked.
+Consumers on the previous version see no behaviour change until they call it. The model step needs
+the `claude` CLI on PATH; without it the audit still reports its mechanical nominations and archives
+nothing.
+
 ### Fixed — concurrent first-open of a database no longer dies on `journal_mode = WAL`
 
 `openDaemonDatabase` sets `PRAGMA busy_timeout = 15000` *before* `PRAGMA journal_mode = WAL`

--- a/src/cli/__tests__/commands-deep.test.ts
+++ b/src/cli/__tests__/commands-deep.test.ts
@@ -686,7 +686,7 @@ describe('CommandParser', () => {
   });
 
   describe('kebab-case to camelCase normalization', () => {
-    it('should convert --no-color to noColor flag (negation)', () => {
+    it('should convert --no-color to color=false, NOT a noColor flag', () => {
       // --no-color is boolean negation => flags.color = false
       const result = parser.parse(['--no-color']);
       expect(result.flags.color).toBe(false);

--- a/src/cli/__tests__/commands/memory-audit-learnings.test.ts
+++ b/src/cli/__tests__/commands/memory-audit-learnings.test.ts
@@ -1,0 +1,518 @@
+/**
+ * `flo memory audit-learnings` end-to-end against a real store (#1466).
+ *
+ * Covers the halves the pure-module tests cannot: that the default run writes
+ * nothing, that a verdict is requested only for the mechanically nominated
+ * entries, that `--apply` archives rather than deletes and the archived rows
+ * really do leave every read surface, and that an immediate re-run is quiet.
+ *
+ * The model call is exercised through the same node-stub seam
+ * `bin/meditate-distill.mjs` uses, so the spawn path is real (argument array,
+ * no shell) on all three platforms without a Claude CLI on PATH — Rule #1.
+ */
+
+import { describe, expect, it, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { output } from '../../output.js';
+import { openDaemonDatabase } from '../../memory/daemon-backend.js';
+import { getNamespaceCounts, listEntries, searchEntries } from '../../memory/entries-read.js';
+import { getLearningsOverview } from '../../memory/learnings-overview.js';
+import { syncHnswSidecar } from '../../memory/hnsw-persistence.js';
+import { hasMemoryEntriesTable } from '../../services/cherry-pick-learnings.js';
+import {
+  auditLearningsCommand,
+  AUDIT_STATE_FILE,
+  JUDGE_STUB_ENV,
+  readAuditState,
+} from '../../commands/memory-audit-learnings.js';
+import { CommandParser } from '../../parser.js';
+import type { CommandContext } from '../../types.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+const DIM = 8;
+
+/**
+ * A stub Claude CLI. Reads the prompt off argv, echoes the keys it was asked
+ * about into a log file so a test can assert exactly what was sent, and answers
+ * with a verdict chosen by the key's own name.
+ */
+const STUB_SOURCE = `
+const fs = require('fs');
+let prompt = '';
+process.stdin.setEncoding('utf-8');
+process.stdin.on('data', (d) => { prompt += d; });
+process.stdin.on('end', () => {
+  const keys = [];
+  for (const line of prompt.split('\\n')) {
+    const m = /^### \\d+\\. (.+)$/.exec(line.trim());
+    if (m) keys.push(m[1]);
+  }
+  const logPath = process.env.MOFLO_AUDIT_TEST_LOG;
+  if (logPath) {
+    fs.writeFileSync(logPath, JSON.stringify({
+      keys,
+      promptLength: prompt.length,
+      // Recorded so a test can prove the prompt never rode on the command line.
+      argv: process.argv.slice(2),
+    }), 'utf-8');
+  }
+  const verdictFor = (k) =>
+    k.includes('retire') ? 'RETIRE'
+    : k.includes('merge') ? 'MERGE'
+    : k.includes('compress') ? 'COMPRESS'
+    : 'KEEP';
+  process.stdout.write(keys.map((k) => k + '\\t' + verdictFor(k) + '\\treason for ' + k).join('\\n'));
+});
+`;
+
+interface SeedRow {
+  key: string;
+  content?: string;
+  embedding?: number[];
+  updatedAt?: number;
+  accessCount?: number;
+}
+
+let tmp: string;
+let dbPath: string;
+let stubPath: string;
+let judgeLog: string;
+let written: string[];
+let now: number;
+
+/** A unit vector rotated by `angle`, padded to DIM — dials cosine similarity. */
+function vec(angle: number): number[] {
+  const v = new Array(DIM).fill(0);
+  v[0] = Math.cos(angle);
+  v[1] = Math.sin(angle);
+  return v;
+}
+
+function seed(rows: SeedRow[]): void {
+  const db = openDaemonDatabase(dbPath);
+  try {
+    db.run(`CREATE TABLE IF NOT EXISTS memory_entries (
+      id TEXT PRIMARY KEY, key TEXT NOT NULL, namespace TEXT DEFAULT 'default',
+      content TEXT NOT NULL, type TEXT DEFAULT 'semantic',
+      embedding TEXT, embedding_model TEXT, embedding_dimensions INTEGER,
+      tags TEXT, metadata TEXT, owner_id TEXT,
+      created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+      expires_at INTEGER, last_accessed_at INTEGER,
+      access_count INTEGER DEFAULT 0, status TEXT DEFAULT 'active',
+      UNIQUE(namespace, key)
+    )`);
+    for (const r of rows) {
+      const updatedAt = r.updatedAt ?? now - 300 * DAY;
+      db.run(
+        `INSERT OR REPLACE INTO memory_entries
+           (id, key, namespace, content, embedding, embedding_model, embedding_dimensions,
+            created_at, updated_at, access_count, status)
+         VALUES (?, ?, 'learnings', ?, ?, 'local', ?, ?, ?, ?, 'active')`,
+        [
+          `id-${r.key}`,
+          r.key,
+          r.content ?? `body for ${r.key}`,
+          r.embedding ? JSON.stringify(r.embedding) : null,
+          r.embedding ? DIM : null,
+          updatedAt,
+          updatedAt,
+          r.accessCount ?? 0,
+        ],
+      );
+    }
+  } finally {
+    db.close();
+  }
+}
+
+function ctx(flags: Record<string, unknown> = {}): CommandContext {
+  return { args: [], flags: { _: [], ...flags } as CommandContext['flags'], cwd: tmp, interactive: false };
+}
+
+function statusOf(key: string): string | null {
+  const db = openDaemonDatabase(dbPath);
+  try {
+    const res = db.exec(`SELECT status FROM memory_entries WHERE key = ? AND namespace = 'learnings'`, [key]);
+    const value = res[0]?.values?.[0]?.[0];
+    return value == null ? null : String(value);
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * ONE project root for the whole file, cleared between cases.
+ *
+ * The write path is `deleteEntry`, which resolves the store through a
+ * process-wide bridge singleton that pins to the first project it sees — the
+ * same shape production runs in, one project per process. A fresh temp root per
+ * test would leave every case after the first writing into the first case's
+ * database. Truncating the table per test gives the same isolation without
+ * fighting a singleton that is correct for its actual environment.
+ */
+beforeAll(() => {
+  // realpath: on macOS os.tmpdir() is a symlink into /private/var and
+  // findProjectRoot resolves it, so an unresolved root would not match (Rule #1).
+  tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-1466-')));
+  fs.mkdirSync(path.join(tmp, '.moflo'), { recursive: true });
+  dbPath = path.join(tmp, '.moflo', 'moflo.db');
+
+  stubPath = path.join(tmp, 'judge-stub.cjs');
+  fs.writeFileSync(stubPath, STUB_SOURCE, 'utf-8');
+  judgeLog = path.join(tmp, 'judge-log.json');
+
+  process.env.CLAUDE_PROJECT_DIR = tmp;
+  process.env.MOFLO_AUDIT_TEST_LOG = judgeLog;
+  process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
+});
+
+afterAll(() => {
+  delete process.env.CLAUDE_PROJECT_DIR;
+  delete process.env[JUDGE_STUB_ENV];
+  delete process.env.MOFLO_AUDIT_TEST_LOG;
+  delete process.env.MOFLO_DISABLE_DAEMON_ROUTING;
+  try {
+    fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  } catch {
+    /* best-effort — Windows can hold a brief handle */
+  }
+});
+
+beforeEach(() => {
+  now = Date.now();
+  process.env[JUDGE_STUB_ENV] = stubPath;
+
+  const db = openDaemonDatabase(dbPath);
+  try {
+    if (hasMemoryEntriesTable(db)) db.run('DELETE FROM memory_entries');
+  } finally {
+    db.close();
+  }
+  for (const stale of [AUDIT_STATE_FILE, 'hnsw.index', 'hnsw.manifest.json']) {
+    fs.rmSync(path.join(tmp, '.moflo', stale), { force: true });
+  }
+  fs.rmSync(judgeLog, { force: true });
+
+  written = [];
+  vi.spyOn(output, 'writeln').mockImplementation((text = '') => { written.push(String(text)); });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('flo memory audit-learnings (#1466)', () => {
+  it('is dry by default and prints per-bucket counts', async () => {
+    seed([
+      { key: 'dup-old-retire', embedding: vec(0), updatedAt: now - 5 * DAY, accessCount: 2 },
+      { key: 'dup-new', embedding: vec(0.01), updatedAt: now, accessCount: 2 },
+      { key: 'stale-retire', updatedAt: now - 300 * DAY, accessCount: 0 },
+    ]);
+
+    const result = await auditLearningsCommand.action(ctx());
+    const printed = written.join('\n');
+
+    expect(result.success).toBe(true);
+    expect(printed).toContain('DRY RUN');
+    expect(printed).toContain('Near-duplicate');
+    expect(printed).toContain('Unused and old');
+    expect(printed).toContain('Superseded vocabulary');
+
+    const data = result.data as { dryRun: boolean; counts: Record<string, number> };
+    expect(data.dryRun).toBe(true);
+    expect(data.counts.duplicate).toBe(1);
+    expect(data.counts.unused).toBe(1);
+    expect(data.counts.superseded).toBe(0);
+
+    // The whole point of "dry": nothing moved, even though the judge said RETIRE.
+    expect(statusOf('dup-old-retire')).toBe('active');
+    expect(statusOf('stale-retire')).toBe('active');
+  });
+
+  it('sends only the mechanically nominated entries to the judge, and reports how many', async () => {
+    seed([
+      { key: 'dup-old-retire', embedding: vec(0), updatedAt: now - 5 * DAY, accessCount: 2 },
+      { key: 'dup-new', embedding: vec(0.01), updatedAt: now, accessCount: 2 },
+      { key: 'healthy', updatedAt: now - DAY, accessCount: 9 },
+    ]);
+
+    const result = await auditLearningsCommand.action(ctx());
+
+    const sent = JSON.parse(fs.readFileSync(judgeLog, 'utf-8')) as { keys: string[] };
+    expect(sent.keys).toEqual(['dup-old-retire']);
+    // Neither the cluster's surviving statement nor an unflagged entry costs tokens.
+    expect(sent.keys).not.toContain('dup-new');
+    expect(sent.keys).not.toContain('healthy');
+
+    const data = result.data as { judged: number; nominated: number };
+    expect(data.judged).toBe(1);
+    expect(data.nominated).toBe(1);
+  });
+
+  it('makes no model call at all when nothing is nominated', async () => {
+    seed([{ key: 'healthy', updatedAt: now - DAY, accessCount: 9 }]);
+
+    const result = await auditLearningsCommand.action(ctx());
+
+    expect(fs.existsSync(judgeLog)).toBe(false);
+    expect((result.data as { judged: number }).judged).toBe(0);
+  });
+
+  it('reports a skipped judgement distinctly from a judgement that found nothing', async () => {
+    seed([{ key: 'stale-retire', updatedAt: now - 300 * DAY, accessCount: 0 }]);
+
+    const result = await auditLearningsCommand.action(ctx({ judge: false }));
+
+    expect(fs.existsSync(judgeLog)).toBe(false);
+    const data = result.data as { judged: number; judgeSkipped: boolean; nominated: number };
+    expect(data.judged).toBe(0);
+    expect(data.judgeSkipped).toBe(true);
+    expect(data.nominated).toBe(1);
+  });
+
+  it('--apply archives rather than deletes, and archived rows leave every read surface', async () => {
+    seed([
+      { key: 'stale-retire', content: 'a lesson about a migration that finished', updatedAt: now - 300 * DAY, embedding: vec(0.9) },
+      { key: 'keeper', content: 'a footgun that still exists', updatedAt: now - DAY, accessCount: 5, embedding: vec(2.0) },
+    ]);
+
+    const before = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+    expect(before.vectorCount).toBe(2);
+
+    const result = await auditLearningsCommand.action(ctx({ apply: true, force: true }));
+
+    expect((result.data as { archived: number }).archived).toBe(1);
+
+    // Archived, NOT deleted: the row survives so #1463's reconciler can emit a
+    // tombstone from it instead of the entry being re-imported at session start.
+    expect(statusOf('stale-retire')).toBe('archived');
+    expect(statusOf('keeper')).toBe('active');
+
+    const listed = await listEntries({ namespace: 'learnings', dbPath, limit: 50 });
+    expect(listed.entries.map((e) => e.key)).toEqual(['keeper']);
+
+    const counts = await getNamespaceCounts(dbPath);
+    expect(counts.namespaces.learnings).toBe(1);
+
+    const overview = await getLearningsOverview({ dbPath });
+    expect(overview.total).toBe(1);
+    expect(overview.recent.map((r) => r.key)).toEqual(['keeper']);
+
+    // The search index is the fourth surface: the archived entry's vector is
+    // gone, so a semantic search cannot reach it either.
+    const after = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+    expect(after.vectorCount).toBe(1);
+
+    // And the search API itself. `threshold: -1` keeps the assertion about
+    // presence rather than about how the seeded vectors happen to score — the
+    // keeper coming back is what makes the archived entry's absence meaningful.
+    const found = await searchEntries({
+      query: 'a lesson about a migration that finished',
+      namespace: 'learnings',
+      dbPath,
+      limit: 50,
+      threshold: -1,
+    });
+    const hits = found.results.map((r) => r.key);
+    expect(hits).toContain('keeper');
+    expect(hits).not.toContain('stale-retire');
+  }, 120_000);
+
+  it('clusters on stored vectors only — never re-embeds on the default path', async () => {
+    // Byte-identical content with no stored vectors. A pass that generated
+    // embeddings would score these 1.0 and nominate one; reading the column
+    // means it sees nothing to compare.
+    seed([
+      { key: 'twin-a', content: 'exactly the same words', updatedAt: now - DAY, accessCount: 5 },
+      { key: 'twin-b', content: 'exactly the same words', updatedAt: now - 2 * DAY, accessCount: 5 },
+      { key: 'dup-old-retire', content: 'unrelated', embedding: vec(0), updatedAt: now - 5 * DAY, accessCount: 5 },
+      { key: 'dup-new', content: 'unrelated too', embedding: vec(0.01), updatedAt: now, accessCount: 5 },
+    ]);
+
+    const result = await auditLearningsCommand.action(ctx());
+    const data = result.data as { counts: Record<string, number>; examined: number };
+
+    // Only the vector-carrying pair clusters.
+    expect(data.counts.duplicate).toBe(1);
+    expect(data.examined).toBe(4);
+    expect(written.join('\n')).toContain('have no stored vector');
+  });
+
+  it('sends the prompt over stdin, never on the command line', async () => {
+    // ~36 KB at default settings. As a single argv element that is past
+    // Windows' 32,767-char CreateProcess limit, so the judge would fail on
+    // Windows only — at DEFAULT settings (Rule #1).
+    seed(
+      Array.from({ length: 40 }, (_, i) => ({
+        key: `stale-keep-${i}`,
+        content: 'x'.repeat(600),
+        updatedAt: now - (300 + i) * DAY,
+        accessCount: 0,
+      })),
+    );
+
+    await auditLearningsCommand.action(ctx({ unusedLimit: 40 }));
+
+    const sent = JSON.parse(fs.readFileSync(judgeLog, 'utf-8')) as {
+      keys: string[]; promptLength: number; argv: string[];
+    };
+    expect(sent.keys.length).toBe(40);
+    expect(sent.promptLength).toBeGreaterThan(10_000);
+    for (const arg of sent.argv) expect(arg.length).toBeLessThan(200);
+  });
+
+  it('never archives a MERGE verdict — nothing here performs the merge', async () => {
+    seed([
+      { key: 'dup-old-merge', embedding: vec(0), updatedAt: now - 5 * DAY, accessCount: 2 },
+      { key: 'dup-new', embedding: vec(0.01), updatedAt: now, accessCount: 2 },
+    ]);
+
+    const result = await auditLearningsCommand.action(ctx({ apply: true, force: true }));
+
+    expect((result.data as { archived: number }).archived).toBe(0);
+    expect(statusOf('dup-old-merge')).toBe('active');
+    expect(written.join('\n')).toContain('MERGE into dup-new');
+  });
+
+  it('never archives every statement of a rule at once', async () => {
+    // Both the cluster survivor and its restatement are old and unused, so the
+    // unused pass nominates the survivor too and the judge answers RETIRE for
+    // both. Archiving on that would leave the rule with no statement at all.
+    seed([
+      { key: 'survivor-retire', embedding: vec(0), updatedAt: now - 300 * DAY, accessCount: 0 },
+      { key: 'restatement-retire', embedding: vec(0.01), updatedAt: now - 400 * DAY, accessCount: 0 },
+    ]);
+
+    const result = await auditLearningsCommand.action(ctx({ apply: true, force: true }));
+
+    expect((result.data as { archived: number }).archived).toBe(1);
+    expect(statusOf('survivor-retire')).toBe('active');
+    expect(statusOf('restatement-retire')).toBe('archived');
+  });
+
+  it('--recheck re-examines without erasing the verdicts it bypasses', async () => {
+    seed([
+      { key: 'stale-keep', updatedAt: now - 300 * DAY, accessCount: 0 },
+      { key: 'other-keep', updatedAt: now - 310 * DAY, accessCount: 0 },
+    ]);
+
+    await auditLearningsCommand.action(ctx({ apply: true, force: true }));
+    expect(readAuditState(tmp).size).toBe(2);
+
+    // The recheck deliberately nominates only ONE of the two, so a run that
+    // started from an empty record and wrote it back leaves a record of one —
+    // silently dropping the other entry's verdict and re-judging it next time.
+    // Re-judging the same set would rewrite both and hide the loss.
+    await auditLearningsCommand.action(ctx({ apply: true, force: true, recheck: true, unusedLimit: 1 }));
+
+    expect(readAuditState(tmp).size).toBe(2);
+  });
+
+  it('declines instead of hanging when --apply has no terminal to confirm on', async () => {
+    seed([{ key: 'stale-retire', updatedAt: now - 300 * DAY, accessCount: 0 }]);
+
+    // No --force, and the test process has no TTY — the same shape as a cron
+    // entry or a CI step. A bare confirm() would block on a pipe forever.
+    const result = await auditLearningsCommand.action({ ...ctx({ apply: true }), interactive: false });
+
+    expect((result.data as { applied: boolean }).applied).toBe(false);
+    expect(statusOf('stale-retire')).toBe('active');
+    expect(written.join('\n')).toContain('Confirmation required');
+  });
+
+  it('reports an empty store as zero learnings rather than failing', async () => {
+    // beforeEach truncated the table; nothing seeded.
+    const result = await auditLearningsCommand.action(ctx());
+
+    expect(result.success).toBe(true);
+    expect((result.data as { examined: number }).examined).toBe(0);
+    expect((result.data as { nominated: number }).nominated).toBe(0);
+  });
+
+  it('never archives a COMPRESS verdict — that would delete the signal it said to keep', async () => {
+    seed([{ key: 'stale-compress', updatedAt: now - 300 * DAY, accessCount: 0 }]);
+
+    const result = await auditLearningsCommand.action(ctx({ apply: true, force: true }));
+
+    expect((result.data as { archived: number }).archived).toBe(0);
+    expect(statusOf('stale-compress')).toBe('active');
+    expect(readAuditState(tmp).get('stale-compress')?.verdict).toBe('COMPRESS');
+  });
+
+  it('refuses to apply on nominations alone when no verdict came back', async () => {
+    seed([{ key: 'stale-retire', updatedAt: now - 300 * DAY, accessCount: 0 }]);
+
+    const result = await auditLearningsCommand.action(ctx({ apply: true, force: true, judge: false }));
+
+    expect((result.data as { archived: number }).archived).toBe(0);
+    expect(statusOf('stale-retire')).toBe('active');
+    expect(written.join('\n')).toContain('nominations alone are not a decision');
+  });
+
+  it('re-running immediately after --apply reports zero remaining candidates', async () => {
+    seed([
+      { key: 'stale-retire', updatedAt: now - 300 * DAY, accessCount: 0 },
+      { key: 'stale-keep', updatedAt: now - 310 * DAY, accessCount: 0 },
+    ]);
+
+    const first = await auditLearningsCommand.action(ctx({ apply: true, force: true }));
+    expect((first.data as { nominated: number }).nominated).toBe(2);
+    expect((first.data as { archived: number }).archived).toBe(1);
+    expect(fs.existsSync(path.join(tmp, '.moflo', AUDIT_STATE_FILE))).toBe(true);
+
+    fs.rmSync(judgeLog, { force: true });
+    const second = await auditLearningsCommand.action(ctx());
+
+    const data = second.data as { nominated: number; counts: Record<string, number>; judged: number };
+    expect(data.nominated).toBe(0);
+    expect(data.counts.unused).toBe(0);
+    // Idempotence has to reach the model call too, or a quiet re-run still costs
+    // a headless spawn every time.
+    expect(data.judged).toBe(0);
+    expect(fs.existsSync(judgeLog)).toBe(false);
+  });
+
+  it('--recheck re-examines entries that already carry a verdict', async () => {
+    seed([{ key: 'stale-keep', updatedAt: now - 300 * DAY, accessCount: 0 }]);
+
+    await auditLearningsCommand.action(ctx({ apply: true, force: true }));
+    const rechecked = await auditLearningsCommand.action(ctx({ recheck: true }));
+
+    expect((rechecked.data as { nominated: number }).nominated).toBe(1);
+  });
+
+  it('reaches the skip path from the real CLI spelling of the flag', async () => {
+    // The parser turns `--no-<x>` into `<x> = false`, so an option NAMED
+    // `no-judge` parses into a flag nothing reads and the skip silently never
+    // happens. Asserted through the real parser rather than the option list,
+    // because the list looks correct under either spelling.
+    const parser = new CommandParser();
+    parser.registerCommand(auditLearningsCommand);
+
+    const parsed = parser.parse(['audit-learnings', '--no-judge']);
+
+    expect(parsed.flags.judge).toBe(false);
+    seed([{ key: 'stale-retire', updatedAt: now - 300 * DAY, accessCount: 0 }]);
+
+    const result = await auditLearningsCommand.action({ ...ctx(), flags: parsed.flags });
+
+    expect(fs.existsSync(judgeLog)).toBe(false);
+    expect((result.data as { judgeSkipped: boolean }).judgeSkipped).toBe(true);
+  });
+
+  it('leaves the store untouched when the judge fails', async () => {
+    seed([{ key: 'stale-retire', updatedAt: now - 300 * DAY, accessCount: 0 }]);
+    const failing = path.join(tmp, 'failing-stub.cjs');
+    fs.writeFileSync(failing, 'process.exit(3);\n', 'utf-8');
+    process.env[JUDGE_STUB_ENV] = failing;
+
+    const result = await auditLearningsCommand.action(ctx({ apply: true, force: true }));
+
+    expect(result.success).toBe(true);
+    expect((result.data as { archived: number }).archived).toBe(0);
+    expect(statusOf('stale-retire')).toBe('active');
+  });
+});

--- a/src/cli/__tests__/commands/spell-schedule.test.ts
+++ b/src/cli/__tests__/commands/spell-schedule.test.ts
@@ -652,7 +652,9 @@ describe('spell schedule command', () => {
       mockCallMCP.mockImplementationOnce(async () => ({ success: true }));
 
       await createCmd().action!(makeCtx({
-        flags: { _: [], name: 'audit', cron: '0 9 * * *', noAutostart: true },
+        // `autostart: false` is what `--no-autostart` parses to; the previous
+        // `noAutostart: true` was a key the parser never produces (#1474).
+        flags: { _: [], name: 'audit', cron: '0 9 * * *', autostart: false },
       })) as CommandResult;
 
       expect(mockReconcile).not.toHaveBeenCalled();

--- a/src/cli/__tests__/memory/learnings-audit.test.ts
+++ b/src/cli/__tests__/memory/learnings-audit.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Unit tests for the pure curation passes behind `flo memory audit-learnings`
+ * (#1466).
+ *
+ * The module is deliberately free of fs/db/spawn, so every one of these runs
+ * against plain objects — which is the point: the ranking and clustering rules
+ * are the part that decides what a model gets asked about, and they need to be
+ * checkable without a store.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  AUDIT_VERDICTS,
+  DEFAULT_UNUSED_MIN_AGE_MS,
+  buildAuditPlan,
+  buildJudgePrompt,
+  findDuplicates,
+  findSuperseded,
+  findUnused,
+  parseVerdicts,
+  selectArchivable,
+  selectManualActions,
+  type AuditRow,
+  type AuditVerdict,
+} from '../../memory/learnings-audit.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = 1_800_000_000_000;
+
+function row(overrides: Partial<AuditRow> & { key: string }): AuditRow {
+  return {
+    id: `id-${overrides.key}`,
+    content: `content for ${overrides.key}`,
+    embedding: null,
+    createdAt: NOW - 10 * DAY,
+    updatedAt: NOW - 10 * DAY,
+    accessCount: 3,
+    ...overrides,
+  };
+}
+
+/** A unit vector rotated by `angle` — lets a test dial cosine similarity exactly. */
+function vec(angle: number): number[] {
+  return [Math.cos(angle), Math.sin(angle), 0, 0];
+}
+
+describe('findDuplicates', () => {
+  it('nominates the older member and keeps the newest as representative', () => {
+    const rows = [
+      row({ key: 'older', embedding: vec(0), updatedAt: NOW - 5 * DAY }),
+      row({ key: 'newest', embedding: vec(0.01), updatedAt: NOW }),
+    ];
+
+    const found = findDuplicates(rows, 0.9);
+
+    expect(found).toHaveLength(1);
+    expect(found[0].row.key).toBe('older');
+    expect(found[0].duplicateOf).toBe('newest');
+    expect(found[0].similarity).toBeGreaterThan(0.9);
+  });
+
+  it('leaves entries below the threshold alone', () => {
+    const rows = [
+      row({ key: 'a', embedding: vec(0), updatedAt: NOW }),
+      row({ key: 'b', embedding: vec(Math.PI / 3), updatedAt: NOW - DAY }), // cos 60° = 0.5
+    ];
+
+    expect(findDuplicates(rows, 0.9)).toEqual([]);
+  });
+
+  it('never nominates every member of a cluster — one statement always survives', () => {
+    const rows = [
+      row({ key: 'a', embedding: vec(0), updatedAt: NOW }),
+      row({ key: 'b', embedding: vec(0.01), updatedAt: NOW - DAY }),
+      row({ key: 'c', embedding: vec(0.02), updatedAt: NOW - 2 * DAY }),
+    ];
+
+    const found = findDuplicates(rows, 0.9);
+
+    expect(found.map((f) => f.row.key).sort()).toEqual(['b', 'c']);
+    expect(new Set(found.map((f) => f.duplicateOf))).toEqual(new Set(['a']));
+  });
+
+  it('skips rows with no stored vector rather than re-embedding them', () => {
+    // IDENTICAL content, no stored vectors. Anything that computed an embedding
+    // here would score these at 1.0 and cluster them — finding nothing is the
+    // proof that the pass reads the column and never calls the embedder.
+    const rows = [
+      row({ key: 'vectorless-1', content: 'exactly the same words', embedding: null }),
+      row({ key: 'vectorless-2', content: 'exactly the same words', embedding: null }),
+    ];
+
+    expect(findDuplicates(rows, 0.9)).toEqual([]);
+  });
+
+  it('ignores a zero vector, which has no direction to compare', () => {
+    const rows = [
+      row({ key: 'zero-a', embedding: [0, 0, 0, 0], updatedAt: NOW }),
+      row({ key: 'zero-b', embedding: [0, 0, 0, 0], updatedAt: NOW - DAY }),
+    ];
+
+    expect(findDuplicates(rows, 0.9)).toEqual([]);
+  });
+});
+
+describe('findUnused', () => {
+  it('nominates only never-used entries past the age floor', () => {
+    const rows = [
+      row({ key: 'old-unused', accessCount: 0, updatedAt: NOW - 200 * DAY }),
+      row({ key: 'old-but-used', accessCount: 4, updatedAt: NOW - 200 * DAY }),
+      row({ key: 'recent-unused', accessCount: 0, updatedAt: NOW - DAY }),
+    ];
+
+    const found = findUnused(rows, { now: NOW, minAgeMs: DEFAULT_UNUSED_MIN_AGE_MS });
+
+    expect(found.map((r) => r.key)).toEqual(['old-unused']);
+  });
+
+  it('ranks least-recently-updated first and caps at the limit', () => {
+    const rows = [
+      row({ key: 'middle', accessCount: 0, updatedAt: NOW - 200 * DAY }),
+      row({ key: 'oldest', accessCount: 0, updatedAt: NOW - 400 * DAY }),
+      row({ key: 'newest', accessCount: 0, updatedAt: NOW - 100 * DAY }),
+    ];
+
+    const found = findUnused(rows, { now: NOW, minAgeMs: 90 * DAY, limit: 2 });
+
+    expect(found.map((r) => r.key)).toEqual(['oldest', 'middle']);
+  });
+});
+
+describe('findSuperseded', () => {
+  it('returns nothing against the shipped (empty) vocabulary', () => {
+    const rows = [row({ key: 'a', content: 'anything at all' })];
+
+    expect(findSuperseded(rows)).toEqual([]);
+  });
+
+  it('matches a retired term on word boundaries, case-insensitively', () => {
+    const vocabulary = [{ from: 'widget', to: 'gadget' }];
+    const rows = [
+      row({ key: 'hit', content: 'The Widget cache must be flushed first.' }),
+      row({ key: 'substring-only', content: 'widgetfactory is unrelated' }),
+    ];
+
+    const found = findSuperseded(rows, vocabulary);
+
+    expect(found.map((f) => f.row.key)).toEqual(['hit']);
+    expect(found[0].terms[0].to).toBe('gadget');
+  });
+
+  it('does not treat a regex metacharacter in a term as a pattern', () => {
+    const vocabulary = [{ from: 'a.b', to: 'a-b' }];
+    const rows = [row({ key: 'literal-only', content: 'axb should not match' })];
+
+    expect(findSuperseded(rows, vocabulary)).toEqual([]);
+  });
+});
+
+describe('buildAuditPlan', () => {
+  it('reports per-bucket counts and unions the buckets into one candidate set', () => {
+    const rows = [
+      row({ key: 'dup-old', embedding: vec(0), updatedAt: NOW - DAY }),
+      row({ key: 'dup-new', embedding: vec(0.01), updatedAt: NOW }),
+      row({ key: 'stale', accessCount: 0, updatedAt: NOW - 300 * DAY }),
+    ];
+
+    const plan = buildAuditPlan(rows, { now: NOW });
+
+    expect(plan.examined).toBe(3);
+    expect(plan.counts.duplicate).toBe(1);
+    expect(plan.counts.unused).toBe(1);
+    expect(plan.counts.superseded).toBe(0);
+    expect(plan.candidates.map((c) => c.key).sort()).toEqual(['dup-old', 'stale']);
+  });
+
+  it('records both buckets on an entry two passes agree on, and ranks it first', () => {
+    const rows = [
+      row({ key: 'both', embedding: vec(0), accessCount: 0, updatedAt: NOW - 300 * DAY }),
+      row({ key: 'representative', embedding: vec(0.01), updatedAt: NOW }),
+      row({ key: 'only-unused', accessCount: 0, updatedAt: NOW - 200 * DAY }),
+    ];
+
+    const plan = buildAuditPlan(rows, { now: NOW });
+
+    expect(plan.candidates[0].key).toBe('both');
+    expect(plan.candidates[0].buckets.sort()).toEqual(['duplicate', 'unused']);
+    expect(plan.candidates[0].duplicateOf).toBe('representative');
+  });
+
+  it('skips entries whose recorded verdict still matches their content', () => {
+    const rows = [row({ key: 'stale', content: 'body', accessCount: 0, updatedAt: NOW - 300 * DAY })];
+    const hashContent = (c: string): string => `h:${c}`;
+
+    const plan = buildAuditPlan(rows, {
+      now: NOW,
+      hashContent,
+      decided: new Map([['stale', { verdict: 'KEEP' as AuditVerdict, hash: 'h:body', at: NOW }]]),
+    });
+
+    expect(plan.alreadyDecided).toBe(1);
+    expect(plan.candidates).toEqual([]);
+    expect(plan.counts.unused).toBe(0);
+  });
+
+  it('re-nominates an entry that was rewritten since its verdict', () => {
+    const rows = [row({ key: 'stale', content: 'rewritten', accessCount: 0, updatedAt: NOW - 300 * DAY })];
+    const hashContent = (c: string): string => `h:${c}`;
+
+    const plan = buildAuditPlan(rows, {
+      now: NOW,
+      hashContent,
+      decided: new Map([['stale', { verdict: 'KEEP' as AuditVerdict, hash: 'h:body', at: NOW }]]),
+    });
+
+    expect(plan.alreadyDecided).toBe(0);
+    expect(plan.candidates.map((c) => c.key)).toEqual(['stale']);
+  });
+
+  it('picks the cluster representative from every row, not just the undecided ones', () => {
+    // The newest entry already carries a KEEP, so it drops out of the pending
+    // set. Clustering over `pending` alone would promote the older restatement
+    // to representative and nominate the NEWER entry — the inversion the
+    // newest-first sort exists to prevent.
+    const rows = [
+      row({ key: 'newest-kept', content: 'body', embedding: vec(0), updatedAt: NOW }),
+      row({ key: 'older-a', embedding: vec(0.01), updatedAt: NOW - 5 * DAY }),
+      row({ key: 'older-b', embedding: vec(0.02), updatedAt: NOW - 6 * DAY }),
+    ];
+    const hashContent = (c: string): string => `h:${c}`;
+
+    const plan = buildAuditPlan(rows, {
+      now: NOW,
+      hashContent,
+      decided: new Map([['newest-kept', { verdict: 'KEEP' as AuditVerdict, hash: 'h:body', at: NOW }]]),
+    });
+
+    expect(plan.candidates.map((c) => c.key).sort()).toEqual(['older-a', 'older-b']);
+    for (const candidate of plan.candidates) expect(candidate.duplicateOf).toBe('newest-kept');
+  });
+
+  it('reports what the unused pass matched, not only what its cap let through', () => {
+    const rows = Array.from({ length: 10 }, (_, i) =>
+      row({ key: `stale-${i}`, accessCount: 0, updatedAt: NOW - (300 + i) * DAY }),
+    );
+
+    const plan = buildAuditPlan(rows, { now: NOW, unusedLimit: 3 });
+
+    // Printing only "3" on a store with 10 matches reads as full coverage.
+    expect(plan.unusedCoverage).toEqual({ matched: 10, nominated: 3 });
+    expect(plan.counts.unused).toBe(3);
+  });
+
+  it('caps the candidate set at the judge limit and reports the overflow', () => {
+    const rows = Array.from({ length: 5 }, (_, i) =>
+      row({ key: `stale-${i}`, accessCount: 0, updatedAt: NOW - (300 + i) * DAY }),
+    );
+
+    const plan = buildAuditPlan(rows, { now: NOW, judgeLimit: 2 });
+
+    expect(plan.candidates).toHaveLength(2);
+    expect(plan.overflow).toBe(3);
+  });
+});
+
+describe('buildJudgePrompt', () => {
+  it('carries the KEEP/RETIRE/COMPRESS/MERGE table and every candidate key', () => {
+    const plan = buildAuditPlan(
+      [
+        row({ key: 'dup-old', embedding: vec(0), updatedAt: NOW - DAY }),
+        row({ key: 'dup-new', embedding: vec(0.01), updatedAt: NOW }),
+      ],
+      { now: NOW },
+    );
+
+    const prompt = buildJudgePrompt(plan.candidates, NOW);
+
+    for (const verdict of AUDIT_VERDICTS) expect(prompt).toContain(verdict);
+    expect(prompt).toContain('dup-old');
+    expect(prompt).toContain('near-duplicate of "dup-new"');
+  });
+
+  it('caps each body so one long entry cannot blow up the prompt', () => {
+    const plan = buildAuditPlan(
+      [row({ key: 'long', content: 'x'.repeat(5_000), accessCount: 0, updatedAt: NOW - 300 * DAY })],
+      { now: NOW },
+    );
+
+    expect(buildJudgePrompt(plan.candidates, NOW).length).toBeLessThan(3_000);
+  });
+});
+
+describe('parseVerdicts', () => {
+  it('reads tab-separated verdict lines', () => {
+    const text = 'alpha\tRETIRE\tmigration finished\nbeta\tKEEP\tstill bites';
+
+    const verdicts = parseVerdicts(text, ['alpha', 'beta']);
+
+    expect(verdicts.get('alpha')).toEqual({ verdict: 'RETIRE', reason: 'migration finished' });
+    expect(verdicts.get('beta')?.verdict).toBe('KEEP');
+  });
+
+  it('survives a preamble, list markers, and pipe separators', () => {
+    const text = [
+      'Here are my verdicts:',
+      '',
+      '1. alpha | MERGE | restates beta',
+      '- beta | KEEP | load-bearing',
+    ].join('\n');
+
+    const verdicts = parseVerdicts(text, ['alpha', 'beta']);
+
+    expect(verdicts.get('alpha')?.verdict).toBe('MERGE');
+    expect(verdicts.get('beta')?.verdict).toBe('KEEP');
+  });
+
+  it('keeps a key that starts with digits intact', () => {
+    // A bare [-*\d.\s]+ strip eats the front of `1466-lesson`, the key then
+    // fails the known-keys check, and the verdict is silently dropped.
+    const verdicts = parseVerdicts('1466-lesson\tRETIRE\tsuperseded', ['1466-lesson']);
+
+    expect(verdicts.get('1466-lesson')?.verdict).toBe('RETIRE');
+  });
+
+  it('ignores keys that were never sent, so a hallucination cannot cause an archive', () => {
+    const verdicts = parseVerdicts('invented\tRETIRE\tnope', ['alpha']);
+
+    expect(verdicts.size).toBe(0);
+  });
+
+  it('ignores a verdict word outside the vocabulary', () => {
+    const verdicts = parseVerdicts('alpha\tDELETE\tnot a verdict', ['alpha']);
+
+    expect(verdicts.size).toBe(0);
+  });
+});
+
+describe('selectArchivable', () => {
+  it('archives RETIRE only — never KEEP, COMPRESS, or MERGE', () => {
+    const plan = buildAuditPlan(
+      ['retire-me', 'merge-me', 'keep-me', 'compress-me'].map((key, i) =>
+        row({ key, accessCount: 0, updatedAt: NOW - (300 + i) * DAY }),
+      ),
+      { now: NOW },
+    );
+    const verdicts = new Map<string, { verdict: AuditVerdict; reason: string }>([
+      ['retire-me', { verdict: 'RETIRE', reason: '' }],
+      ['merge-me', { verdict: 'MERGE', reason: '' }],
+      ['keep-me', { verdict: 'KEEP', reason: '' }],
+      ['compress-me', { verdict: 'COMPRESS', reason: '' }],
+    ]);
+
+    // MERGE means "fold these into one" and nothing here performs the fold, so
+    // archiving on it deletes content the verdict said to preserve. Worse, both
+    // members of a pair can honestly be answered MERGE.
+    expect(selectArchivable(plan.candidates, verdicts).map((c) => c.key)).toEqual(['retire-me']);
+    expect(selectManualActions(plan.candidates, verdicts).map((m) => m.candidate.key).sort()).toEqual([
+      'compress-me',
+      'merge-me',
+    ]);
+  });
+
+  it('never archives the survivor of a cluster, even when another pass nominated it', () => {
+    // The newest statement of the rule is old and never used, so `findUnused`
+    // nominates it independently of the duplicate pass that was protecting it.
+    const rows = [
+      row({ key: 'survivor', embedding: vec(0), accessCount: 0, updatedAt: NOW - 300 * DAY }),
+      row({ key: 'restatement', embedding: vec(0.01), accessCount: 0, updatedAt: NOW - 400 * DAY }),
+    ];
+    const plan = buildAuditPlan(rows, { now: NOW });
+    const verdicts = new Map<string, { verdict: AuditVerdict; reason: string }>(
+      plan.candidates.map((c) => [c.key, { verdict: 'RETIRE' as AuditVerdict, reason: '' }]),
+    );
+
+    expect(plan.candidates.map((c) => c.key).sort()).toEqual(['restatement', 'survivor']);
+
+    const archivable = selectArchivable(plan.candidates, verdicts).map((c) => c.key);
+
+    expect(archivable).toEqual(['restatement']);
+    expect(archivable).not.toContain('survivor');
+  });
+
+  it('archives nothing when no verdict came back', () => {
+    const plan = buildAuditPlan([row({ key: 'a', accessCount: 0, updatedAt: NOW - 300 * DAY })], { now: NOW });
+
+    expect(selectArchivable(plan.candidates, new Map())).toEqual([]);
+  });
+});

--- a/src/cli/__tests__/negative-flags-1474.test.ts
+++ b/src/cli/__tests__/negative-flags-1474.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Every `--no-<x>` flag reaches the code that reads it (#1474).
+ *
+ * These were all silent no-ops: each option was declared `no-<x>`, so the parser
+ * — which turns `--no-<x>` into `<x> = false` — never produced the `noX` key the
+ * handler read. `--no-dashboard` started a dashboard, `--no-embeddings` embedded,
+ * `--no-autostart` registered a login service.
+ *
+ * Note what does NOT pin this: the parser negates `--no-<x>` into `<x> = false`
+ * regardless of how the option is declared, so renaming a declaration changes no
+ * parsed key and a test over parser output passes before and after the fix. The
+ * regression is pinned by `tests/guards/negative-option-name-guard.test.ts`,
+ * whose second guard forbids any `flags.no<Something>` read — with `no-*`
+ * declarations banned, the parser can never emit such a key, so every one of
+ * those reads is a permanent `undefined`.
+ *
+ * What this file adds is the positive half: that the key each handler now reads
+ * carries the right value for both spellings, parsed through the REAL registered
+ * command rather than a fixture. Together they cover both directions — the guard
+ * stops a reader reaching for a key that cannot exist, these show the key that
+ * does exist means what the handler thinks it means.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { CommandParser } from '../parser.js';
+import { getCommandAsync } from '../commands/index.js';
+import type { Command } from '../types.js';
+
+/** Parse `argv` against the real registered `command`, returning its flags. */
+async function parseFor(command: string, argv: string[]): Promise<Record<string, unknown>> {
+  const parser = new CommandParser();
+  const cmd = await getCommandAsync(command);
+  expect(cmd, `command '${command}' is not registered`).toBeTruthy();
+  parser.registerCommand(cmd as Command);
+  return parser.parse([command, ...argv]).flags as unknown as Record<string, unknown>;
+}
+
+describe('--no-<x> flags take effect (#1474)', () => {
+  it('flo daemon start --no-dashboard suppresses the dashboard', async () => {
+    const off = await parseFor('daemon', ['start', '--no-dashboard']);
+    const on = await parseFor('daemon', ['start']);
+
+    // daemon.ts reads `ctx.flags.dashboard === false`.
+    expect(off.dashboard === false).toBe(true);
+    expect(on.dashboard === false).toBe(false);
+  });
+
+  it('flo memory index-guidance --no-embeddings skips embedding generation', async () => {
+    const off = await parseFor('memory', ['index-guidance', '--no-embeddings']);
+    const on = await parseFor('memory', ['index-guidance']);
+
+    // memory.ts reads `ctx.flags.embeddings === false` in both index-guidance
+    // and code-map.
+    expect(off.embeddings === false).toBe(true);
+    expect(on.embeddings === false).toBe(false);
+  });
+
+  it('flo memory code-map --no-embeddings skips embedding generation', async () => {
+    const off = await parseFor('memory', ['code-map', '--no-embeddings']);
+
+    expect(off.embeddings === false).toBe(true);
+  });
+
+  it('flo hooks coverage-route --no-movector disables the native backend', async () => {
+    const off = await parseFor('hooks', ['coverage-route', '--no-movector']);
+    const on = await parseFor('hooks', ['coverage-route']);
+
+    // hooks.ts reads `ctx.flags.movector !== false`.
+    expect(off.movector !== false).toBe(false);
+    expect(on.movector !== false).toBe(true);
+  });
+
+  it('flo hooks statusline --no-color drops ANSI colors', async () => {
+    const off = await parseFor('hooks', ['statusline', '--no-color']);
+    const on = await parseFor('hooks', ['statusline']);
+
+    // hooks.ts reads `ctx.flags.color === false`.
+    expect(off.color === false).toBe(true);
+    expect(on.color === false).toBe(false);
+  });
+
+  it('flo spell schedule --no-autostart skips the login-service registration', async () => {
+    const off = await parseFor('spell', ['schedule', '--no-autostart']);
+    const on = await parseFor('spell', ['schedule']);
+
+    // spell-schedule.ts reads `ctx.flags.autostart === false`.
+    expect(off.autostart === false).toBe(true);
+    expect(on.autostart === false).toBe(false);
+  });
+
+  it('flo hive-mind spawn --no-auto-permissions stops automatic permission handling', async () => {
+    const off = await parseFor('hive-mind', ['spawn', '--no-auto-permissions']);
+    const on = await parseFor('hive-mind', ['spawn']);
+
+    // hive-mind.ts reads `flags.autoPermissions === false`.
+    expect(off.autoPermissions === false).toBe(true);
+    expect(on.autoPermissions === false).toBe(false);
+  });
+
+  it('flo epic run --no-merge forces the single-branch strategy', async () => {
+    const off = await parseFor('epic', ['run', '42', '--no-merge']);
+    const on = await parseFor('epic', ['run', '42']);
+
+    // epic.ts reads `ctx.flags.merge === false`. This one had teeth: the flag is
+    // documented as an alias for --strategy single-branch, and while it was a
+    // no-op an epic asked for single-branch ran auto-merge instead.
+    expect(off.merge === false).toBe(true);
+    expect(on.merge === false).toBe(false);
+  });
+
+  it('the global --no-update suppresses the startup update check', () => {
+    const parser = new CommandParser();
+    const off = parser.parse(['--no-update']).flags as unknown as Record<string, unknown>;
+    const on = parser.parse([]).flags as unknown as Record<string, unknown>;
+
+    // index.ts reads `flags.update !== false`.
+    expect(off.update !== false).toBe(false);
+    expect(on.update !== false).toBe(true);
+  });
+
+  it('the global --no-color disables colored output', () => {
+    // Global options live on the parser, not the command tree. This one also
+    // had the defect: `index.ts` read `flags.noColor`, which the parser never
+    // set, so `--no-color` never disabled anything.
+    const parser = new CommandParser();
+    const off = parser.parse(['--no-color']).flags as unknown as Record<string, unknown>;
+    const on = parser.parse([]).flags as unknown as Record<string, unknown>;
+
+    // index.ts reads `flags.color === false`.
+    expect(off.color === false).toBe(true);
+    // A global's declared default IS applied, unlike a command-level one.
+    expect(on.color).toBe(true);
+  });
+});

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -64,7 +64,7 @@ const startCommand: Command = {
     { name: 'max-cpu-load', type: 'string', description: 'Override maxCpuLoad resource threshold (e.g. 4.0)' },
     { name: 'min-free-memory', type: 'string', description: 'Override minFreeMemoryPercent resource threshold (e.g. 15)' },
     { name: 'dashboard-port', type: 'string', description: `Dashboard HTTP port (default: ${DEFAULT_DASHBOARD_PORT})` },
-    { name: 'no-dashboard', type: 'boolean', description: 'Disable the dashboard HTTP server' },
+    { name: 'dashboard', type: 'boolean', default: true, description: 'Dashboard HTTP server (--no-dashboard to disable)' },
   ],
   examples: [
     { command: 'flo daemon start', description: 'Start daemon in background (default)' },
@@ -75,7 +75,10 @@ const startCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const quiet = ctx.flags.quiet as boolean;
     const foreground = ctx.flags.foreground as boolean;
-    const noDashboard = ctx.flags.noDashboard as boolean;
+    // `--no-dashboard` parses to `dashboard = false`; there has never been a
+    // `noDashboard` flag for the parser to set (#1474). The internal name stays
+    // negative because it is threaded through the start/attach helpers below.
+    const noDashboard = ctx.flags.dashboard === false;
     const rawDashboardPort = ctx.flags.dashboardPort as string | undefined;
     // #1315 — the shared chokepoint. Every daemon-start path lands here:
     // `maybeAutoStartDaemon`, the session-start launcher, bin/hooks.mjs, the

--- a/src/cli/commands/epic.ts
+++ b/src/cli/commands/epic.ts
@@ -611,7 +611,11 @@ const epicCommand: Command = {
           return { success: false, message: 'Usage: flo epic <issue-number> [--strategy] [--no-merge] [--verbose] [--dry-run]' };
         }
         const dryRun = ctx.flags.dryRun === true;
-        const noMerge = ctx.flags.noMerge === true;
+        // `--no-merge` parses to `merge = false`; there has never been a
+        // `noMerge` key, so this read was always undefined and the documented
+        // alias silently did nothing — an epic asked for single-branch ran
+        // auto-merge instead (#1474).
+        const noMerge = ctx.flags.merge === false;
         const verbose = ctx.flags['verbose'] === true;
         const strategyFlag = ctx.flags['strategy'] as string | undefined;
         let strategy: EpicStrategy = 'single-branch';

--- a/src/cli/commands/hive-mind.ts
+++ b/src/cli/commands/hive-mind.ts
@@ -268,7 +268,9 @@ async function spawnClaudeCodeInstance(
       // explicitly set to 'autonomous' via flag. Non-interactive mode is
       // required for headless execution, so --dangerously-skip-permissions
       // is always included — but --allowedTools restricts the blast radius.
-      const noAutoPerms = flags.noAutoPermissions;
+      // `--no-auto-permissions` parses to `autoPermissions = false`; there has
+      // never been a `noAutoPermissions` key for the parser to set (#1474).
+      const noAutoPerms = flags.autoPermissions === false;
       if (!noAutoPerms) {
         const permLevel = (flags.permissionLevel as string) ?? 'elevated';
         const resolved = resolvePermissions(permLevel);
@@ -560,10 +562,10 @@ const spawnCommand: Command = {
       default: 'elevated'
     },
     {
-      name: 'no-auto-permissions',
-      description: 'Disable automatic permission handling (Claude will prompt for each action)',
+      name: 'auto-permissions',
+      description: 'Automatic permission handling (--no-auto-permissions to prompt for each action)',
       type: 'boolean',
-      default: false
+      default: true
     },
     {
       name: 'dry-run',

--- a/src/cli/commands/hooks.ts
+++ b/src/cli/commands/hooks.ts
@@ -2512,10 +2512,10 @@ const coverageRouteCommand: Command = {
       default: 80
     },
     {
-      name: 'no-movector',
-      description: 'Disable movector integration',
+      name: 'movector',
+      description: 'movector integration (--no-movector to disable)',
       type: 'boolean',
-      default: false
+      default: true
     }
   ],
   examples: [
@@ -2525,7 +2525,7 @@ const coverageRouteCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const task = ctx.args[0] || ctx.flags.task as string;
     const threshold = ctx.flags.threshold as number || 80;
-    const useNativeBackend = !ctx.flags.noMovector;
+    const useNativeBackend = ctx.flags.movector !== false;
 
     if (!task) {
       output.printError('Task description is required. Use --task or -t flag.');
@@ -3134,10 +3134,10 @@ const statuslineCommand: Command = {
       default: false
     },
     {
-      name: 'no-color',
-      description: 'Disable ANSI colors',
+      name: 'color',
+      description: 'ANSI colors (--no-color to disable)',
       type: 'boolean',
-      default: false
+      default: true
     }
   ],
   examples: [
@@ -3379,7 +3379,7 @@ const statuslineCommand: Command = {
     }
 
     // Full colored output
-    const noColor = ctx.flags.noColor;
+    const noColor = ctx.flags.color === false;
     const c = noColor ? {
       reset: '', bold: '', dim: '', red: '', green: '', yellow: '', blue: '',
       purple: '', cyan: '', brightRed: '', brightGreen: '', brightYellow: '',

--- a/src/cli/commands/memory-audit-learnings.ts
+++ b/src/cli/commands/memory-audit-learnings.ts
@@ -1,0 +1,593 @@
+/**
+ * `flo memory audit-learnings` (#1466) — curation pass over durable learnings.
+ *
+ * Every side effect the audit needs lives here: reading the store, the
+ * verdict-state file, the bounded headless model call, and the archive write.
+ * The judgement itself is pure and lives in `memory/learnings-audit.ts`, which
+ * is what makes the clustering and ranking testable without a database.
+ *
+ * **Dry by default.** A run with no flags reads, nominates, judges, and prints;
+ * it never writes to the store. `--apply` archives (`status = 'archived'`) via
+ * the same `archiveDurableRow` primitive `flo memory delete` uses, so the
+ * deletion carries a tombstone the #1463 reconciler can propagate instead of
+ * being silently re-imported on the next session start.
+ *
+ * Cross-platform (Rule #1): `path.join` throughout, `child_process.spawn` with
+ * an argument array (no shell), `windowsHide` on the child, and no POSIX-only
+ * utilities.
+ *
+ * @module commands/memory-audit-learnings
+ */
+
+import * as fs from 'fs';
+import * as pathModule from 'path';
+import { spawn } from 'child_process';
+import type { Command, CommandContext, CommandResult } from '../types.js';
+import { output } from '../output.js';
+import { confirm } from '../prompt.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
+import { deleteEntry } from '../memory/entries-write.js';
+import { openDaemonDatabase, type SqlJsLikeDatabase } from '../memory/daemon-backend.js';
+import { resolveBridgeDbPath } from '../memory/bridge-core.js';
+import { findProjectRoot } from '../services/project-root.js';
+import { hasMemoryEntriesTable } from '../services/cherry-pick-learnings.js';
+import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
+import { hashContent } from '../memory/auto-memory-bridge.js';
+import {
+  LEARNINGS_NAMESPACE,
+  buildAuditPlan,
+  buildJudgePrompt,
+  parseVerdicts,
+  selectArchivable,
+  selectManualActions,
+  DEFAULT_DUPLICATE_THRESHOLD,
+  DEFAULT_JUDGE_LIMIT,
+  DEFAULT_UNUSED_LIMIT,
+  DEFAULT_UNUSED_MIN_AGE_MS,
+  type AuditCandidate,
+  type AuditPlan,
+  type AuditRow,
+  type AuditVerdict,
+  type DecidedEntry,
+} from '../memory/learnings-audit.js';
+
+/** Where recorded verdicts live. Local-only — never part of the shared artifact. */
+export const AUDIT_STATE_FILE = 'learnings-audit.json';
+/** Bump when the record shape changes; an older file is discarded, not migrated. */
+const AUDIT_STATE_VERSION = 1;
+/** Cheap formatter/judge model — same tier the auto-meditate distill runs on. */
+const JUDGE_MODEL_ID = 'claude-haiku-4-5-20251001';
+/** Hard ceiling on the headless judge; killed past this. */
+const JUDGE_TIMEOUT_MS = 180_000;
+/** Narrowest read-only tool grant for the judge child. See `runJudge`. */
+const JUDGE_ALLOWED_TOOLS = 'Read';
+
+/**
+ * Test seam mirroring `bin/meditate-distill.mjs`: when set to a script path the
+ * judge runs as `node <stub> --print <prompt>` instead of `claude --print
+ * <prompt>`, so the spawn is exercisable on all three platforms without a real
+ * Claude CLI on PATH.
+ */
+export const JUDGE_STUB_ENV = 'MOFLO_AUDIT_LEARNINGS_NODE_STUB';
+
+interface AuditState {
+  version: number;
+  decided: Record<string, DecidedEntry>;
+}
+
+function stateFilePath(projectRoot: string): string {
+  return pathModule.join(projectRoot, '.moflo', AUDIT_STATE_FILE);
+}
+
+/** Read recorded verdicts. Any unreadable or stale-version file reads as empty. */
+export function readAuditState(projectRoot: string): Map<string, DecidedEntry> {
+  try {
+    const raw = fs.readFileSync(stateFilePath(projectRoot), 'utf-8');
+    const parsed = JSON.parse(raw) as AuditState;
+    if (parsed?.version !== AUDIT_STATE_VERSION || !parsed.decided) return new Map();
+    return new Map(Object.entries(parsed.decided));
+  } catch {
+    // Absent, truncated, or hand-edited into invalid JSON. Losing the record
+    // costs one re-judgement; refusing to run over it costs the command.
+    return new Map();
+  }
+}
+
+/**
+ * Write the verdict record back.
+ *
+ * Read-modify-write with no lock: two `--apply` runs racing on the same project
+ * would lose one run's verdicts. Not worth a lock — this is a hand-invoked
+ * curation command, the loss costs one re-judgement, and `atomicWriteFileSync`
+ * already rules out a torn file (its temp name is pid- and random-suffixed, so
+ * concurrent writers cannot clobber each other's staging file either).
+ */
+export function writeAuditState(projectRoot: string, decided: ReadonlyMap<string, DecidedEntry>): void {
+  const file = stateFilePath(projectRoot);
+  fs.mkdirSync(pathModule.dirname(file), { recursive: true });
+  const payload: AuditState = { version: AUDIT_STATE_VERSION, decided: Object.fromEntries(decided) };
+  atomicWriteFileSync(file, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+/**
+ * Parse a stored embedding. A malformed vector reads as absent rather than
+ * throwing — one bad row must not take the whole audit down.
+ */
+function parseEmbedding(raw: unknown): number[] | null {
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) && parsed.length > 0 ? (parsed as number[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load the active learnings rows the audit operates on.
+ *
+ * The missing-table case is PROBED rather than caught. A blanket try/catch here
+ * would turn a corrupt or locked database into a cheerful "0 active learnings
+ * examined", which is the same lie #1149 exists to prevent — a real read failure
+ * must reach the caller.
+ */
+export function readLearningsRows(db: SqlJsLikeDatabase): AuditRow[] {
+  if (!hasMemoryEntriesTable(db)) return [];
+
+  const result = db.exec(
+    `SELECT id, key, content, embedding, created_at, updated_at, access_count
+       FROM memory_entries
+      WHERE status = 'active' AND namespace = ?`,
+    [LEARNINGS_NAMESPACE],
+  );
+
+  return (result[0]?.values ?? []).map((row) => {
+    const [id, key, content, embedding, createdAt, updatedAt, accessCount] = row;
+    return {
+      id: String(id ?? ''),
+      key: String(key ?? ''),
+      content: String(content ?? ''),
+      embedding: parseEmbedding(embedding),
+      createdAt: Number(createdAt) || 0,
+      updatedAt: Number(updatedAt) || 0,
+      accessCount: Number(accessCount) || 0,
+    };
+  });
+}
+
+interface JudgeResult {
+  ok: boolean;
+  output: string;
+  error?: string;
+}
+
+/**
+ * Run one bounded headless judgement. Never throws — a failure is a result.
+ *
+ * The prompt goes over **stdin**, not argv. `bin/meditate-distill.mjs` passes
+ * its prompt as an argument, which is safe there because it sends 25 one-line
+ * lessons; this one sends up to 60 entries with 400-char bodies — roughly 36 KB,
+ * comfortably past Windows' 32,767-character `CreateProcess` command-line limit,
+ * so an argv prompt would fail on Windows at the DEFAULT settings (Rule #1).
+ * `claude --print` with no positional prompt reads stdin, which has no such cap
+ * on any platform.
+ */
+function runJudge(projectRoot: string, prompt: string): Promise<JudgeResult> {
+  return new Promise((resolve) => {
+    const stub = process.env[JUDGE_STUB_ENV];
+    const cmd = stub ? process.execPath : 'claude';
+    // The judge reads a prompt and writes verdict lines — it needs no tools at
+    // all. The flag wants a value, so grant the narrowest read-only one rather
+    // than leaving the child with an unrestricted default (Write/Edit/Bash) in
+    // somebody else's repository.
+    const args = stub ? [stub, '--print'] : ['--print', '--allowedTools', JUDGE_ALLOWED_TOOLS];
+
+    let child;
+    try {
+      child = spawn(cmd, args, {
+        cwd: projectRoot,
+        env: {
+          ...process.env,
+          // Mark the child so its own hooks no-op (#860) — without this the
+          // judge would trip the session-start indexer chain in every consumer.
+          CLAUDE_CODE_HEADLESS: 'true',
+          ANTHROPIC_MODEL: JUDGE_MODEL_ID,
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+    } catch (err) {
+      resolve({ ok: false, output: '', error: err instanceof Error ? err.message : String(err) });
+      return;
+    }
+
+    let text = '';
+    let settled = false;
+    const finish = (r: JudgeResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(r);
+    };
+    const timer = setTimeout(() => {
+      try { child.kill('SIGTERM'); } catch { /* already gone */ }
+      finish({ ok: false, output: text, error: `timed out after ${JUDGE_TIMEOUT_MS}ms` });
+    }, JUDGE_TIMEOUT_MS);
+
+    child.stdout?.on('data', (d) => { text += String(d); });
+    child.stderr?.on('data', (d) => { text += String(d); });
+    child.on('error', (err) => finish({ ok: false, output: text, error: err.message }));
+    child.on('close', (code) => finish({ ok: code === 0, output: text }));
+
+    // A child that exits before reading the prompt makes this write EPIPE.
+    // That is the same failure the `close` handler is about to report, so
+    // swallow it here rather than letting it reach the process as unhandled.
+    child.stdin?.on('error', () => { /* reported via close/error above */ });
+    try {
+      child.stdin?.end(prompt, 'utf-8');
+    } catch {
+      /* same — the exit path carries the diagnosis */
+    }
+  });
+}
+
+function toPositiveNumber(value: unknown, fallback: number): number {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/** `--unused-min-age-days` in ms, falling back to the module default. */
+function unusedMinAgeMs(flag: unknown): number {
+  const days = Number(flag);
+  return Number.isFinite(days) && days > 0 ? days * 24 * 60 * 60 * 1000 : DEFAULT_UNUSED_MIN_AGE_MS;
+}
+
+function printPlan(plan: AuditPlan): void {
+  output.writeln();
+  output.writeln(output.bold('Nominations'));
+  output.printTable({
+    columns: [
+      { key: 'bucket', header: 'Bucket', width: 24 },
+      { key: 'count', header: 'Count', width: 10, align: 'right' },
+    ],
+    data: [
+      { bucket: 'Near-duplicate', count: plan.counts.duplicate },
+      { bucket: 'Unused and old', count: plan.counts.unused },
+      { bucket: 'Superseded vocabulary', count: plan.counts.superseded },
+      { bucket: output.bold('To judge'), count: output.bold(String(plan.candidates.length)) },
+    ],
+  });
+
+  const notes: string[] = [
+    `${plan.examined} active learning${plan.examined === 1 ? '' : 's'} examined`,
+  ];
+  if (plan.unusedCoverage.matched > plan.unusedCoverage.nominated) {
+    // Never let a cap read as full coverage.
+    notes.push(
+      `${plan.unusedCoverage.matched} entries are unused and old; the ${plan.unusedCoverage.nominated} `
+      + 'least-recently-updated were nominated (--unused-limit to widen)',
+    );
+  }
+  if (plan.alreadyDecided > 0) {
+    notes.push(`${plan.alreadyDecided} already carry a recorded verdict (--recheck to re-examine)`);
+  }
+  if (plan.withoutEmbedding > 0) {
+    notes.push(`${plan.withoutEmbedding} have no stored vector — invisible to the duplicate pass`);
+  }
+  if (plan.overflow > 0) {
+    notes.push(`${plan.overflow} nomination(s) over the judge limit — they resurface next run`);
+  }
+  output.printList(notes);
+}
+
+function printVerdicts(
+  candidates: readonly AuditCandidate[],
+  verdicts: ReadonlyMap<string, { verdict: AuditVerdict; reason: string }>,
+): void {
+  output.writeln();
+  output.writeln(output.bold('Verdicts'));
+  output.printTable({
+    columns: [
+      { key: 'key', header: 'Entry', width: 44 },
+      { key: 'verdict', header: 'Verdict', width: 10 },
+      { key: 'reason', header: 'Reason', width: 46 },
+    ],
+    data: candidates
+      .filter((c) => verdicts.has(c.key))
+      .map((c) => {
+        const v = verdicts.get(c.key)!;
+        return { key: c.key, verdict: v.verdict, reason: v.reason };
+      }),
+  });
+
+  const unanswered = candidates.length - verdicts.size;
+  if (unanswered > 0) {
+    output.printWarning(`${unanswered} entr${unanswered === 1 ? 'y' : 'ies'} received no verdict — left untouched`);
+  }
+}
+
+/** Say what a non-archiving verdict is asking for, so it never just evaporates. */
+function printManualActions(
+  manual: ReadonlyArray<{ candidate: AuditCandidate; verdict: AuditVerdict }>,
+): void {
+  if (manual.length === 0) return;
+  output.writeln();
+  output.printInfo(
+    `${manual.length} entr${manual.length === 1 ? 'y needs' : 'ies need'} an author, not an archive — `
+    + '--apply never removes these, because both verdicts mean the content still has to survive:',
+  );
+  output.printList(
+    manual.map(({ candidate, verdict }) =>
+      verdict === 'MERGE'
+        ? `${candidate.key} — MERGE into ${candidate.duplicateOf ?? 'its near-duplicate'}, then retire it`
+        : `${candidate.key} — COMPRESS: rewrite to 1-3 sentences`,
+    ),
+  );
+}
+
+export const auditLearningsCommand: Command = {
+  name: 'audit-learnings',
+  description: 'Evaluate durable learnings for staleness (dry by default)',
+  options: [
+    {
+      name: 'apply',
+      description: 'Archive entries the audit judged RETIRE or MERGE',
+      type: 'boolean',
+      default: false,
+    },
+    {
+      // Declared positively. The parser turns `--no-<x>` into `<x> = false`
+      // (parser.ts § long flag), so an option NAMED `no-judge` would be
+      // unreachable: typing `--no-judge` sets `judge`, and nothing reads it.
+      name: 'judge',
+      description: 'Request a model verdict for nominated entries (--no-judge to skip)',
+      type: 'boolean',
+      default: true,
+    },
+    {
+      name: 'recheck',
+      description: 'Re-examine entries that already carry a recorded verdict',
+      type: 'boolean',
+      default: false,
+    },
+    {
+      name: 'duplicate-threshold',
+      description: `Cosine similarity for near-duplicates (default ${DEFAULT_DUPLICATE_THRESHOLD})`,
+      type: 'number',
+    },
+    {
+      name: 'unused-min-age-days',
+      description: `Age floor before an unused entry is nominated (default ${DEFAULT_UNUSED_MIN_AGE_MS / 86_400_000})`,
+      type: 'number',
+    },
+    {
+      name: 'unused-limit',
+      description: `Max unused entries nominated (default ${DEFAULT_UNUSED_LIMIT})`,
+      type: 'number',
+    },
+    {
+      name: 'judge-limit',
+      description: `Max entries sent for a verdict (default ${DEFAULT_JUDGE_LIMIT})`,
+      type: 'number',
+    },
+    {
+      name: 'force',
+      short: 'f',
+      description: 'Skip the confirmation prompt on --apply',
+      type: 'boolean',
+      default: false,
+    },
+  ],
+  examples: [
+    { command: 'flo memory audit-learnings', description: 'Dry run — nominate, judge, and report' },
+    { command: 'flo memory audit-learnings --no-judge', description: 'Mechanical nominations only, no model call' },
+    { command: 'flo memory audit-learnings --apply', description: 'Archive the entries judged RETIRE' },
+  ],
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    try {
+      return await runAudit(ctx);
+    } catch (error) {
+      // Opening the store, reading it, or writing the verdict record can all
+      // throw. Report them as a failed command rather than an unhandled
+      // rejection that prints a stack trace over the plan the user just read.
+      output.printError(`audit-learnings failed: ${errorDetail(error)}`);
+      return { success: false, exitCode: 1 };
+    }
+  },
+};
+
+async function runAudit(ctx: CommandContext): Promise<CommandResult> {
+    const apply = ctx.flags.apply === true;
+    const judge = ctx.flags.judge !== false;
+    const recheck = ctx.flags.recheck === true;
+    const force = ctx.flags.force === true;
+    const asJson = ctx.flags.format === 'json';
+
+    const projectRoot = findProjectRoot({ cwd: process.cwd() });
+    const dbPath = resolveBridgeDbPath(projectRoot);
+
+    if (!fs.existsSync(dbPath)) {
+      output.printError(`No memory store found at ${dbPath}. Run: flo memory init`);
+      return { success: false, exitCode: 1 };
+    }
+
+    // Always load the record: `--recheck` bypasses it for NOMINATION only.
+    // Starting from an empty map and writing that back would erase every prior
+    // verdict, making the next ordinary run re-nominate and re-pay for the whole
+    // judged set — the opposite of what a recheck is asking for.
+    const decided = readAuditState(projectRoot);
+    const decidedForPlan = recheck ? new Map<string, DecidedEntry>() : decided;
+
+    let rows: AuditRow[];
+    const db = openDaemonDatabase(dbPath);
+    try {
+      rows = readLearningsRows(db);
+    } finally {
+      db.close();
+    }
+
+    const plan = buildAuditPlan(rows, {
+      duplicateThreshold: toPositiveNumber(ctx.flags.duplicateThreshold, DEFAULT_DUPLICATE_THRESHOLD),
+      unusedLimit: toPositiveNumber(ctx.flags.unusedLimit, DEFAULT_UNUSED_LIMIT),
+      judgeLimit: toPositiveNumber(ctx.flags.judgeLimit, DEFAULT_JUDGE_LIMIT),
+      decided: decidedForPlan,
+      unusedMinAgeMs: unusedMinAgeMs(ctx.flags.unusedMinAgeDays),
+      hashContent,
+    });
+
+    if (!asJson) {
+      if (!apply) output.writeln(output.warning('DRY RUN - No changes will be made'));
+      printPlan(plan);
+    }
+
+    // Report the number sent for a verdict on every path, including the paths
+    // that send none — "0 judged" and "judging skipped" are different answers
+    // and a reader has to be able to tell them apart.
+    let verdicts = new Map<string, { verdict: AuditVerdict; reason: string }>();
+    let judged = 0;
+    let judgeError: string | undefined;
+
+    if (!judge) {
+      judgeError = 'skipped (--no-judge)';
+    } else if (plan.candidates.length === 0) {
+      judgeError = undefined;
+    } else {
+      judged = plan.candidates.length;
+      if (!asJson) {
+        output.printInfo(`Requesting a verdict for ${judged} nominated entr${judged === 1 ? 'y' : 'ies'}…`);
+      }
+      const result = await runJudge(projectRoot, buildJudgePrompt(plan.candidates));
+      if (result.ok) {
+        verdicts = parseVerdicts(result.output, plan.candidates.map((c) => c.key));
+      } else {
+        judgeError = result.error ?? 'the judge exited non-zero';
+      }
+    }
+
+    if (judgeError && judge && !asJson) {
+      output.printWarning(`No verdicts: ${judgeError}. Nominations above stand; nothing was archived.`);
+    }
+    if (!asJson && verdicts.size > 0) printVerdicts(plan.candidates, verdicts);
+
+    const archivable = selectArchivable(plan.candidates, verdicts);
+    const manual = selectManualActions(plan.candidates, verdicts);
+    if (!asJson) printManualActions(manual);
+
+    const summary = {
+      dryRun: !apply,
+      examined: plan.examined,
+      alreadyDecided: plan.alreadyDecided,
+      counts: plan.counts,
+      nominated: plan.candidates.length,
+      overflow: plan.overflow,
+      judged,
+      judgeSkipped: !judge,
+      judgeError,
+      verdicts: Object.fromEntries([...verdicts].map(([k, v]) => [k, v.verdict])),
+      archivable: archivable.map((c) => c.key),
+      archiveFailures: [] as string[],
+      manualActions: manual.map(({ candidate, verdict }) => ({ key: candidate.key, verdict })),
+      archived: 0,
+    };
+
+    if (!apply) {
+      if (asJson) output.printJson(summary);
+      else if (archivable.length > 0) {
+        output.writeln();
+        output.printInfo(`Re-run with --apply to archive ${archivable.length} entr${archivable.length === 1 ? 'y' : 'ies'}.`);
+      }
+      return { success: true, data: summary };
+    }
+
+    if (verdicts.size === 0) {
+      // Without verdicts there is nothing to apply. Nominations are evidence,
+      // not decisions — archiving on them alone is exactly the age-based purge
+      // this command exists to replace.
+      const reason = 'No verdicts to apply — nominations alone are not a decision.';
+      if (asJson) output.printJson({ ...summary, applied: false, reason });
+      else output.printWarning(reason);
+      return { success: true, data: summary };
+    }
+
+    if (archivable.length > 0 && !force) {
+      // A prompt needs somewhere to read the answer from. Under `--format json`,
+      // in CI, or from a cron entry there is no terminal, and `confirm()` would
+      // block forever on a pipe that never sends a line — so say what is needed
+      // and decline instead of hanging.
+      const canPrompt = ctx.interactive && process.stdin.isTTY === true && !asJson;
+      if (!canPrompt) {
+        const pending = { ...summary, applied: false, reason: 'Confirmation required — re-run with --force.' };
+        if (asJson) output.printJson(pending);
+        else output.printWarning(`${pending.reason} (no interactive terminal to confirm on)`);
+        return { success: true, data: pending };
+      }
+      const confirmed = await confirm({
+        message: `Archive ${archivable.length} learning${archivable.length === 1 ? '' : 's'}?`,
+        default: false,
+      });
+      if (!confirmed) {
+        output.printInfo('Audit cancelled — nothing was archived');
+        return { success: true, data: summary };
+      }
+    }
+
+    // Every mutation goes through `deleteEntry`, never a direct handle on the
+    // store. This command runs in the foreground while the user's daemon is very
+    // likely holding `.moflo/moflo.db`, and a raw cross-process write there is
+    // exactly the single-writer violation epic #1054 exists to prevent — the
+    // whitelist classifies `durable-store-io` as `daemon-offline` for that
+    // reason, and this caller is not offline. Routing also means the archive
+    // semantics are inherited rather than restated: `deleteEntry` and
+    // `bridgeDeleteEntry` both send a durable namespace to `archiveDurableRow`,
+    // so a `learnings` delete already archives, keeps the row, and leaves the
+    // tombstone #1463's reconciler propagates.
+    //
+    // No `dbPath` is passed on purpose: supplying one is how a caller opts OUT
+    // of that routing, which would put the raw write straight back.
+    let archived = 0;
+    const archiveFailures: string[] = [];
+    for (const candidate of archivable) {
+      try {
+        const result = await deleteEntry({ key: candidate.key, namespace: LEARNINGS_NAMESPACE });
+        if (result?.deleted === true) archived++;
+        else archiveFailures.push(`${candidate.key}: ${result?.error ?? 'not deleted'}`);
+      } catch (err) {
+        archiveFailures.push(`${candidate.key}: ${errorDetail(err)}`);
+      }
+    }
+
+    // Record every verdict, not just the archived ones. A KEEP that is not
+    // recorded is re-nominated by the same mechanical pass on the next run,
+    // which would make the audit permanently noisy instead of idempotent.
+    const now = Date.now();
+    const nextState = new Map(decided);
+    for (const candidate of plan.candidates) {
+      const v = verdicts.get(candidate.key);
+      if (!v) continue;
+      nextState.set(candidate.key, { verdict: v.verdict, hash: hashContent(candidate.content), at: now });
+    }
+    writeAuditState(projectRoot, nextState);
+
+    summary.dryRun = false;
+    summary.archived = archived;
+    summary.archiveFailures = archiveFailures;
+    if (archiveFailures.length > 0 && !asJson) {
+      // Never let a partial apply read as a clean one: the verdict record below
+      // still marks these decided, so a silent failure would retire them from
+      // the audit's attention without ever removing them.
+      output.printWarning(`${archiveFailures.length} entr${archiveFailures.length === 1 ? 'y' : 'ies'} could not be archived:`);
+      output.printList(archiveFailures);
+    }
+    if (asJson) {
+      output.printJson({ ...summary, applied: true });
+    } else {
+      output.writeln();
+      output.printSuccess(`Archived ${archived} learning${archived === 1 ? '' : 's'}`);
+      output.printList([
+        `Verdicts recorded: ${verdicts.size}`,
+        'Archived entries are excluded from memory_search, flo memory list, and memory_stats.',
+      ]);
+    }
+
+    return { success: true, data: { ...summary, applied: true } };
+}

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -1860,7 +1860,7 @@ const indexGuidanceCommand: Command = {
       type: 'string'
     },
     {
-      name: 'no-embeddings',
+      name: 'embeddings',
       description: 'Skip embedding generation after indexing',
       type: 'boolean',
       default: false
@@ -1880,7 +1880,7 @@ const indexGuidanceCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const forceReindex = ctx.flags.force as boolean;
     const specificFile = ctx.flags.file as string | undefined;
-    const skipEmbeddings = ctx.flags.noEmbeddings as boolean;
+    const skipEmbeddings = ctx.flags.embeddings === false;
     const overlapPercent = (ctx.flags.overlap as number) || DEFAULT_OVERLAP_PERCENT;
     const NAMESPACE = 'guidance';
 
@@ -2391,7 +2391,7 @@ const codeMapCommand: Command = {
       default: false
     },
     {
-      name: 'no-embeddings',
+      name: 'embeddings',
       description: 'Skip embedding generation after mapping',
       type: 'boolean',
       default: false
@@ -2406,7 +2406,7 @@ const codeMapCommand: Command = {
     const forceRegen = ctx.flags.force as boolean;
     const verbose = ctx.flags.verbose as boolean;
     const statsOnly = ctx.flags.stats as boolean;
-    const skipEmbeddings = ctx.flags.noEmbeddings as boolean;
+    const skipEmbeddings = ctx.flags.embeddings === false;
     const cwd = ctx.cwd || process.cwd();
 
     output.writeln();

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -16,6 +16,7 @@ import { memoryDbPath } from '../services/moflo-paths.js';
 import { resolveBridgeDbPath } from '../memory/bridge-core.js';
 import { findProjectRoot } from '../services/project-root.js';
 import { generateId } from '../shared/utils/id.js';
+import { auditLearningsCommand } from './memory-audit-learnings.js';
 
 // Memory backends
 const BACKENDS = [
@@ -3060,7 +3061,7 @@ const restoreCommand: Command = {
 export const memoryCommand: Command = {
   name: 'memory',
   description: 'Memory management commands',
-  subcommands: [initMemoryCommand, storeCommand, retrieveCommand, searchCommand, listCommand, deleteCommand, statsCommand, configureCommand, cleanupCommand, compressCommand, exportCommand, importCommand, indexGuidanceCommand, rebuildIndexCommand, codeMapCommand, refreshCommand, restoreLearningsCommand, syncCommand, teamExportCommand, teamImportCommand, backupCommand, restoreCommand],
+  subcommands: [initMemoryCommand, storeCommand, retrieveCommand, searchCommand, listCommand, deleteCommand, statsCommand, configureCommand, cleanupCommand, auditLearningsCommand, compressCommand, exportCommand, importCommand, indexGuidanceCommand, rebuildIndexCommand, codeMapCommand, refreshCommand, restoreLearningsCommand, syncCommand, teamExportCommand, teamImportCommand, backupCommand, restoreCommand],
   options: [],
   examples: [
     { command: 'flo memory store -k "key" -v "value"', description: 'Store data' },

--- a/src/cli/commands/spell-schedule.ts
+++ b/src/cli/commands/spell-schedule.ts
@@ -93,7 +93,7 @@ const createCommand: Command = {
     { name: 'cron', short: 'c', description: 'Cron expression (5-field)', type: 'string' },
     { name: 'interval', short: 'i', description: 'Interval (e.g., "6h", "30m", "1d")', type: 'string' },
     { name: 'at', short: 'a', description: 'One-time ISO 8601 datetime', type: 'string' },
-    { name: 'no-autostart', description: 'Do not register the daemon as an OS login service', type: 'boolean' },
+    { name: 'autostart', description: 'Register the daemon as an OS login service (--no-autostart to skip)', type: 'boolean', default: true },
   ],
   examples: [
     { command: 'moflo spell schedule create -n audit --cron "0 9 * * *"', description: 'Daily at 9am' },
@@ -192,8 +192,10 @@ const createCommand: Command = {
     // Short-circuit: a fresh create can only ever trigger an install (count
     // just went up). If the service is already installed, the reconcile is a
     // guaranteed noop — skip the count fetch entirely.
-    // Note: parser normalises --no-autostart to ctx.flags.noAutostart (#787).
-    const skipAutostart = ctx.flags.noAutostart === true;
+    // The parser turns `--no-autostart` into `autostart = false`; it has never
+    // produced a `noAutostart` key, so the previous read here was always
+    // undefined and the flag was a no-op (#1474).
+    const skipAutostart = ctx.flags.autostart === false;
     const alreadyInstalled = readiness.daemonInstalled;
     let reconcileTransition: 'installed' | 'uninstalled' | 'noop' = 'noop';
     if (!skipAutostart && !alreadyInstalled) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -169,7 +169,7 @@ export class CLI {
         return;
       }
 
-      if (flags.noColor) {
+      if (flags.color === false) {
         this.output.setColorEnabled(false);
       }
 
@@ -189,7 +189,9 @@ export class CLI {
       }
 
       // Run startup update check (non-blocking, silent on skip)
-      if (!flags.noUpdate && commandPath[0] !== 'update') {
+      // `--no-update` parses to `update = false`; `noUpdate` was never set, so
+      // the check ran even when the user asked it not to (#1474).
+      if (flags.update !== false && commandPath[0] !== 'update') {
         this.checkForUpdatesOnStartup().catch(() => {/* silent */});
       }
 

--- a/src/cli/memory/learnings-audit.ts
+++ b/src/cli/memory/learnings-audit.ts
@@ -1,0 +1,571 @@
+/**
+ * Curation pass over the `learnings` namespace (#1466).
+ *
+ * `flo memory cleanup` purges by age, which is the wrong instrument for durable
+ * rows — a three-year-old lesson about a footgun that still exists is worth more
+ * than last week's note about a migration that finished. #1464 made that
+ * explicit by exempting durable namespaces from age-based cleanup, which left
+ * `learnings` with no evaluation surface at all: a consumer store reached 1,582
+ * entries with no way to tell which of them were still true.
+ *
+ * The shape that makes this affordable at that size is **mechanical filters
+ * first, model judgement last**. The filters here do not decide anything — they
+ * nominate. Three cheap passes (near-duplicate clustering over the embeddings
+ * already stored on the row, least-used-and-old ranking, and retired-vocabulary
+ * matching) narrow ~1,500 entries to a few dozen, and only those go to a model.
+ * A full-store LLM sweep is the design this exists to avoid.
+ *
+ * This module is pure by construction: no filesystem, no database, no spawning.
+ * Rows come in, a plan comes out. The command layer
+ * (`commands/memory-audit-learnings.ts`) owns every side effect, which is what
+ * makes the ranking and clustering testable without a store.
+ *
+ * @module memory/learnings-audit
+ */
+
+/** The namespace this audit is scoped to. */
+export const LEARNINGS_NAMESPACE = 'learnings';
+
+/**
+ * One row of the audit's input, already parsed out of `memory_entries`.
+ *
+ * `embedding` is the vector as stored — the default path never re-embeds, which
+ * is what keeps the duplicate pass free.
+ */
+export interface AuditRow {
+  id: string;
+  key: string;
+  content: string;
+  /** Parsed embedding, or null when the row has none (unusable for clustering). */
+  embedding: number[] | null;
+  createdAt: number;
+  updatedAt: number;
+  accessCount: number;
+}
+
+/** Why an entry was nominated. An entry can be nominated by more than one pass. */
+export type AuditBucket = 'duplicate' | 'unused' | 'superseded';
+
+/**
+ * The verdict vocabulary, taken verbatim from the auto-memory decision table in
+ * `.claude/guidance/internal/memory-hygiene.md`. Deliberately not reinvented:
+ * the judgement being made here — "would removing this entry make a future
+ * decision wrong?" — is the same judgement that table already encodes for `.md`
+ * memories, and two vocabularies for one decision is how they drift apart.
+ */
+export type AuditVerdict = 'KEEP' | 'RETIRE' | 'COMPRESS' | 'MERGE';
+
+export const AUDIT_VERDICTS: readonly AuditVerdict[] = ['KEEP', 'RETIRE', 'COMPRESS', 'MERGE'];
+
+/**
+ * A term that has been retired in favour of another, used to flag entries still
+ * speaking the old language.
+ */
+export interface SupersededTerm {
+  /** The retired term. Matched case-insensitively on word boundaries. */
+  from: string;
+  /** What replaced it — shown to the model as context, never applied automatically. */
+  to: string;
+  /** Optional one-line explanation of the rename. */
+  note?: string;
+}
+
+/**
+ * Retired vocabulary. **Ships empty, and a guard test keeps it that way.**
+ *
+ * A rename is always local to one project: the consumer that renamed `foo` to
+ * `bar` is the only project where an entry saying `foo` is stale, and shipping
+ * their row would flag innocent entries in every other consumer's store — while
+ * also publishing that consumer's internal vocabulary to everyone who installs
+ * moflo (Rule #3). The row shape is documented rather than demonstrated for the
+ * same reason.
+ *
+ * A project that wants entries flagged fills this in downstream:
+ *
+ *     { from: 'old-term', to: 'new-term', note: 'renamed in <their ticket>' }
+ */
+export const SUPERSEDED_VOCABULARY: readonly SupersededTerm[] = [];
+
+/** An entry nominated for a verdict, with the evidence that nominated it. */
+export interface AuditCandidate {
+  key: string;
+  id: string;
+  content: string;
+  createdAt: number;
+  updatedAt: number;
+  accessCount: number;
+  /** Every pass that nominated this entry, in pass order. */
+  buckets: AuditBucket[];
+  /**
+   * For a `duplicate` nomination, the key of the cluster representative this
+   * entry is a near-copy of. The representative itself is never nominated.
+   */
+  duplicateOf?: string;
+  /** Cosine similarity to {@link duplicateOf}. */
+  similarity?: number;
+  /** For a `superseded` nomination, the retired terms found in the content. */
+  supersededTerms?: SupersededTerm[];
+}
+
+/** Per-bucket nomination counts, reported before any model is involved. */
+export interface AuditBucketCounts {
+  duplicate: number;
+  unused: number;
+  superseded: number;
+}
+
+/**
+ * How many rows the unused pass MATCHED, before its cap.
+ *
+ * Reported separately because the two numbers diverge by design: the cap exists
+ * so a store written before usage recording began does not nominate its entire
+ * contents, which means `counts.unused` is a sample. Printing only the capped
+ * number would read as "25 unused entries" on a store with 800 of them — a
+ * silent truncation presented as full coverage.
+ */
+export interface UnusedCoverage {
+  matched: number;
+  nominated: number;
+}
+
+export interface AuditPlan {
+  /** Active learnings rows examined. */
+  examined: number;
+  /** Rows skipped because a prior `--apply` already recorded a verdict for them. */
+  alreadyDecided: number;
+  /** Rows with no stored vector — invisible to the duplicate pass. */
+  withoutEmbedding: number;
+  counts: AuditBucketCounts;
+  /** What the unused pass matched vs. what its cap let through. */
+  unusedCoverage: UnusedCoverage;
+  /** The union of all three buckets, ranked, capped by `judgeLimit`. */
+  candidates: AuditCandidate[];
+  /** Nominations dropped by `judgeLimit`; they resurface on the next run. */
+  overflow: number;
+}
+
+/** A verdict already recorded by a previous `--apply`, keyed by entry key. */
+export interface DecidedEntry {
+  verdict: AuditVerdict;
+  /** Content hash at the time of the decision — a rewritten entry is re-judged. */
+  hash: string;
+  at: number;
+}
+
+export interface AuditPlanOptions {
+  /**
+   * Cosine similarity at or above which two entries are near-duplicates.
+   * Higher than the 0.80 the memory protocol treats as a confident *search*
+   * hit: retrieval wants topical neighbours, this wants restatements.
+   */
+  duplicateThreshold?: number;
+  /** Minimum age (ms since last update) before an unused entry is nominated. */
+  unusedMinAgeMs?: number;
+  /**
+   * Cap on `unused` nominations. This bucket needs a cap the other two do not:
+   * usage recording only started with #1464, so every entry written before it
+   * reads as zero-usage regardless of how load-bearing it is. Ranking least-used
+   * first and taking the top N is what the ticket means by "a cheap way to rank
+   * what deserves a model's attention" rather than a delete rule.
+   */
+  unusedLimit?: number;
+  /** Hard cap on candidates sent for a verdict — bounds the prompt and its cost. */
+  judgeLimit?: number;
+  /** Retired vocabulary to match against. Defaults to the (empty) shipped table. */
+  vocabulary?: readonly SupersededTerm[];
+  /** Verdicts recorded by a previous `--apply`, keyed by entry key. */
+  decided?: ReadonlyMap<string, DecidedEntry>;
+  /** Stable content hash, injected so the module stays free of `node:crypto`. */
+  hashContent?: (content: string) => string;
+  /** Clock, injected for deterministic tests. */
+  now?: number;
+}
+
+export const DEFAULT_DUPLICATE_THRESHOLD = 0.9;
+export const DEFAULT_UNUSED_MIN_AGE_MS = 90 * 24 * 60 * 60 * 1000;
+export const DEFAULT_UNUSED_LIMIT = 25;
+export const DEFAULT_JUDGE_LIMIT = 60;
+
+/**
+ * Group near-duplicate rows, returning the non-representative members.
+ *
+ * Greedy single-pass clustering: rows are walked newest-first, so the entry that
+ * survives a cluster is the most recently updated statement of the rule and the
+ * older restatements are the ones nominated. That ordering is the whole point —
+ * a duplicate pass that kept an arbitrary member would sometimes retire the
+ * corrected version and keep the one it replaced.
+ *
+ * Pass the FULL row set, not a filtered one: representatives are chosen from
+ * whatever is handed in, so clustering over a subset can promote an older
+ * restatement to representative and nominate the newer entry instead — exactly
+ * the inversion the newest-first sort exists to prevent. `buildAuditPlan`
+ * therefore clusters over every row and filters the nominations afterwards.
+ *
+ * O(n²) in rows that carry a vector. At the ~1,500 entries this exists for that
+ * is roughly a million comparisons — well under a second, and it costs no
+ * embedding calls at all, which is the trade the ticket asks for. Vectors are
+ * normalised once up front rather than through `cosineSim`, which would
+ * recompute both magnitudes on every one of those comparisons.
+ */
+export function findDuplicates(
+  rows: readonly AuditRow[],
+  threshold: number = DEFAULT_DUPLICATE_THRESHOLD,
+): Array<{ row: AuditRow; duplicateOf: string; similarity: number }> {
+  const embedded = rows
+    .filter((r): r is AuditRow & { embedding: number[] } => Array.isArray(r.embedding) && r.embedding.length > 0)
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .map((row) => {
+      let sumSquares = 0;
+      for (const component of row.embedding) sumSquares += component * component;
+      const magnitude = Math.sqrt(sumSquares);
+      // A zero vector has no direction, so it can neither match nor be matched.
+      // `unit: null` keeps it in the walk without ever passing the threshold.
+      const unit = magnitude === 0 ? null : row.embedding.map((component) => component / magnitude);
+      return { row, unit };
+    });
+
+  const claimed = new Set<string>();
+  const found: Array<{ row: AuditRow; duplicateOf: string; similarity: number }> = [];
+
+  for (let i = 0; i < embedded.length; i++) {
+    const representative = embedded[i];
+    if (!representative.unit || claimed.has(representative.row.key)) continue;
+    for (let j = i + 1; j < embedded.length; j++) {
+      const other = embedded[j];
+      if (!other.unit || claimed.has(other.row.key)) continue;
+
+      // Both vectors are unit length, so the dot product IS the cosine.
+      const length = Math.min(representative.unit.length, other.unit.length);
+      let similarity = 0;
+      for (let k = 0; k < length; k++) similarity += representative.unit[k] * other.unit[k];
+      if (similarity < threshold) continue;
+
+      // Claim the member, not the representative: a representative that stayed
+      // claimable could be absorbed into a later cluster and nominated itself,
+      // which would leave the rule with no surviving statement at all.
+      claimed.add(other.row.key);
+      found.push({ row: other.row, duplicateOf: representative.row.key, similarity });
+    }
+  }
+
+  return found;
+}
+
+/**
+ * Rank never-used entries older than `minAgeMs`, least-recently-updated first,
+ * and return the top `limit`.
+ *
+ * Nomination only. Zero recorded usage is weak evidence — usage recording is
+ * newer than most of the rows it is being read against — which is exactly why
+ * this feeds a model rather than a DELETE.
+ */
+export function findUnused(
+  rows: readonly AuditRow[],
+  options: { now: number; minAgeMs?: number; limit?: number },
+): AuditRow[] {
+  const minAgeMs = options.minAgeMs ?? DEFAULT_UNUSED_MIN_AGE_MS;
+  const limit = options.limit ?? DEFAULT_UNUSED_LIMIT;
+  const cutoff = options.now - minAgeMs;
+
+  return rows
+    .filter((r) => r.accessCount <= 0 && r.updatedAt <= cutoff)
+    .sort((a, b) => a.updatedAt - b.updatedAt)
+    .slice(0, Math.max(0, limit));
+}
+
+/** Escape a vocabulary term for use inside a RegExp. */
+function escapeRegExp(term: string): string {
+  return term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Find entries still using retired vocabulary.
+ *
+ * Matched on word boundaries so a retired `db` does not fire on `dbPath`, and
+ * case-insensitively so a rename survives the entry's own capitalisation. With
+ * the shipped table empty this returns nothing, which is the intended default.
+ */
+export function findSuperseded(
+  rows: readonly AuditRow[],
+  vocabulary: readonly SupersededTerm[] = SUPERSEDED_VOCABULARY,
+): Array<{ row: AuditRow; terms: SupersededTerm[] }> {
+  if (vocabulary.length === 0) return [];
+
+  const matchers = vocabulary.map((term) => ({
+    term,
+    re: new RegExp(`\\b${escapeRegExp(term.from)}\\b`, 'i'),
+  }));
+
+  const found: Array<{ row: AuditRow; terms: SupersededTerm[] }> = [];
+  for (const row of rows) {
+    const terms = matchers.filter((m) => m.re.test(row.content)).map((m) => m.term);
+    if (terms.length > 0) found.push({ row, terms });
+  }
+  return found;
+}
+
+/**
+ * Run the three mechanical passes and assemble the candidate set.
+ *
+ * Entries with a recorded verdict whose content has not changed since are
+ * dropped before any pass runs — that is what makes a second run immediately
+ * after `--apply` report nothing (the audit is idempotent), and it is also why
+ * the hash is part of the record: a rewritten entry is a new claim and gets
+ * judged again.
+ */
+export function buildAuditPlan(
+  rows: readonly AuditRow[],
+  options: AuditPlanOptions = {},
+): AuditPlan {
+  const now = options.now ?? Date.now();
+  const decided = options.decided ?? new Map<string, DecidedEntry>();
+  const hash = options.hashContent;
+  const judgeLimit = options.judgeLimit ?? DEFAULT_JUDGE_LIMIT;
+
+  const pending: AuditRow[] = [];
+  let alreadyDecided = 0;
+  for (const row of rows) {
+    const record = decided.get(row.key);
+    // No hash function means we cannot tell a rewrite from the entry we judged;
+    // re-judging is the safe side of that, so the record is ignored.
+    if (record && hash && record.hash === hash(row.content)) {
+      alreadyDecided++;
+      continue;
+    }
+    pending.push(row);
+  }
+
+  const byKey = new Map<string, AuditCandidate>();
+  const nominate = (row: AuditRow, bucket: AuditBucket): AuditCandidate => {
+    let candidate = byKey.get(row.key);
+    if (!candidate) {
+      candidate = {
+        key: row.key,
+        id: row.id,
+        content: row.content,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        accessCount: row.accessCount,
+        buckets: [],
+      };
+      byKey.set(row.key, candidate);
+    }
+    if (!candidate.buckets.includes(bucket)) candidate.buckets.push(bucket);
+    return candidate;
+  };
+
+  const pendingKeys = new Set(pending.map((r) => r.key));
+
+  // Cluster over EVERY row, then keep only the pending nominations. Clustering
+  // over `pending` alone would let a previously-kept newest entry drop out of
+  // the candidate pool and promote an older restatement to representative,
+  // nominating the newer entry instead.
+  const duplicates = findDuplicates(rows, options.duplicateThreshold)
+    .filter((hit) => pendingKeys.has(hit.row.key));
+  for (const hit of duplicates) {
+    const candidate = nominate(hit.row, 'duplicate');
+    candidate.duplicateOf = hit.duplicateOf;
+    candidate.similarity = hit.similarity;
+  }
+
+  const unusedMatched = findUnused(pending, {
+    now,
+    minAgeMs: options.unusedMinAgeMs,
+    limit: Number.POSITIVE_INFINITY,
+  });
+  const unused = unusedMatched.slice(0, Math.max(0, options.unusedLimit ?? DEFAULT_UNUSED_LIMIT));
+  for (const row of unused) nominate(row, 'unused');
+
+  const superseded = findSuperseded(pending, options.vocabulary);
+  for (const hit of superseded) {
+    const candidate = nominate(hit.row, 'superseded');
+    candidate.supersededTerms = hit.terms;
+  }
+
+  const counts: AuditBucketCounts = {
+    duplicate: duplicates.length,
+    unused: unused.length,
+    superseded: superseded.length,
+  };
+
+  // Most-nominated first, then oldest — an entry three passes agree on is the
+  // one a bounded prompt should spend its budget on.
+  const ranked = [...byKey.values()].sort(
+    (a, b) => b.buckets.length - a.buckets.length || a.updatedAt - b.updatedAt,
+  );
+  const candidates = ranked.slice(0, Math.max(0, judgeLimit));
+
+  return {
+    examined: rows.length,
+    alreadyDecided,
+    // Counted over every examined row, matching `examined`'s denominator.
+    withoutEmbedding: rows.filter((r) => !r.embedding || r.embedding.length === 0).length,
+    counts,
+    unusedCoverage: { matched: unusedMatched.length, nominated: unused.length },
+    candidates,
+    overflow: ranked.length - candidates.length,
+  };
+}
+
+/** Per-candidate body cap in the judge prompt — bounds cost, keeps the claim readable. */
+export const JUDGE_CONTENT_CAP = 400;
+
+function describeBuckets(candidate: AuditCandidate): string {
+  const parts: string[] = [];
+  for (const bucket of candidate.buckets) {
+    if (bucket === 'duplicate') {
+      parts.push(
+        `near-duplicate of "${candidate.duplicateOf}" (similarity ${(candidate.similarity ?? 0).toFixed(3)})`,
+      );
+    } else if (bucket === 'unused') {
+      parts.push('never returned by a search since usage recording began');
+    } else {
+      const terms = (candidate.supersededTerms ?? [])
+        .map((t) => `"${t.from}" → "${t.to}"`)
+        .join(', ');
+      parts.push(`uses retired vocabulary: ${terms}`);
+    }
+  }
+  return parts.join('; ');
+}
+
+/**
+ * Build the judgement prompt for the nominated entries.
+ *
+ * The decision table is restated inline rather than referenced by path: the
+ * model answering this runs headless in a consumer's project, where
+ * `.claude/guidance/internal/memory-hygiene.md` does not exist.
+ */
+export function buildJudgePrompt(candidates: readonly AuditCandidate[], now: number = Date.now()): string {
+  const dayMs = 24 * 60 * 60 * 1000;
+  const entries = candidates
+    .map((candidate, index) => {
+      const ageDays = Math.max(0, Math.round((now - candidate.createdAt) / dayMs));
+      const body = candidate.content.length > JUDGE_CONTENT_CAP
+        ? `${candidate.content.slice(0, JUDGE_CONTENT_CAP)}…`
+        : candidate.content;
+      return [
+        `### ${index + 1}. ${candidate.key}`,
+        `- flagged because: ${describeBuckets(candidate)}`,
+        `- age: ${ageDays} day(s); recorded uses: ${candidate.accessCount}`,
+        `- content: ${body.replace(/\s+/g, ' ').trim()}`,
+      ].join('\n');
+    })
+    .join('\n\n');
+
+  return [
+    'You are auditing durable engineering learnings stored in a project memory.',
+    'Each entry below was flagged by a mechanical filter. The filters nominate; you decide.',
+    '',
+    'Classify every entry into exactly one bucket:',
+    '',
+    '| Verdict | When to apply |',
+    '|---|---|',
+    '| KEEP | The entry still drives a decision someone might make today. |',
+    '| RETIRE | Resolved incident, completed migration, or a rule now enforced by a lint/test/CI gate. |',
+    '| COMPRESS | Load-bearing but verbose; the durable signal fits in 1-3 sentences. |',
+    '| MERGE | Restates another entry listed here; the two should become one. |',
+    '',
+    'Only RETIRE removes an entry. MERGE and COMPRESS are reported to a human to act on,',
+    'so use them when the content still needs to survive in some form somewhere.',
+    '',
+    'The test: "if this entry were removed today, would any future decision be wrong?"',
+    'If no — because the situation no longer arises, or a machine gate already prevents the',
+    'failure — it is RETIRE. When genuinely unsure, answer KEEP: a wrongly kept entry costs',
+    'a little search budget, a wrongly retired one costs the lesson.',
+    '',
+    'A near-duplicate flag is evidence, not a verdict: two entries can restate one rule',
+    '(MERGE) or cover genuinely different cases that merely read alike (KEEP).',
+    '',
+    `Answer with exactly ${candidates.length} line(s), nothing else. One line per entry:`,
+    '',
+    '<key><TAB><VERDICT><TAB><reason in under 15 words>',
+    '',
+    '---',
+    '',
+    entries,
+  ].join('\n');
+}
+
+/**
+ * Parse the model's verdict lines, keyed by entry key.
+ *
+ * Deliberately lenient about separators and surrounding prose — the cost of a
+ * strict parser here is discarding a whole batch of correct verdicts over a
+ * stray preamble. Keys not present in `expected` are ignored, so a hallucinated
+ * entry cannot cause an archive.
+ */
+export function parseVerdicts(
+  text: string,
+  expected: readonly string[],
+): Map<string, { verdict: AuditVerdict; reason: string }> {
+  const known = new Set(expected);
+  const out = new Map<string, { verdict: AuditVerdict; reason: string }>();
+
+  for (const rawLine of String(text ?? '').split(/\r?\n/)) {
+    // Strip a list marker only — a bare `[-*\d.\s]+` class also eats the front
+    // of a key like `1466-lesson`, which then fails the `known` check and
+    // silently loses its verdict (and re-nominates on every future run).
+    const line = rawLine.trim().replace(/^(?:[-*+]|\d+[.)])\s+/, '');
+    if (!line) continue;
+    const parts = line.split(/\t|\s*\|\s*|\s{2,}|\s+-\s+/).map((p) => p.trim()).filter(Boolean);
+    if (parts.length < 2) continue;
+
+    const key = parts[0].replace(/^["'`]|["'`]$/g, '');
+    if (!known.has(key) || out.has(key)) continue;
+
+    const verdict = parts[1].toUpperCase().replace(/[^A-Z]/g, '') as AuditVerdict;
+    if (!AUDIT_VERDICTS.includes(verdict)) continue;
+
+    out.set(key, { verdict, reason: parts.slice(2).join(' ') });
+  }
+
+  return out;
+}
+
+/**
+ * The entries `--apply` archives.
+ *
+ * **RETIRE only.** MERGE and COMPRESS both describe work that preserves content
+ * — fold this into that one, rewrite this shorter — and nothing here performs
+ * either. Archiving on those verdicts would delete the very signal the verdict
+ * said to keep, and MERGE is the more dangerous of the two: "restates another
+ * entry listed here" is a true statement about BOTH members of a pair, so a
+ * model answering MERGE twice would erase the rule entirely. They are reported
+ * for an author to act on instead.
+ *
+ * A cluster's representative is excluded even when it is itself nominated. The
+ * duplicate pass protects the newest statement of a rule from its own bucket,
+ * but `findUnused` and `findSuperseded` walk the same rows and can nominate that
+ * representative independently — and a RETIRE on it alongside RETIREs on its
+ * duplicates takes every statement of the rule at once.
+ */
+export function selectArchivable(
+  candidates: readonly AuditCandidate[],
+  verdicts: ReadonlyMap<string, { verdict: AuditVerdict; reason: string }>,
+): AuditCandidate[] {
+  const survivors = new Set(
+    candidates.map((candidate) => candidate.duplicateOf).filter((key): key is string => Boolean(key)),
+  );
+
+  return candidates.filter((candidate) => {
+    if (survivors.has(candidate.key)) return false;
+    return verdicts.get(candidate.key)?.verdict === 'RETIRE';
+  });
+}
+
+/**
+ * Entries whose verdict asks for an author's hand rather than an archive —
+ * MERGE and COMPRESS. Reported so a verdict never silently evaporates.
+ */
+export function selectManualActions(
+  candidates: readonly AuditCandidate[],
+  verdicts: ReadonlyMap<string, { verdict: AuditVerdict; reason: string }>,
+): Array<{ candidate: AuditCandidate; verdict: AuditVerdict }> {
+  const out: Array<{ candidate: AuditCandidate; verdict: AuditVerdict }> = [];
+  for (const candidate of candidates) {
+    const verdict = verdicts.get(candidate.key)?.verdict;
+    if (verdict === 'MERGE' || verdict === 'COMPRESS') out.push({ candidate, verdict });
+  }
+  return out;
+}

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -82,10 +82,14 @@ export class CommandParser {
         choices: ['text', 'json', 'table']
       },
       {
-        name: 'no-color',
-        description: 'Disable colored output',
+        // Declared POSITIVELY. The long-flag branch below turns `--no-<x>` into
+        // `<x> = false`, so an option named `no-color` can never produce a
+        // `noColor` key and every reader of one is dead (#1474). `--no-color`
+        // still works — that spelling IS the negation this parser performs.
+        name: 'color',
+        description: 'Colored output (--no-color to disable)',
         type: 'boolean',
-        default: false
+        default: true
       },
       {
         name: 'interactive',

--- a/tests/epic-command.test.ts
+++ b/tests/epic-command.test.ts
@@ -66,7 +66,10 @@ describe('epic command structure', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const result = await epicCommand.action({
       args: ['run', '42'],
-      flags: { noMerge: true, strategy: 'auto-merge' },
+      // `merge: false` is what `--no-merge` actually parses to. The previous
+      // `noMerge: true` was a key the parser never produces, so this passed
+      // while the real flag did nothing (#1474).
+      flags: { merge: false, strategy: 'auto-merge' },
     });
     expect(result.success).toBe(false);
     expect(result.message).toContain('--no-merge cannot be combined with --strategy auto-merge');

--- a/tests/guards/negative-option-name-guard.test.ts
+++ b/tests/guards/negative-option-name-guard.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Guard: no CLI option may be declared with a `no-` prefixed name (#1474).
+ *
+ * The parser treats `--no-<x>` as boolean negation — it writes
+ * `flags[camelCase(x)] = false` and never produces a `noX` key (see
+ * `CommandParser.parseFlag`, the `arg.startsWith('--no-')` branch). So an option
+ * *declared* `no-judge` is unreachable: typing `--no-judge` sets `judge`, the
+ * handler reads `noJudge`, gets `undefined`, and the flag is a silent no-op.
+ *
+ * Nothing else catches this. There is no type error — `ParsedFlags` is an index
+ * signature — and reviewing the declaration cannot catch it either, because the
+ * declaration looks equally correct under both spellings. Eight options shipped
+ * this way before the guard existed, six of them user-facing no-ops
+ * (`--no-dashboard`, `--no-embeddings` ×2, `--no-movector`, `--no-color`,
+ * `--no-autostart`), and one carried a comment asserting the opposite behaviour.
+ *
+ * The fix is never to rename the reader. Declare the POSITIVE name with
+ * `default: true` and read `flags.<x> !== false`; the `--no-<x>` spelling users
+ * already type keeps working, because negation is what the parser was doing all
+ * along.
+ *
+ * Walks the REAL registered command tree rather than grepping source, so an
+ * option built programmatically is covered too — and asserts the parser
+ * behaviour directly, so the guard fails if the reasoning above ever stops
+ * being true.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { getCommandNames, getCommandAsync } from '../../src/cli/commands/index.js';
+import { CommandParser } from '../../src/cli/parser.js';
+import type { Command } from '../../src/cli/types.js';
+
+async function collectOptionNames(): Promise<Array<{ path: string; name: string }>> {
+  const found: Array<{ path: string; name: string }> = [];
+  const seen = new Set<string>();
+
+  const walk = (cmd: Command, ancestors: string[]): void => {
+    const segments = [...ancestors, cmd.name];
+    const key = segments.join(' ');
+    if (seen.has(key)) return;
+    seen.add(key);
+
+    for (const opt of cmd.options ?? []) found.push({ path: key, name: opt.name });
+    for (const sub of cmd.subcommands ?? []) walk(sub, segments);
+  };
+
+  for (const name of getCommandNames()) {
+    const cmd = await getCommandAsync(name);
+    if (cmd) walk(cmd, []);
+  }
+
+  return found;
+}
+
+describe('negative option names (#1474)', () => {
+  it('no registered command declares an option named no-*', async () => {
+    const offenders = (await collectOptionNames())
+      .filter((opt) => opt.name.startsWith('no-'))
+      .map((opt) => `${opt.path} --${opt.name}`);
+
+    expect(
+      offenders,
+      'Declare the positive name with default: true and read `flags.<x> !== false`. '
+      + '`--no-<x>` keeps working — the parser already negates it.',
+    ).toEqual([]);
+  });
+
+  it('no global option is declared no-* either', () => {
+    // Globals live on the parser, not in the command tree, so the walk above
+    // cannot see them — and the global `no-color` was one of the original eight.
+    const parser = new CommandParser();
+    const globals = (parser as unknown as { globalOptions: Array<{ name: string }> }).globalOptions;
+
+    expect(globals.filter((opt) => opt.name.startsWith('no-')).map((opt) => opt.name)).toEqual([]);
+  });
+
+  it('--no-<x> really does set <x> to false, which is why the rule holds', () => {
+    const parser = new CommandParser();
+    parser.registerCommand({
+      name: 'guard-demo',
+      description: 'fixture',
+      options: [{ name: 'judge', type: 'boolean', default: true }],
+      action: async () => ({ success: true }),
+    } as Command);
+
+    const negated = parser.parse(['guard-demo', '--no-judge']).flags;
+    const bare = parser.parse(['guard-demo']).flags;
+
+    expect(negated.judge).toBe(false);
+    // The key an option named `no-judge` would have needed. It never appears,
+    // which is the whole defect.
+    expect(negated.noJudge).toBeUndefined();
+
+    // And the second half of why the positive spelling needs care: a
+    // command-level `default` is NOT applied unless the option shadows a global
+    // (see CommandParser.applyDefaults), so an unset flag is `undefined`, not
+    // its declared default. Readers must therefore test `!== false` / `=== false`
+    // rather than trust the default to have materialised — a bare truthiness
+    // check on `flags.judge` would read as "off" for the user who passed nothing.
+    expect(bare.judge).toBeUndefined();
+    expect(bare.judge !== false).toBe(true);
+  });
+});
+
+/** Every `.ts` under `src/cli`, excluding tests. */
+function cliSourceFiles(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      if (name === '__tests__' || name === 'node_modules') continue;
+      cliSourceFiles(full, out);
+      continue;
+    }
+    if (name.endsWith('.ts') && !name.endsWith('.test.ts') && !name.endsWith('.d.ts')) out.push(full);
+  }
+  return out;
+}
+
+describe('nothing reads a flag key the parser cannot produce (#1474)', () => {
+  it('no source reads flags.no<Something>', () => {
+    // This is the half that actually broke. With the rule above in force, an
+    // option can never be named `no-x`, so the parser can never emit a `noX`
+    // key — `--no-x` writes `x`. Any `flags.noSomething` read is therefore
+    // reading a key that is always `undefined`, which is precisely the silent
+    // no-op this issue is about. Renaming the DECLARATION alone would not have
+    // fixed anything: the parser negates `--no-x` into `x` either way.
+    //
+    // `noColor` is the shape to watch for — it read as a real setting for years.
+    const offenders: string[] = [];
+    for (const file of cliSourceFiles(join(__dirname, '..', '..', 'src', 'cli'))) {
+      const source = readFileSync(file, 'utf-8');
+      source.split(/\r?\n/).forEach((line, index) => {
+        // `flags.noX` / `ctx.flags.noX` — a capital after `no` so `nodes`,
+        // `noop`, `normalize` and friends are not matched.
+        if (/\bflags\.no[A-Z]\w*/.test(line)) {
+          offenders.push(`${file.replace(/.*src\/cli\//, 'src/cli/')}:${index + 1}: ${line.trim()}`);
+        }
+      });
+    }
+
+    expect(
+      offenders,
+      'Read the positive key instead: `flags.<x> === false` for "was it disabled", '
+      + '`flags.<x> !== false` for "is it enabled".',
+    ).toEqual([]);
+  });
+});

--- a/tests/guards/superseded-vocabulary-empty-guard.test.ts
+++ b/tests/guards/superseded-vocabulary-empty-guard.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Guard: `SUPERSEDED_VOCABULARY` must ship empty (#1466).
+ *
+ * The table maps retired terms to their replacements so `flo memory
+ * audit-learnings` can flag learnings still speaking the old language. A rename
+ * is always local to one project — the consumer that renamed `foo` to `bar` is
+ * the only place an entry saying `foo` is stale — so a row committed here would
+ * flag innocent entries in every other consumer's store the moment they
+ * `npm install moflo`.
+ *
+ * It is also a Rule #3 surface. A rename is usually named after the thing being
+ * renamed, so the row that documents it tends to carry a project's internal
+ * vocabulary, and this file ships to every consumer and lives in git history
+ * permanently.
+ *
+ * If this goes red: the fix is to take the row back out, not to allowlist it.
+ * A project that wants entries flagged fills the table in downstream, where the
+ * rename actually happened.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { SUPERSEDED_VOCABULARY } from '../../src/cli/memory/learnings-audit.js';
+
+describe('SUPERSEDED_VOCABULARY ships empty (#1466)', () => {
+  it('holds no rows', () => {
+    expect(SUPERSEDED_VOCABULARY).toEqual([]);
+  });
+
+  it('is declared empty in source, not emptied at runtime', () => {
+    // A runtime `.length = 0` or a filtered copy would satisfy the assertion
+    // above while leaving the retired terms sitting in the shipped file — which
+    // is the half of this that matters for disclosure.
+    const source = fsReadSource();
+    const declaration = /export const SUPERSEDED_VOCABULARY[^=]*=\s*(\[[^\]]*\])/.exec(source);
+
+    expect(declaration, 'SUPERSEDED_VOCABULARY is no longer a literal array declaration').not.toBeNull();
+    expect(declaration![1].replace(/\s/g, '')).toBe('[]');
+  });
+});
+
+function fsReadSource(): string {
+  // Imported lazily so the guard's failure message points at the assertion
+  // rather than at a module-load error in a source-only checkout.
+  const { readFileSync } = require('node:fs') as typeof import('node:fs');
+  const { join } = require('node:path') as typeof import('node:path');
+  return readFileSync(join(__dirname, '..', '..', 'src', 'cli', 'memory', 'learnings-audit.ts'), 'utf-8');
+}

--- a/tests/system/fixtures/writer-audit-whitelist.json
+++ b/tests/system/fixtures/writer-audit-whitelist.json
@@ -1,336 +1,341 @@
 {
-  "$comment": "Canonical writer audit whitelist for moflo.db. Every file:line that mutates .moflo/moflo.db MUST appear here. See docs/internal/1054-writer-audit.md. Three terminal classifications: in-daemon (writes from inside the daemon process), daemon-rpc (cross-process writers routing via daemon-write-client), daemon-offline (launcher stops daemon before invoking).",
-  "patterns": {
-    "$comment": "Source-text patterns that trigger an audit hit. Lint test (tests/system/moflo-db-writer-audit.test.ts) greps these and fails on any unmatched hit. Patterns are JavaScript regex source strings.",
-    "regex": [
-      "\\.export\\(\\)\\s*\\)",
-      "writeFileSync\\([^)]*Buffer\\.from\\([^)]*\\.export\\(\\)",
-      "atomicWriteFileSync\\([^)]*\\.export\\(\\)",
-      "\\bdb\\.run\\(",
-      "\\bdb\\.exec\\(",
-      "INSERT\\s+OR\\s+REPLACE",
-      "UPDATE\\s+memory_entries"
-    ]
-  },
-  "scope": {
-    "$comment": "Path globs the lint test scans. Excludes test fixtures, type-only files, and pure documentation.",
-    "include": [
-      "src/cli/**/*.ts",
-      "bin/**/*.mjs",
-      "bin/**/*.cjs"
-    ],
-    "exclude": [
-      "src/cli/__tests__/**",
-      "src/cli/**/*.test.ts",
-      "src/cli/**/*.d.ts",
-      "**/node_modules/**"
-    ]
-  },
-  "writers": [
-    {
-      "file": "src/cli/memory/entries-write.ts",
-      "classification": "in-daemon",
-      "notes": "Chokepoint (storeEntry/deleteEntry/storeEntries) — #981/#985; decomposed from memory-initializer.ts (#1203). memory-initializer.ts is now a barrel re-export and no longer mutates."
-    },
-    {
-      "file": "src/cli/memory/entries-read.ts",
-      "classification": "in-daemon",
-      "notes": "Read-side SELECTs via db.exec (searchEntries/listEntries/getEntry/getNamespaceCounts) — classified for completeness; decomposed from memory-initializer.ts (#1203)"
-    },
-    {
-      "file": "src/cli/memory/schema.ts",
-      "classification": "in-daemon",
-      "notes": "Schema DDL + ensureSchemaColumns ALTER-TABLE migration + getInitialMetadata INSERT OR REPLACE; decomposed from memory-initializer.ts (#1203)"
-    },
-    {
-      "file": "src/cli/memory/init.ts",
-      "classification": "in-daemon",
-      "notes": "initializeMemoryDatabase / checkAndMigrateLegacy / applyTemporalDecay; decomposed from memory-initializer.ts (#1203)"
-    },
-    {
-      "file": "src/cli/memory/verify.ts",
-      "classification": "in-daemon",
-      "notes": "verifyMemoryInit self-test writes+deletes a probe row; decomposed from memory-initializer.ts (#1203)"
-    },
-    {
-      "file": "src/cli/memory/learnings-overview.ts",
-      "classification": "in-daemon",
-      "notes": "Read-only SELECTs over the learnings namespace for the Luminarium panel (#1203) — classified for completeness"
-    },
-    {
-      "file": "src/cli/memory/sqlite-backend.ts",
-      "classification": "in-daemon",
-      "notes": "node:sqlite backend — default as of Phase 4 (#1083); sqljs-backend.ts deleted in Phase 5 (#1084)"
-    },
-    {
-      "file": "src/cli/memory/daemon-backend.ts",
-      "classification": "in-daemon",
-      "notes": "TS twin of bin/lib/get-backend.mjs#openBackend — sql.js-shape adapter around node:sqlite + WAL used by the daemon bridge (controller-registry, bridge-core). Single-process by construction"
-    },
-    {
-      "file": "src/cli/memory/bridge-core.ts",
-      "classification": "in-daemon",
-      "notes": "Bridge-internal atomic write; single-process by construction"
-    },
-    {
-      "file": "src/cli/mcp-tools/aidefence-moflodb-store.ts",
-      "classification": "daemon-rpc",
-      "notes": "MCP-server process; routes via chokepoint post-#986"
-    },
-    {
-      "file": "src/cli/mcp-tools/memory-tools.ts",
-      "classification": "daemon-rpc",
-      "notes": "MCP handlers funnel through chokepoint"
-    },
-    {
-      "file": "src/cli/mcp-tools/memory-admin-tools.ts",
-      "classification": "daemon-offline",
-      "notes": "#1349 export/import/cleanup/detailed-stats use db.exec only for SELECTs and route every delete through the deleteEntry chokepoint. memory_compress is the sole direct mutation (VACUUM + wal_checkpoint) and self-enforces the offline precondition: it reads the daemon lock and refuses with an explicit error when a live daemon owns the DB, rather than racing it."
-    },
-    {
-      "file": "src/cli/swarm/swarm-persistence.ts",
-      "classification": "daemon-rpc",
-      "notes": "Cross-process; DI'd through chokepoint"
-    },
-    {
-      "file": "src/cli/swarm/message-bus/write-through-adapter.ts",
-      "classification": "daemon-rpc",
-      "notes": "WriteThroughAdapter DI'd through chokepoint"
-    },
-    {
-      "file": "src/cli/commands/memory.ts",
-      "classification": "daemon-rpc",
-      "notes": "flo memory CLI subprocess funnels via chokepoint"
-    },
-    {
-      "file": "src/cli/commands/doctor-checks-memory-access.ts",
-      "classification": "daemon-rpc",
-      "notes": "Probe seed routes via memory_store with chunk metadata in-band (#1064); chokepoint accepts metadata so no direct DB handle remains"
-    },
-    {
-      "file": "src/cli/commands/doctor-checks-memory.ts",
-      "classification": "daemon-rpc",
-      "notes": "Doctor memory checks run in-session; mutations route via chokepoint"
-    },
-    {
-      "file": "src/cli/commands/doctor-embedding-hygiene.ts",
-      "classification": "daemon-rpc",
-      "notes": "Doctor embedding hygiene check; routes via chokepoint when mutating"
-    },
-    {
-      "file": "src/cli/commands/doctor-checks-coverage-truth.ts",
-      "classification": "in-daemon",
-      "notes": "Coverage Truth doctor check (#1059) — read-only SELECT COUNT(*); classified for completeness"
-    },
-    {
-      "file": "src/cli/commands/embeddings.ts",
-      "classification": "daemon-rpc",
-      "notes": "flo embeddings CLI subprocess funnels via chokepoint"
-    },
-    {
-      "file": "src/cli/embeddings/migration/sqljs-helpers.ts",
-      "classification": "daemon-offline",
-      "notes": "One-time embedding migration helpers — #981 Layer 4, runs pre-boot"
-    },
-    {
-      "file": "src/cli/memory/bridge-entries.ts",
-      "classification": "in-daemon",
-      "notes": "Bridge-internal writers — #981 Layer 3 (bridge runs in single host process, not cross-process)"
-    },
-    {
-      "file": "src/cli/memory/memory-bridge.ts",
-      "classification": "in-daemon",
-      "notes": "Bridge core — #981 Layer 3 (bridge-internal, not a cross-process writer)"
-    },
-    {
-      "file": "src/cli/memory/controllers/attestation-log.ts",
-      "classification": "in-daemon",
-      "notes": "MofloDb controller — runs inside the memory subsystem's host process, funnels via bridge"
-    },
-    {
-      "file": "src/cli/memory/controllers/batch-operations.ts",
-      "classification": "in-daemon",
-      "notes": "MofloDb batch controller — bridge-internal, in-process"
-    },
-    {
-      "file": "src/cli/memory/controllers/causal-graph.ts",
-      "classification": "in-daemon",
-      "notes": "MofloDb causal-graph controller — bridge-internal"
-    },
-    {
-      "file": "src/cli/memory/controllers/hierarchical-memory.ts",
-      "classification": "in-daemon",
-      "notes": "MofloDb hierarchical controller — bridge-internal"
-    },
-    {
-      "file": "src/cli/memory/controllers/learning-system.ts",
-      "classification": "in-daemon",
-      "notes": "MofloDb learning-system controller — bridge-internal"
-    },
-    {
-      "file": "src/cli/memory/controllers/reflexion.ts",
-      "classification": "in-daemon",
-      "notes": "MofloDb reflexion controller — bridge-internal"
-    },
-    {
-      "file": "src/cli/memory/controllers/skills.ts",
-      "classification": "in-daemon",
-      "notes": "MofloDb skills controller — bridge-internal"
-    },
-    {
-      "file": "src/cli/memory/rvf-migration.ts",
-      "classification": "daemon-offline",
-      "notes": "One-time RVF schema migration — runs pre-boot via launcher"
-    },
-    {
-      "file": "src/cli/services/sqljs-migration-store.ts",
-      "classification": "daemon-offline",
-      "notes": "One-time DB schema migration — #981 Layer 4, runs pre-boot"
-    },
-    {
-      "file": "src/cli/commands/route.ts",
-      "classification": "in-daemon",
-      "notes": "Q-learning router export — not a moflo.db write; classified for completeness"
-    },
-    {
-      "file": "src/cli/movector/q-learning-router.ts",
-      "classification": "in-daemon",
-      "notes": "Q-learning serialization — not moflo.db; classified for completeness"
-    },
-    {
-      "file": "src/cli/services/embeddings-migration.ts",
-      "classification": "daemon-offline",
-      "notes": "Launcher pre-boot via runEmbeddingsMigrationIfNeeded — S2 guarantees no stale daemon during this phase"
-    },
-    {
-      "file": "src/cli/services/ephemeral-namespace-purge.ts",
-      "classification": "daemon-offline",
-      "notes": "Launcher pre-boot (#727/#968)"
-    },
-    {
-      "file": "src/cli/services/soft-delete-purge.ts",
-      "classification": "daemon-offline",
-      "notes": "Launcher pre-boot periodic purge"
-    },
-    {
-      "file": "src/cli/services/cherry-pick-learnings.ts",
-      "classification": "daemon-offline",
-      "notes": "One-time launcher pre-boot cherry-pick"
-    },
-    {
-      "file": "src/cli/services/durable-store-io.ts",
-      "classification": "daemon-offline",
-      "notes": "Shared DB half of durable-learning reconciliation (#1463): reads the durable slice and applies the merge plan for the team artifact and the worktree durable sync. Both callers run pre-boot at session-start or from a CLI command, the same offline shape as cherry-pick-learnings and team-artifact-sync."
-    },
-    {
-      "file": "src/cli/services/team-artifact-sync.ts",
-      "classification": "daemon-offline",
-      "notes": "Imports the git-tracked team JSONL artifact into local moflo.db at session-start before the daemon spawns (#1234); same pre-boot writer shape as cherry-pick. The team-import CLI path matches restore-learnings' offline usage."
-    },
-    {
-      "file": "src/cli/services/snapshot-restore.ts",
-      "classification": "daemon-offline",
-      "notes": "Whole-DB snapshot backup (VACUUM INTO via db.exec) + restore (atomicWriteFileSync of moflo.db) for fast workspace hydration (#1244). Session-start auto-hydrate (block 3e-1244) runs BEFORE the daemon spawns; the backup/restore CLI verbs are manual offline ops — same pre-boot writer shape as cherry-pick/team-artifact."
-    },
-    {
-      "file": "src/cli/services/learning-service.ts",
-      "classification": "daemon-offline",
-      "notes": "Hooks library save() — S3 verifies caller context and confirms classification"
-    },
-    {
-      "file": "src/cli/embeddings/persistent-cache.ts",
-      "classification": "separate-db",
-      "notes": "Writes .cache/embeddings.db — NOT moflo.db. Out of scope for this audit."
-    },
-    {
-      "file": "src/cli/shared/events/event-store.ts",
-      "classification": "separate-db",
-      "notes": "Event store separate file — NOT moflo.db"
-    },
-    {
-      "file": "src/cli/memory/hnsw-persistence.ts",
-      "classification": "separate-db",
-      "notes": "Writes .moflo/hnsw.index — separate file from moflo.db"
-    },
-    {
-      "file": "src/cli/guidance/ruvbot-integration.ts",
-      "classification": "in-daemon",
-      "notes": "chain.export() is in-memory serialization, not DB write"
-    },
-    {
-      "file": "bin/migrations/strip-context-preambles.mjs",
-      "classification": "daemon-offline",
-      "notes": "Launcher pre-boot — S3 wraps invocation with explicit daemon-stop/start"
-    },
-    {
-      "file": "bin/migrations/purge-doc-entries.mjs",
-      "classification": "daemon-offline",
-      "notes": "Launcher pre-boot — S3 wraps invocation"
-    },
-    {
-      "file": "bin/migrations/purge-spec-chunks.mjs",
-      "classification": "daemon-offline",
-      "notes": "Launcher pre-boot — S3 wraps invocation"
-    },
-    {
-      "file": "bin/migrations/knowledge-purge.mjs",
-      "classification": "daemon-offline",
-      "notes": "Launcher pre-boot — S3 wraps invocation"
-    },
-    {
-      "file": "bin/migrations/knowledge-to-learnings.mjs",
-      "classification": "daemon-offline",
-      "notes": "Launcher pre-boot — S3 wraps invocation"
-    },
-    {
-      "file": "bin/build-embeddings.mjs",
-      "classification": "daemon-offline",
-      "notes": "Launcher / healer — S3 wraps invocation with explicit daemon-stop"
-    },
-    {
-      "file": "bin/index-guidance.mjs",
-      "classification": "daemon-offline",
-      "notes": "Daemon worker subprocess — S3 adds content-diff before INSERT OR REPLACE per feedback_indexer_preserve_embeddings"
-    },
-    {
-      "file": "bin/index-tests.mjs",
-      "classification": "daemon-offline",
-      "notes": "Daemon worker subprocess — S3 adds content-diff"
-    },
-    {
-      "file": "bin/index-patterns.mjs",
-      "classification": "daemon-offline",
-      "notes": "Daemon worker subprocess — S3 adds content-diff"
-    },
-    {
-      "file": "bin/index-reference.mjs",
-      "classification": "daemon-offline",
-      "notes": "Daemon worker subprocess (library-docs grounding #1184) — content-diff via applyIncrementalChunks"
-    },
-    {
-      "file": "bin/generate-code-map.mjs",
-      "classification": "daemon-offline",
-      "notes": "Daemon worker subprocess — S3 adds content-diff"
-    },
-    {
-      "file": "bin/lib/db-repair.mjs",
-      "classification": "daemon-offline",
-      "notes": "Launcher repair path — S3 verifies daemon-stop wrapper"
-    },
-    {
-      "file": "bin/lib/incremental-write.mjs",
-      "classification": "daemon-offline",
-      "notes": "Helper used by indexers — content-diff already implemented (#745)"
-    },
-    {
-      "file": "bin/lib/get-backend.mjs",
-      "classification": "daemon-offline",
-      "notes": "JS-twin factory — every bin/ writer routes through openBackend(); defaults to node:sqlite as of Phase 4 (#1083), sql.js path deleted in Phase 5 (#1084)"
-    },
-    {
-      "file": "bin/lib/embedding-backlog.mjs",
-      "classification": "in-daemon",
-      "notes": "Read-only probe (#1383) — opens with readOnly:true and runs a single SELECT EXISTS; classified for completeness like entries-read.ts. Mutates nothing, so it is safe alongside a live daemon."
-    }
+ "$comment": "Canonical writer audit whitelist for moflo.db. Every file:line that mutates .moflo/moflo.db MUST appear here. See docs/internal/1054-writer-audit.md. Three terminal classifications: in-daemon (writes from inside the daemon process), daemon-rpc (cross-process writers routing via daemon-write-client), daemon-offline (launcher stops daemon before invoking).",
+ "patterns": {
+  "$comment": "Source-text patterns that trigger an audit hit. Lint test (tests/system/moflo-db-writer-audit.test.ts) greps these and fails on any unmatched hit. Patterns are JavaScript regex source strings.",
+  "regex": [
+   "\\.export\\(\\)\\s*\\)",
+   "writeFileSync\\([^)]*Buffer\\.from\\([^)]*\\.export\\(\\)",
+   "atomicWriteFileSync\\([^)]*\\.export\\(\\)",
+   "\\bdb\\.run\\(",
+   "\\bdb\\.exec\\(",
+   "INSERT\\s+OR\\s+REPLACE",
+   "UPDATE\\s+memory_entries"
   ]
+ },
+ "scope": {
+  "$comment": "Path globs the lint test scans. Excludes test fixtures, type-only files, and pure documentation.",
+  "include": [
+   "src/cli/**/*.ts",
+   "bin/**/*.mjs",
+   "bin/**/*.cjs"
+  ],
+  "exclude": [
+   "src/cli/__tests__/**",
+   "src/cli/**/*.test.ts",
+   "src/cli/**/*.d.ts",
+   "**/node_modules/**"
+  ]
+ },
+ "writers": [
+  {
+   "file": "src/cli/memory/entries-write.ts",
+   "classification": "in-daemon",
+   "notes": "Chokepoint (storeEntry/deleteEntry/storeEntries) — #981/#985; decomposed from memory-initializer.ts (#1203). memory-initializer.ts is now a barrel re-export and no longer mutates."
+  },
+  {
+   "file": "src/cli/memory/entries-read.ts",
+   "classification": "in-daemon",
+   "notes": "Read-side SELECTs via db.exec (searchEntries/listEntries/getEntry/getNamespaceCounts) — classified for completeness; decomposed from memory-initializer.ts (#1203)"
+  },
+  {
+   "file": "src/cli/memory/schema.ts",
+   "classification": "in-daemon",
+   "notes": "Schema DDL + ensureSchemaColumns ALTER-TABLE migration + getInitialMetadata INSERT OR REPLACE; decomposed from memory-initializer.ts (#1203)"
+  },
+  {
+   "file": "src/cli/memory/init.ts",
+   "classification": "in-daemon",
+   "notes": "initializeMemoryDatabase / checkAndMigrateLegacy / applyTemporalDecay; decomposed from memory-initializer.ts (#1203)"
+  },
+  {
+   "file": "src/cli/memory/verify.ts",
+   "classification": "in-daemon",
+   "notes": "verifyMemoryInit self-test writes+deletes a probe row; decomposed from memory-initializer.ts (#1203)"
+  },
+  {
+   "file": "src/cli/memory/learnings-overview.ts",
+   "classification": "in-daemon",
+   "notes": "Read-only SELECTs over the learnings namespace for the Luminarium panel (#1203) — classified for completeness"
+  },
+  {
+   "file": "src/cli/memory/sqlite-backend.ts",
+   "classification": "in-daemon",
+   "notes": "node:sqlite backend — default as of Phase 4 (#1083); sqljs-backend.ts deleted in Phase 5 (#1084)"
+  },
+  {
+   "file": "src/cli/memory/daemon-backend.ts",
+   "classification": "in-daemon",
+   "notes": "TS twin of bin/lib/get-backend.mjs#openBackend — sql.js-shape adapter around node:sqlite + WAL used by the daemon bridge (controller-registry, bridge-core). Single-process by construction"
+  },
+  {
+   "file": "src/cli/memory/bridge-core.ts",
+   "classification": "in-daemon",
+   "notes": "Bridge-internal atomic write; single-process by construction"
+  },
+  {
+   "file": "src/cli/mcp-tools/aidefence-moflodb-store.ts",
+   "classification": "daemon-rpc",
+   "notes": "MCP-server process; routes via chokepoint post-#986"
+  },
+  {
+   "file": "src/cli/mcp-tools/memory-tools.ts",
+   "classification": "daemon-rpc",
+   "notes": "MCP handlers funnel through chokepoint"
+  },
+  {
+   "file": "src/cli/mcp-tools/memory-admin-tools.ts",
+   "classification": "daemon-offline",
+   "notes": "#1349 export/import/cleanup/detailed-stats use db.exec only for SELECTs and route every delete through the deleteEntry chokepoint. memory_compress is the sole direct mutation (VACUUM + wal_checkpoint) and self-enforces the offline precondition: it reads the daemon lock and refuses with an explicit error when a live daemon owns the DB, rather than racing it."
+  },
+  {
+   "file": "src/cli/swarm/swarm-persistence.ts",
+   "classification": "daemon-rpc",
+   "notes": "Cross-process; DI'd through chokepoint"
+  },
+  {
+   "file": "src/cli/swarm/message-bus/write-through-adapter.ts",
+   "classification": "daemon-rpc",
+   "notes": "WriteThroughAdapter DI'd through chokepoint"
+  },
+  {
+   "file": "src/cli/commands/memory.ts",
+   "classification": "daemon-rpc",
+   "notes": "flo memory CLI subprocess funnels via chokepoint"
+  },
+  {
+   "file": "src/cli/commands/memory-audit-learnings.ts",
+   "classification": "daemon-rpc",
+   "notes": "flo memory audit-learnings (#1466). Mutations route through the deleteEntry chokepoint with no dbPath, so the #981 daemon preamble applies and a durable namespace archives via archiveDurableRow. The audit pattern hit is the read side: one direct SELECT over learnings rows for embedding + access_count, which no MCP read surface exposes. Read-only, same shape as learnings-overview.ts."
+  },
+  {
+   "file": "src/cli/commands/doctor-checks-memory-access.ts",
+   "classification": "daemon-rpc",
+   "notes": "Probe seed routes via memory_store with chunk metadata in-band (#1064); chokepoint accepts metadata so no direct DB handle remains"
+  },
+  {
+   "file": "src/cli/commands/doctor-checks-memory.ts",
+   "classification": "daemon-rpc",
+   "notes": "Doctor memory checks run in-session; mutations route via chokepoint"
+  },
+  {
+   "file": "src/cli/commands/doctor-embedding-hygiene.ts",
+   "classification": "daemon-rpc",
+   "notes": "Doctor embedding hygiene check; routes via chokepoint when mutating"
+  },
+  {
+   "file": "src/cli/commands/doctor-checks-coverage-truth.ts",
+   "classification": "in-daemon",
+   "notes": "Coverage Truth doctor check (#1059) — read-only SELECT COUNT(*); classified for completeness"
+  },
+  {
+   "file": "src/cli/commands/embeddings.ts",
+   "classification": "daemon-rpc",
+   "notes": "flo embeddings CLI subprocess funnels via chokepoint"
+  },
+  {
+   "file": "src/cli/embeddings/migration/sqljs-helpers.ts",
+   "classification": "daemon-offline",
+   "notes": "One-time embedding migration helpers — #981 Layer 4, runs pre-boot"
+  },
+  {
+   "file": "src/cli/memory/bridge-entries.ts",
+   "classification": "in-daemon",
+   "notes": "Bridge-internal writers — #981 Layer 3 (bridge runs in single host process, not cross-process)"
+  },
+  {
+   "file": "src/cli/memory/memory-bridge.ts",
+   "classification": "in-daemon",
+   "notes": "Bridge core — #981 Layer 3 (bridge-internal, not a cross-process writer)"
+  },
+  {
+   "file": "src/cli/memory/controllers/attestation-log.ts",
+   "classification": "in-daemon",
+   "notes": "MofloDb controller — runs inside the memory subsystem's host process, funnels via bridge"
+  },
+  {
+   "file": "src/cli/memory/controllers/batch-operations.ts",
+   "classification": "in-daemon",
+   "notes": "MofloDb batch controller — bridge-internal, in-process"
+  },
+  {
+   "file": "src/cli/memory/controllers/causal-graph.ts",
+   "classification": "in-daemon",
+   "notes": "MofloDb causal-graph controller — bridge-internal"
+  },
+  {
+   "file": "src/cli/memory/controllers/hierarchical-memory.ts",
+   "classification": "in-daemon",
+   "notes": "MofloDb hierarchical controller — bridge-internal"
+  },
+  {
+   "file": "src/cli/memory/controllers/learning-system.ts",
+   "classification": "in-daemon",
+   "notes": "MofloDb learning-system controller — bridge-internal"
+  },
+  {
+   "file": "src/cli/memory/controllers/reflexion.ts",
+   "classification": "in-daemon",
+   "notes": "MofloDb reflexion controller — bridge-internal"
+  },
+  {
+   "file": "src/cli/memory/controllers/skills.ts",
+   "classification": "in-daemon",
+   "notes": "MofloDb skills controller — bridge-internal"
+  },
+  {
+   "file": "src/cli/memory/rvf-migration.ts",
+   "classification": "daemon-offline",
+   "notes": "One-time RVF schema migration — runs pre-boot via launcher"
+  },
+  {
+   "file": "src/cli/services/sqljs-migration-store.ts",
+   "classification": "daemon-offline",
+   "notes": "One-time DB schema migration — #981 Layer 4, runs pre-boot"
+  },
+  {
+   "file": "src/cli/commands/route.ts",
+   "classification": "in-daemon",
+   "notes": "Q-learning router export — not a moflo.db write; classified for completeness"
+  },
+  {
+   "file": "src/cli/movector/q-learning-router.ts",
+   "classification": "in-daemon",
+   "notes": "Q-learning serialization — not moflo.db; classified for completeness"
+  },
+  {
+   "file": "src/cli/services/embeddings-migration.ts",
+   "classification": "daemon-offline",
+   "notes": "Launcher pre-boot via runEmbeddingsMigrationIfNeeded — S2 guarantees no stale daemon during this phase"
+  },
+  {
+   "file": "src/cli/services/ephemeral-namespace-purge.ts",
+   "classification": "daemon-offline",
+   "notes": "Launcher pre-boot (#727/#968)"
+  },
+  {
+   "file": "src/cli/services/soft-delete-purge.ts",
+   "classification": "daemon-offline",
+   "notes": "Launcher pre-boot periodic purge"
+  },
+  {
+   "file": "src/cli/services/cherry-pick-learnings.ts",
+   "classification": "daemon-offline",
+   "notes": "One-time launcher pre-boot cherry-pick"
+  },
+  {
+   "file": "src/cli/services/durable-store-io.ts",
+   "classification": "daemon-offline",
+   "notes": "Shared DB half of durable-learning reconciliation (#1463): reads the durable slice and applies the merge plan for the team artifact and the worktree durable sync. Both callers run pre-boot at session-start or from a CLI command, the same offline shape as cherry-pick-learnings and team-artifact-sync."
+  },
+  {
+   "file": "src/cli/services/team-artifact-sync.ts",
+   "classification": "daemon-offline",
+   "notes": "Imports the git-tracked team JSONL artifact into local moflo.db at session-start before the daemon spawns (#1234); same pre-boot writer shape as cherry-pick. The team-import CLI path matches restore-learnings' offline usage."
+  },
+  {
+   "file": "src/cli/services/snapshot-restore.ts",
+   "classification": "daemon-offline",
+   "notes": "Whole-DB snapshot backup (VACUUM INTO via db.exec) + restore (atomicWriteFileSync of moflo.db) for fast workspace hydration (#1244). Session-start auto-hydrate (block 3e-1244) runs BEFORE the daemon spawns; the backup/restore CLI verbs are manual offline ops — same pre-boot writer shape as cherry-pick/team-artifact."
+  },
+  {
+   "file": "src/cli/services/learning-service.ts",
+   "classification": "daemon-offline",
+   "notes": "Hooks library save() — S3 verifies caller context and confirms classification"
+  },
+  {
+   "file": "src/cli/embeddings/persistent-cache.ts",
+   "classification": "separate-db",
+   "notes": "Writes .cache/embeddings.db — NOT moflo.db. Out of scope for this audit."
+  },
+  {
+   "file": "src/cli/shared/events/event-store.ts",
+   "classification": "separate-db",
+   "notes": "Event store separate file — NOT moflo.db"
+  },
+  {
+   "file": "src/cli/memory/hnsw-persistence.ts",
+   "classification": "separate-db",
+   "notes": "Writes .moflo/hnsw.index — separate file from moflo.db"
+  },
+  {
+   "file": "src/cli/guidance/ruvbot-integration.ts",
+   "classification": "in-daemon",
+   "notes": "chain.export() is in-memory serialization, not DB write"
+  },
+  {
+   "file": "bin/migrations/strip-context-preambles.mjs",
+   "classification": "daemon-offline",
+   "notes": "Launcher pre-boot — S3 wraps invocation with explicit daemon-stop/start"
+  },
+  {
+   "file": "bin/migrations/purge-doc-entries.mjs",
+   "classification": "daemon-offline",
+   "notes": "Launcher pre-boot — S3 wraps invocation"
+  },
+  {
+   "file": "bin/migrations/purge-spec-chunks.mjs",
+   "classification": "daemon-offline",
+   "notes": "Launcher pre-boot — S3 wraps invocation"
+  },
+  {
+   "file": "bin/migrations/knowledge-purge.mjs",
+   "classification": "daemon-offline",
+   "notes": "Launcher pre-boot — S3 wraps invocation"
+  },
+  {
+   "file": "bin/migrations/knowledge-to-learnings.mjs",
+   "classification": "daemon-offline",
+   "notes": "Launcher pre-boot — S3 wraps invocation"
+  },
+  {
+   "file": "bin/build-embeddings.mjs",
+   "classification": "daemon-offline",
+   "notes": "Launcher / healer — S3 wraps invocation with explicit daemon-stop"
+  },
+  {
+   "file": "bin/index-guidance.mjs",
+   "classification": "daemon-offline",
+   "notes": "Daemon worker subprocess — S3 adds content-diff before INSERT OR REPLACE per feedback_indexer_preserve_embeddings"
+  },
+  {
+   "file": "bin/index-tests.mjs",
+   "classification": "daemon-offline",
+   "notes": "Daemon worker subprocess — S3 adds content-diff"
+  },
+  {
+   "file": "bin/index-patterns.mjs",
+   "classification": "daemon-offline",
+   "notes": "Daemon worker subprocess — S3 adds content-diff"
+  },
+  {
+   "file": "bin/index-reference.mjs",
+   "classification": "daemon-offline",
+   "notes": "Daemon worker subprocess (library-docs grounding #1184) — content-diff via applyIncrementalChunks"
+  },
+  {
+   "file": "bin/generate-code-map.mjs",
+   "classification": "daemon-offline",
+   "notes": "Daemon worker subprocess — S3 adds content-diff"
+  },
+  {
+   "file": "bin/lib/db-repair.mjs",
+   "classification": "daemon-offline",
+   "notes": "Launcher repair path — S3 verifies daemon-stop wrapper"
+  },
+  {
+   "file": "bin/lib/incremental-write.mjs",
+   "classification": "daemon-offline",
+   "notes": "Helper used by indexers — content-diff already implemented (#745)"
+  },
+  {
+   "file": "bin/lib/get-backend.mjs",
+   "classification": "daemon-offline",
+   "notes": "JS-twin factory — every bin/ writer routes through openBackend(); defaults to node:sqlite as of Phase 4 (#1083), sql.js path deleted in Phase 5 (#1084)"
+  },
+  {
+   "file": "bin/lib/embedding-backlog.mjs",
+   "classification": "in-daemon",
+   "notes": "Read-only probe (#1383) — opens with readOnly:true and runs a single SELECT EXISTS; classified for completeness like entries-read.ts. Mutates nothing, so it is safe alongside a live daemon."
+  }
+ ]
 }


### PR DESCRIPTION
Closes #1466. Closes #1474.

## What this adds

`flo memory audit-learnings` — a curation pass over the `learnings` namespace.

`flo memory cleanup` ranks by age, which is the wrong instrument for durable rows: a three-year-old
lesson about a footgun that still exists is worth more than last week's note about a migration that
finished. #1464 made that explicit by exempting durable namespaces from age-based cleanup, which
left `learnings` with no evaluation surface at all — a consumer store reached 1,582 entries with no
way to tell which of them were still true.

**Mechanical filters first, model judgement last.** Three cheap passes *nominate*: near-duplicate
clustering over the embeddings already stored on each row, a least-used-and-old ranking built on
#1464's usage signal, and a retired-vocabulary match. Only the nominated entries — a few dozen out
of a few thousand — reach a bounded headless Haiku for a KEEP / RETIRE / COMPRESS / MERGE verdict,
reusing the decision table moflo already documents for auto-memory files rather than inventing a
second vocabulary for the same judgement. A full-store LLM sweep is the design this avoids.

## The three standing considerations

**Rule #1 — cross-platform.** The judge prompt travels on **stdin, not argv**. At default settings
it is roughly 36 KB; as a single argv element that is past Windows' 32,767-character
`CreateProcess` limit, so an argv prompt would have failed on Windows only, at default settings.
(`bin/meditate-distill.mjs` passes its prompt as an argument safely because it sends 25 one-liners.)
Everything else is `path.join`, `spawn` with an argument array and `windowsHide`, `os.tmpdir()` in
tests, and `fs.realpathSync` on the temp project root so the macOS `/var` → `/private/var` symlink
does not break root resolution.

**Rule #2 — consumer surface.** A new `flo memory` subcommand, one new module, and a three-line
wiring change in `memory.ts`. No `bin/`, no `.claude/scripts/`, no manifest or sync-layer changes —
so no dogfood copy to keep in parity. Failure mode for someone upgrading: none. It is opt-in,
existing `.moflo/` state parses unchanged, no migration, and nothing runs unless the command is
invoked. The model step needs the `claude` CLI on PATH; without it the audit still reports its
mechanical nominations and archives nothing.

**Dogfooding.** Nothing here runs in the daemon/hook/statusline layers, so there is no
publish-then-reinstall round trip for correctness — but the command itself only reaches a consumer
after publish + `npm install`, like any other CLI surface.

## Deviation from the ticket's proposed path

The ticket proposes porting to `bin/lib/learnings-audit.mjs`. Upstream that would be wrong: no
runtime TypeScript in this repo imports from `bin/lib/`, because crossing the dist/bin boundary is
the documented `../../../../` anti-pattern. The established shapes are hand-maintained twins
(`daemon-backend.ts` ↔ `get-backend.mjs`) or single-sourced JSON. Nothing in `bin/` needs the audit —
it is a hand-invoked command, not a hook — so it ships as `src/cli/memory/learnings-audit.ts`
(pure, dependency-injected) plus `src/cli/commands/memory-audit-learnings.ts` (every side effect).
The deliverable is unchanged; the manifest, sync layers, and parity guard are simply not involved.

## Two things reviewers should look at

**Only RETIRE removes anything.** MERGE and COMPRESS both describe work that *preserves* content —
fold this into that one, rewrite this shorter — and the audit performs neither, so archiving on them
would delete the signal the verdict just said to keep. MERGE is the sharper edge: "restates another
entry listed here" is honestly true of *both* members of a pair, so a model answering it twice would
take the rule with it. Both are reported for an author to act on. For the same reason a cluster's
surviving statement is never archived even when a different pass (unused, superseded) nominates it
independently — otherwise a rule can lose every statement of itself in one run.

**Writes route through the chokepoint.** `--apply` calls `deleteEntry` with no `dbPath`, not
`archiveDurableRow` directly. The command runs in the foreground while the user's daemon is very
likely holding `.moflo/moflo.db`, and a raw cross-process write there is the single-writer violation
epic #1054 exists to prevent — the writer-audit whitelist classifies `durable-store-io` as
`daemon-offline` for exactly that reason, and this caller is not offline. Routing also means the
archive semantics are inherited rather than restated: a delete in a durable namespace already
archives, keeps the row, and leaves the tombstone #1463's reconciler propagates. The whitelist entry
is `daemon-rpc`; the audit-pattern hit that remains is the read side, one direct `SELECT` for
`embedding` + `access_count`, which no MCP read surface exposes.

## Rule #3

`SUPERSEDED_VOCABULARY` ships empty behind a guard test with two arms — the exported array is empty,
*and* the source declaration is a literal `[]`, so a runtime-emptied array cannot pass while the
retired terms still sit in the shipped file. A rename belongs to the one project that made it:
shipping a row would flag innocent entries in every other consumer's store, and the row itself would
carry that project's internal vocabulary into a public repository.

## Also fixes #1474 — ten `--no-*` flags were silent no-ops

Found while adding this command's own `--no-judge`, and fixed here rather than deferred: a separate
PR would have cost another review-and-CI cycle for a defect already in hand.

The parser treats `--no-<x>` as boolean negation — it writes `flags[camelCase(x)] = false` and never
produces a `noX` key. Ten flags were read as `flags.noX` anyway: they parsed fine, set nothing the
handler looked at, and did nothing. Each now does what it has always claimed to:

| Flag | Was | Now |
|---|---|---|
| `flo daemon start --no-dashboard` | dashboard started anyway | no dashboard |
| `flo memory index-guidance --no-embeddings` | embedded anyway | generation skipped |
| `flo memory code-map --no-embeddings` | embedded anyway | generation skipped |
| `flo hooks coverage-route --no-movector` | native backend anyway | movector off |
| `flo hooks statusline --no-color` | colours anyway | plain output |
| `flo spell schedule --no-autostart` | login service registered anyway | skipped |
| `flo hive-mind spawn --no-auto-permissions` | auto-handled anyway | prompts per action |
| `flo epic run <n> --no-merge` | ran auto-merge | forces `single-branch` |
| `--no-color` (global) | colours anyway | colour disabled |
| `--no-update` (global) | update check ran anyway | suppressed |

**`flo epic --no-merge` is the one worth reading twice.** It is documented as an alias for
`--strategy single-branch`, and while it was a no-op an epic asked for single-branch silently ran
auto-merge instead.

**The guard that matters is the second one.** Renaming a declaration fixes nothing on its own — the
parser negates `--no-<x>` identically either way, so a test over parser output passes equally before
and after. The real defect is in the *readers*. So one guard forbids declaring an option `no-*`
(command-level or global), and a second forbids any source read of `flags.no<Something>` — with the
first in force the parser can never emit such a key, so every such read is a permanent `undefined`.
The second guard found two of the ten that my own sweep of option declarations had missed.

**Two existing tests were passing by feeding handlers a fiction** — `{ noMerge: true }` and
`{ noAutostart: true }`, keys the CLI can never deliver. They asserted a handler branch in isolation
while the flag reaching it in production was inert, which is how `--no-merge` had a passing test *and*
did nothing. Both now use the shape the parser actually produces.

This half is a **behaviour change** for consumers whose automation passes any flag above; the
CHANGELOG names each one.

## Review

`/flo-simplify` classified this DEEP (1,688 LOC of new logic, 50 net-new declarations) and ran three
Opus agents. They found nine real issues, all fixed and pinned by tests:

- MERGE archiving without merging, and both members of a pair being archivable → RETIRE-only
- a cluster representative being archivable when another pass nominated it → survivors excluded
- clustering over the *filtered* set, which could promote an older restatement to representative and
  nominate the newer entry → clusters over all rows, filters afterwards
- `--recheck` starting from an empty record and writing it back, erasing every prior verdict
- the argv-length limit above
- `parseVerdicts` stripping the front off any key starting with digits (`1466-lesson`), silently
  dropping its verdict
- `readLearningsRows` swallowing every DB error as "0 learnings examined"
- `confirm()` hanging on a non-TTY (cron/CI without `--force`)
- the unused-bucket cap reported as if it were full coverage
- the judge child running with unrestricted tools in a consumer's tree

Reuse fixes from the same pass: `atomicWriteFileSync`, `hashContent`, `hasMemoryEntriesTable`, and
the `deleteEntry` chokepoint replaced hand-rolled equivalents. A follow-up validation pass over the
fixes (new exports and five new module dependencies) found no new problems.

All 16 checks passed on the first commit (`2a51692f4`), including all three platforms on both the
consumer and populated smoke harnesses, before the #1474 commit was added.

## Verification

- Full suite **11,136 passed / 0 failed**; `tsc` and `eslint --max-warnings 0` clean.
- 59 new tests (26 pure-module, 17 command-level, 6 guard, 10 flag-behaviour).
- `/verify` **PASS** on all six acceptance criteria, recorded as `verify:1466` at `2a51692f4`.
- Every acceptance criterion's pinning test was **mutation-checked**: reverting the behaviour turns
  it red. The archive assertions are non-vacuous — stubbing the archive to a no-op fails them.
- AC4 is proven against five real read surfaces: `listEntries`, `getNamespaceCounts`, the learnings
  overview, the HNSW sidecar vector count (2 → 1), and a real `searchEntries` call.
- The #1474 reader guard was mutation-checked against three separate readers; reverting any one of
  them turns it red.

Note on the suite runner: `npm test` exits 0 even when it reports failures — the first run of this
branch printed `Total failed: 3` under a zero exit code (a missing writer-audit whitelist entry).
The numbers above are read from the summary, not the exit status.
