### PR TITLE
fix(memory): refuse captured tool-call markup on write and in the team artifact (#1467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — memory writes refuse captured tool-call markup
+
+A `memory_store` call whose `value` arrived carrying the harness' own parameter markup — the value
+cut off, with a `<parameter name="tags">` opener or a stray `</value>` appended to the text — was
+persisted verbatim, embedded, and shared to the team artifact, under a cheerful
+`{success: true, stored: true}`. One consumer store held 68 such entries in `learnings` alone,
+across three machines, at an accelerating rate. The junk sits inside the field that gets embedded,
+so it degrades the vector for that entry and every search that would have matched it, and the tags
+the fragment was carrying never reach the `tags` column at all.
+
+moflo does not cause this — the markup exists only in the model/harness layer — but it is the last
+component that can catch it, and today it writes it to disk.
+
+- **Writes are now rejected, not repaired.** `storeEntry` is the chokepoint every write path reaches
+  (`flo memory store`, the MCP `memory_store` tool, the daemon's RPC handler), and the check runs
+  before daemon routing and before any embedding, so a rejected value never produces a vector. The
+  error names the namespace, the key, and the offending text so the caller can re-send the write —
+  which is exactly what the silent success prevented 68 times.
+- **Already-stored corruption stops propagating.** `flo memory team-export` skips a corrupt local
+  row (without publishing a tombstone for it) and `flo memory team-import` skips a corrupt artifact
+  line, each reporting the count. A consumer whose artifact is already polluted is helped without
+  running a cleanup pass first.
+- **A value that merely discusses the markup is still stored.** The detector fires only on markup
+  that is both unbalanced and trailing, so the lesson documenting this bug — and every guidance doc
+  that quotes the shape — stores normally. The naive marker match rejects all of them.
+
+**Consumer impact.** A write that previously succeeded with a corrupt trailing fragment now fails:
+the CLI exits non-zero, MCP returns `success: false`. That is the intent — the value was being
+stored broken. Nothing about existing `.moflo/` state changes, and no migration is needed; existing
+corrupt rows stay readable and are simply no longer shared. `MOFLO_ALLOW_TOOL_CALL_MARKUP=1` stores
+a flagged value anyway for the case where a value is genuinely shaped like the corruption. (#1467)
+
 ### Fixed — ten `--no-*` flags were silent no-ops
 
 The parser treats `--no-<x>` as boolean negation: it writes `flags[camelCase(x)] = false` and never

--- a/src/cli/__tests__/memory/store-rejects-markup-1467.test.ts
+++ b/src/cli/__tests__/memory/store-rejects-markup-1467.test.ts
@@ -1,0 +1,123 @@
+/**
+ * `storeEntry` rejects captured tool-call markup before anything is spent (#1467).
+ *
+ * The chokepoint matters more than the surface here: `flo memory store`, the
+ * MCP `memory_store` tool and the daemon's own RPC handler all land in
+ * `storeEntry`, so guarding it once covers every write path. What this file
+ * proves is that the guard runs FIRST — no embedding is generated and the
+ * bridge is never asked to persist — which is the half that makes the ticket's
+ * "the check runs before embedding" criterion non-vacuous. A rejected value
+ * that still produced a vector would leave the exact artefact the fix exists
+ * to prevent.
+ *
+ * Bridge + embedder are mocked (as in learnings-provenance.test.ts), so this is
+ * pure logic on all three platforms — no db, no fs, no model load.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(false),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn().mockReturnValue(Buffer.alloc(0)),
+    statSync: vi.fn().mockReturnValue({ size: 1024 }),
+  };
+});
+
+vi.mock('../../services/moflo-require.js', () => ({
+  mofloImport: vi.fn().mockRejectedValue(new Error('mocked — the bridge path captures the call first')),
+}));
+
+const bridgeCalls: Array<Record<string, unknown>> = [];
+const embedCalls: string[] = [];
+
+vi.mock('../../memory/memory-bridge.js', () => ({
+  bridgeStoreEntry: async (options: Record<string, unknown>) => {
+    bridgeCalls.push(options);
+    return { success: true, id: 'mock-id' };
+  },
+  getControllerRegistry: () => null,
+}));
+
+vi.mock('../../memory/embedding-model.js', async () => {
+  const actual = await vi.importActual<typeof import('../../memory/embedding-model.js')>(
+    '../../memory/embedding-model.js',
+  );
+  return {
+    ...actual,
+    generateEmbedding: async (text: string) => {
+      embedCalls.push(text);
+      return new Float32Array([0.1, 0.2]);
+    },
+  };
+});
+
+/** The exact shape reported in #1467. */
+const CORRUPT = 'the actual lesson text.",\n    <parameter name="tags">["a","b","source:manual"]';
+
+async function store(value: string, key = 'k') {
+  const { storeEntry } = await import('../../memory/memory-initializer.js');
+  return storeEntry({ key, value, namespace: 'learnings', generateEmbeddingFlag: true });
+}
+
+describe('storeEntry rejects captured tool-call markup (#1467)', () => {
+  beforeEach(() => {
+    bridgeCalls.length = 0;
+    embedCalls.length = 0;
+    delete process.env.MOFLO_ALLOW_TOOL_CALL_MARKUP;
+  });
+
+  it('returns success:false instead of the silent success that hid 68 entries', async () => {
+    const result = await store(CORRUPT, 'corrupt-lesson');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('learnings/corrupt-lesson');
+    expect(result.error).toContain('tool-call markup');
+  });
+
+  it('never persists the row', async () => {
+    await store(CORRUPT);
+    expect(bridgeCalls).toHaveLength(0);
+  });
+
+  it('never generates a vector for the rejected value', async () => {
+    await store(CORRUPT);
+    expect(embedCalls).toHaveLength(0);
+  });
+
+  it('rejects the </value> shape too', async () => {
+    const result = await store('a lesson that got cut off\n</value>');
+    expect(result.success).toBe(false);
+    expect(bridgeCalls).toHaveLength(0);
+  });
+
+  it('stores a clean value normally', async () => {
+    const result = await store('A perfectly ordinary lesson about cache invalidation.', 'clean');
+    expect(result.success).toBe(true);
+    expect(bridgeCalls).toHaveLength(1);
+  });
+
+  it('stores a value that discusses the markup without trailing off into it', async () => {
+    const lesson = [
+      'A memory value can arrive carrying `<parameter name="tags">` or a stray',
+      '`</value>` from the harness that wrote it. Reject those at the store, but',
+      'anchor the detector to the trailing position — a bare marker match rejects',
+      'this very lesson, and a rule that cannot describe itself is not usable.',
+    ].join('\n');
+    const result = await store(lesson, 'lesson-about-1467');
+    expect(result.success).toBe(true);
+    expect(bridgeCalls).toHaveLength(1);
+  });
+
+  it('MOFLO_ALLOW_TOOL_CALL_MARKUP=1 stores it anyway', async () => {
+    // The escape hatch the error message advertises. Without it a consumer with
+    // a genuinely fragment-shaped value would have no way through at all.
+    process.env.MOFLO_ALLOW_TOOL_CALL_MARKUP = '1';
+    const result = await store(CORRUPT, 'forced');
+    expect(result.success).toBe(true);
+    expect(bridgeCalls).toHaveLength(1);
+  });
+});

--- a/src/cli/__tests__/memory/store-surfaces-markup-1467.test.ts
+++ b/src/cli/__tests__/memory/store-surfaces-markup-1467.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Both write surfaces refuse captured tool-call markup (#1467).
+ *
+ * The ticket asks for the CLI and the MCP tool explicitly, because they are
+ * separate entry points and fixing one leaves half the writes exposed. They
+ * turn out to share a chokepoint — both call `storeEntry` — so what this file
+ * pins is that each surface actually REACHES it and reports the refusal in its
+ * own idiom: a non-zero exit for the CLI, `success: false` for MCP. A guard
+ * that a surface swallows into a cheerful `{stored: true}` is the failure this
+ * fix exists to end.
+ *
+ * Real store, real registered command, real tool handler — no stubs, so a
+ * surface that stopped calling `storeEntry` would turn this red.
+ */
+
+import { describe, expect, it, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { output } from '../../output.js';
+import { openDaemonDatabase } from '../../memory/daemon-backend.js';
+import { memoryCommand } from '../../commands/memory.js';
+import { memoryTools } from '../../mcp-tools/memory-tools.js';
+import type { Command, CommandContext } from '../../types.js';
+
+/** The exact shape reported in #1467. */
+const CORRUPT = 'the actual lesson text.",\n    <parameter name="tags">["a","b","source:manual"]';
+
+let tmp: string;
+let dbPath: string;
+
+const storeCommand = memoryCommand.subcommands?.find((c) => c.name === 'store') as Command;
+const memoryStore = memoryTools.find((t) => t.name === 'memory_store')!;
+
+function ctx(flags: Record<string, unknown>): CommandContext {
+  return { args: [], flags: { _: [], ...flags } as CommandContext['flags'], cwd: tmp, interactive: false };
+}
+
+/** Rows actually on disk for `key`, whatever their status. */
+function rowsFor(key: string): number {
+  if (!fs.existsSync(dbPath)) return 0;
+  const db = openDaemonDatabase(dbPath);
+  try {
+    const res = db.exec(`SELECT COUNT(*) FROM memory_entries WHERE key = ?`, [key]);
+    return Number(res[0]?.values?.[0]?.[0] ?? 0);
+  } catch {
+    return 0; // no table yet — nothing was written, which is the assertion
+  } finally {
+    db.close();
+  }
+}
+
+beforeAll(() => {
+  // realpath: os.tmpdir() is a symlink into /private/var on macOS and the root
+  // resolver follows it, so an unresolved root would not match (Rule #1).
+  tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-1467-')));
+  fs.mkdirSync(path.join(tmp, '.moflo'), { recursive: true });
+  dbPath = path.join(tmp, '.moflo', 'moflo.db');
+  process.env.CLAUDE_PROJECT_DIR = tmp;
+  process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
+});
+
+afterAll(() => {
+  delete process.env.CLAUDE_PROJECT_DIR;
+  delete process.env.MOFLO_DISABLE_DAEMON_ROUTING;
+  try {
+    fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  } catch { /* Windows file lock — non-fatal */ }
+});
+
+beforeEach(() => {
+  delete process.env.MOFLO_ALLOW_TOOL_CALL_MARKUP;
+});
+
+describe('flo memory store (#1467)', () => {
+  it('fails with a non-zero exit and writes no row', async () => {
+    const errors: string[] = [];
+    const spy = vi.spyOn(output, 'printError').mockImplementation((m: string) => { errors.push(m); });
+    try {
+      const result = await storeCommand.action!(ctx({ key: 'cli-corrupt', value: CORRUPT, namespace: 'learnings' }));
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(1);
+      expect(errors.join('\n')).toContain('tool-call markup');
+    } finally {
+      spy.mockRestore();
+    }
+    expect(rowsFor('cli-corrupt')).toBe(0);
+  });
+});
+
+describe('mcp memory_store (#1467)', () => {
+  it('returns success:false, stored:false, and writes no row', async () => {
+    const result = await memoryStore.handler({
+      key: 'mcp-corrupt',
+      value: CORRUPT,
+      namespace: 'learnings',
+    }) as { success: boolean; stored: boolean; error?: string };
+
+    expect(result.success).toBe(false);
+    // `stored` is what a caller actually reads; #1467's entries all arrived
+    // under a cheerful `{success: true, stored: true}`.
+    expect(result.stored).toBe(false);
+    expect(result.error).toContain('tool-call markup');
+    expect(rowsFor('mcp-corrupt')).toBe(0);
+  });
+
+  it('still stores a value that merely discusses the markup', async () => {
+    const lesson = [
+      'A memory value can arrive carrying `<parameter name="tags">` or a stray',
+      '`</value>` from the harness that wrote it. Reject those at the store, but',
+      'anchor the detector to the trailing position — a bare marker match rejects',
+      'this very lesson, and a rule that cannot describe itself is not usable.',
+    ].join('\n');
+
+    const result = await memoryStore.handler({
+      key: 'mcp-lesson-about-1467',
+      value: lesson,
+      namespace: 'learnings',
+    }) as { success: boolean; stored: boolean; error?: string };
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+    expect(rowsFor('mcp-lesson-about-1467')).toBe(1);
+  });
+});

--- a/src/cli/__tests__/memory/tool-call-markup-1467.test.ts
+++ b/src/cli/__tests__/memory/tool-call-markup-1467.test.ts
@@ -1,0 +1,141 @@
+/**
+ * The captured-tool-call-markup detector (#1467).
+ *
+ * Two axes, and the second is the hard one. Catching the corruption is easy —
+ * grep for `</value>`. Not rejecting the lesson that DOCUMENTS the corruption,
+ * or the guidance doc that quotes it, is what the detector has to earn, and a
+ * naive marker match fails every case in the "clean" block below.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  detectToolCallMarkup,
+  toolCallMarkupError,
+  TRAILING_WINDOW,
+} from '../../memory/tool-call-markup.js';
+
+/** Padding that pushes an earlier marker out of the trailing window. */
+const PROSE = 'x'.repeat(TRAILING_WINDOW + 50);
+
+describe('detectToolCallMarkup: captured markup (#1467)', () => {
+  it('flags a value that ends on an unopened </value>', () => {
+    const hit = detectToolCallMarkup('The lesson text, cut off mid-thought.\n</value>');
+    expect(hit).not.toBeNull();
+    expect(hit!.marker).toBe('</value>');
+    expect(hit!.reason).toBe('trailing-closer');
+  });
+
+  it('flags the observed <parameter name="tags"> tail', () => {
+    // The exact shape reported in #1467: the value ended, the harness resumed
+    // emitting the call, and the next parameter landed inside the text.
+    const value =
+      'When rewriting a regex to kill backtracking, prove the behaviour diff.",\n'
+      + '    <parameter name="tags">["regex","redos","source:manual"]';
+    const hit = detectToolCallMarkup(value);
+    expect(hit).not.toBeNull();
+    expect(hit!.marker).toBe('<parameter name="tags">');
+    expect(hit!.reason).toBe('unterminated-opener');
+  });
+
+  it('flags a trailing fragment even with whitespace after it', () => {
+    expect(detectToolCallMarkup('a lesson\n</value>\n\n  ')).not.toBeNull();
+  });
+
+  it('flags an unterminated opener for any parameter name, not just tags', () => {
+    const value = 'the lesson.",\n<parameter name="metadata">{"type":"lesson"}';
+    expect(detectToolCallMarkup(value)?.marker).toBe('<parameter name="metadata">');
+  });
+
+  it('flags a trailing unopened </parameter>', () => {
+    expect(detectToolCallMarkup('the lesson text.\n</parameter>')?.reason).toBe('trailing-closer');
+  });
+});
+
+describe('detectToolCallMarkup: values that merely discuss markup (#1467)', () => {
+  it('accepts a lesson ABOUT this very bug', () => {
+    // The case the ticket calls out explicitly. It names both markers, then
+    // explains them — and the explanation is the anchor that separates a
+    // quotation from a fragment the value trailed off into.
+    const lesson = [
+      'memory_store values can arrive carrying the harness\' own tool-call markup:',
+      'the value ends early and a `<parameter name="tags">` opener, or a stray',
+      '`</value>` closer, is appended to the text.',
+      '',
+      'moflo is not the cause — the markup exists only in the model/harness layer —',
+      'but it is the last component that can catch it, so the write is rejected at',
+      'the storeEntry chokepoint rather than embedded and shared. Detect it by',
+      'anchoring to the trailing position AND requiring the markup to be unbalanced;',
+      'a bare marker match rejects this lesson.',
+    ].join('\n');
+    expect(detectToolCallMarkup(lesson)).toBeNull();
+  });
+
+  it('accepts balanced markup quoted in full', () => {
+    expect(detectToolCallMarkup('The harness emits <value>the text</value> around it.')).toBeNull();
+  });
+
+  it('accepts an opener quoted inline mid-sentence', () => {
+    // Not at a line start — the harness always puts the fragment on its own line.
+    expect(detectToolCallMarkup('Never write <parameter name="tags"> into a value.')).toBeNull();
+  });
+
+  it('accepts an indented example followed by explanation', () => {
+    // A guidance doc showing the corrupt shape as a code block, then explaining
+    // it. Same line-start position as the real fragment; pushed out of the
+    // trailing window by the prose that follows.
+    const doc = `The corruption looks like this:\n\n    <parameter name="tags">["a"]\n\n${PROSE}`;
+    expect(detectToolCallMarkup(doc)).toBeNull();
+  });
+
+  it('accepts a closer that appears mid-text', () => {
+    expect(detectToolCallMarkup(`A stray </value> shows up in the tail.\n${PROSE}`)).toBeNull();
+  });
+
+  it('accepts ordinary text with angle brackets', () => {
+    expect(detectToolCallMarkup('Guard with `if (a < b && c > d)` before the loop.')).toBeNull();
+    expect(detectToolCallMarkup('<div class="x">html</div>')).toBeNull();
+    expect(detectToolCallMarkup('')).toBeNull();
+    expect(detectToolCallMarkup('a plain lesson with no markup at all')).toBeNull();
+  });
+
+  it('does NOT flag a fragment longer than the trailing window', () => {
+    // A documented boundary, not an oversight: the window is what keeps a doc
+    // that quotes the markup out of the reject path, and every fragment
+    // observed in #1467 is under 60 characters. Pinned so a future widening is
+    // a deliberate decision with this trade-off in view.
+    const value = `the lesson.\n<parameter name="metadata">${'y'.repeat(TRAILING_WINDOW + 1)}`;
+    expect(detectToolCallMarkup(value)).toBeNull();
+  });
+
+  it('accepts a short value whose FIRST line is an unmatched opener', () => {
+    // Nothing precedes the markup, so no text was cut off — this is not the
+    // shape the detector describes. Without the "after text" half of the
+    // line-start rule, every value shorter than the window that opens with
+    // markup was rejected no matter what followed it.
+    expect(detectToolCallMarkup('<parameter name="tags">["a"]\nstill a short value')).toBeNull();
+    expect(detectToolCallMarkup('<value>\nshort')).toBeNull();
+  });
+
+  it('accepts a bare <parameter> with no name attribute', () => {
+    // Not a shape the harness emits; flagging it would be guessing.
+    expect(detectToolCallMarkup('see <parameter>')).toBeNull();
+  });
+});
+
+describe('toolCallMarkupError (#1467)', () => {
+  it('names the namespace, key, and the offending text', () => {
+    const value = 'the lesson.",\n<parameter name="tags">["a","b"]';
+    const message = toolCallMarkupError(detectToolCallMarkup(value)!, value, 'learnings', 'my-lesson');
+    expect(message).toContain('learnings/my-lesson');
+    expect(message).toContain('<parameter name=');
+    expect(message).toContain('MOFLO_ALLOW_TOOL_CALL_MARKUP');
+  });
+
+  it('truncates a long offending tail rather than echoing the whole value', () => {
+    const value = `the lesson.\n<parameter name="tags">${'y'.repeat(150)}`;
+    const message = toolCallMarkupError(detectToolCallMarkup(value)!, value, 'learnings', 'k');
+    expect(message.length).toBeLessThan(600);
+    expect(message).toContain('…');
+  });
+});

--- a/src/cli/__tests__/services/team-artifact-markup-1467.test.ts
+++ b/src/cli/__tests__/services/team-artifact-markup-1467.test.ts
@@ -1,0 +1,234 @@
+/**
+ * The team artifact stops carrying captured tool-call markup (#1467).
+ *
+ * This is the half of the fix that helps a store which is ALREADY polluted. The
+ * write-time guard only protects entries written from now on; the 68 corrupt
+ * rows a consumer already has would keep flowing out to the artifact on every
+ * export and back into every teammate's database on every import. So export
+ * skips a corrupt local row and import skips a corrupt artifact line, each
+ * reporting the count rather than dropping it silently.
+ *
+ * The subtle requirement is that skipping must not read as a DELETION. Export
+ * drops the row from the source snapshot, and `planReconcile` derives deletions
+ * from a local tombstone rather than from an absent key — so a skip publishes
+ * nothing, and `does not publish a tombstone for the skipped entry` pins that.
+ *
+ * Real node:sqlite DBs and real files under os.tmpdir(); every path is joined
+ * (Rule #1).
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+
+import {
+  exportTeamArtifact,
+  importTeamArtifact,
+  TOMBSTONE_NAMESPACE,
+} from '../../services/team-artifact-sync.js';
+import { memoryDbPath } from '../../services/moflo-paths.js';
+import { memoryCommand } from '../../commands/memory.js';
+import { output } from '../../output.js';
+import type { Command, CommandContext } from '../../types.js';
+import { MEMORY_SCHEMA_V3 } from '../../memory/memory-initializer.js';
+import { makeMemoryDb, type FixtureDb } from '../_helpers/legacy-memory-db.js';
+import { DatabaseSync } from 'node:sqlite';
+
+/** The exact shape reported in #1467. */
+const CORRUPT = 'the actual lesson text.",\n    <parameter name="tags">["a","b","source:manual"]';
+const NOW = '2026-08-26T00:00:00.000Z';
+
+const tmpDirs: string[] = [];
+afterEach(async () => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop()!;
+    try {
+      await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    } catch { /* Windows file lock — non-fatal */ }
+  }
+});
+
+async function makeRoot(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'moflo-1467-team-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function seed(
+  dbPath: string,
+  rows: Array<{ key: string; content: string; status?: 'active' | 'archived'; updatedAt?: number }>,
+): Promise<void> {
+  return makeMemoryDb(dbPath, MEMORY_SCHEMA_V3, (db: FixtureDb) => {
+    for (const r of rows) {
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, created_at, updated_at, status)
+         VALUES (?, ?, 'learnings', ?, ?, ?, ?)`,
+        [`id-${r.key}`, r.key, r.content, 1_700_000_000_000, r.updatedAt ?? 1_700_000_000_000, r.status ?? 'active'],
+      );
+    }
+  });
+}
+
+interface ArtifactLine { namespace: string; key: string; content?: string; deleted?: unknown }
+
+function readLines(artifactPath: string): ArtifactLine[] {
+  if (!existsSync(artifactPath)) return [];
+  return readFileSync(artifactPath, 'utf-8')
+    .split(/\r?\n/)
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as ArtifactLine);
+}
+
+function writeLines(artifactPath: string, lines: ArtifactLine[]): void {
+  mkdirSync(dirname(artifactPath), { recursive: true });
+  const provenance = { author: 'teammate', source: 'other-machine', sharedAt: NOW };
+  writeFileSync(
+    artifactPath,
+    lines.map((l) => JSON.stringify({ type: 'semantic', updated_at: 1_700_000_000_000, provenance, ...l })).join('\n') + '\n',
+    'utf-8',
+  );
+}
+
+function localKeys(dbPath: string): string[] {
+  if (!existsSync(dbPath)) return [];
+  const db = new DatabaseSync(dbPath);
+  try {
+    return (db.prepare(`SELECT key FROM memory_entries WHERE status = 'active' ORDER BY key`).all() as Array<{ key: string }>)
+      .map((r) => r.key);
+  } finally {
+    db.close();
+  }
+}
+
+describe('exportTeamArtifact skips captured markup (#1467)', () => {
+  it('shares the clean entry, skips the corrupt one, and reports the count', async () => {
+    const root = await makeRoot();
+    await seed(memoryDbPath(root), [
+      { key: 'clean-lesson', content: 'An ordinary lesson about cache invalidation.' },
+      { key: 'corrupt-lesson', content: CORRUPT },
+    ]);
+    const artifactPath = join(root, '.moflo', 'shared', 'learnings.jsonl');
+
+    const report = exportTeamArtifact({ projectRoot: root, artifactPath, sharedAt: NOW });
+
+    expect(report.skippedCorrupt).toBe(1);
+    expect(report.added).toBe(1);
+    expect(readLines(artifactPath).map((l) => l.key)).toEqual(['clean-lesson']);
+  });
+
+  it('does not publish a tombstone for the skipped entry', async () => {
+    // The trap in dropping a row from the source: if a skip read as "deleted
+    // locally", export would propagate a retraction and every teammate would
+    // lose their own copy of the key.
+    const root = await makeRoot();
+    await seed(memoryDbPath(root), [{ key: 'corrupt-lesson', content: CORRUPT }]);
+    const artifactPath = join(root, '.moflo', 'shared', 'learnings.jsonl');
+
+    const report = exportTeamArtifact({ projectRoot: root, artifactPath, sharedAt: NOW });
+
+    expect(report.deleted).toBe(0);
+    expect(readLines(artifactPath)).toEqual([]);
+  });
+
+  it('still publishes the tombstone for a corrupt entry the user deleted', async () => {
+    // Archiving leaves `content` intact, so a skip keyed on the row's body
+    // would swallow the very deletion that retracts the corrupt line — and a
+    // line already in the artifact would become permanently unretractable,
+    // which is the opposite of what the skip is for.
+    const root = await makeRoot();
+    // Newer than the shared line, so the deletion wins the last-writer compare.
+    await seed(memoryDbPath(root), [
+      { key: 'corrupt-lesson', content: CORRUPT, status: 'archived', updatedAt: 1_800_000_000_000 },
+    ]);
+    const artifactPath = join(root, '.moflo', 'shared', 'learnings.jsonl');
+    writeLines(artifactPath, [{ namespace: 'learnings', key: 'corrupt-lesson', content: CORRUPT }]);
+
+    const report = exportTeamArtifact({ projectRoot: root, artifactPath, sharedAt: NOW });
+
+    expect(report.skippedCorrupt).toBe(0);
+    expect(report.deleted).toBe(1);
+    const [line] = readLines(artifactPath);
+    expect(line.namespace).toBe(TOMBSTONE_NAMESPACE);
+  });
+
+  it('leaves a corrupt line a teammate already shared untouched', async () => {
+    // Removing someone else's line is a different decision than declining to
+    // add our own; export only stops contributing.
+    const root = await makeRoot();
+    await seed(memoryDbPath(root), [{ key: 'corrupt-lesson', content: CORRUPT }]);
+    const artifactPath = join(root, '.moflo', 'shared', 'learnings.jsonl');
+    writeLines(artifactPath, [{ namespace: 'learnings', key: 'corrupt-lesson', content: CORRUPT }]);
+
+    exportTeamArtifact({ projectRoot: root, artifactPath, sharedAt: NOW });
+
+    expect(readLines(artifactPath).map((l) => l.key)).toEqual(['corrupt-lesson']);
+  });
+});
+
+describe('flo memory team-export reports the skip (#1467)', () => {
+  it('warns about the withheld entries rather than dropping them silently', async () => {
+    // "skips (and reports)" — a silent skip would be the same invisibility the
+    // ticket is about, one layer up: the store looks shared, and nobody knows
+    // which entries were held back or why.
+    const root = await makeRoot();
+    await seed(memoryDbPath(root), [
+      { key: 'clean-lesson', content: 'An ordinary lesson.' },
+      { key: 'corrupt-lesson', content: CORRUPT },
+    ]);
+    const artifactPath = join(root, '.moflo', 'shared', 'learnings.jsonl');
+    const teamExport = memoryCommand.subcommands?.find((c) => c.name === 'team-export') as Command;
+
+    const warnings: string[] = [];
+    const spy = vi.spyOn(output, 'printWarning').mockImplementation((m: string) => { warnings.push(m); });
+    const saved = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = root;
+    try {
+      const ctx = { args: [], flags: { _: [], to: artifactPath } as CommandContext['flags'], cwd: root, interactive: false };
+      const result = await teamExport.action!(ctx as CommandContext);
+      expect(result.success).toBe(true);
+    } finally {
+      spy.mockRestore();
+      if (saved === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+      else process.env.CLAUDE_PROJECT_DIR = saved;
+    }
+
+    expect(warnings.join('\n')).toMatch(/1 entry NOT shared.*tool-call markup/s);
+  });
+});
+
+describe('importTeamArtifact skips captured markup (#1467)', () => {
+  it('imports the clean line, skips the corrupt one, and reports the count', async () => {
+    const root = await makeRoot();
+    const artifactPath = join(root, '.moflo', 'shared', 'learnings.jsonl');
+    writeLines(artifactPath, [
+      { namespace: 'learnings', key: 'clean-lesson', content: 'An ordinary lesson.' },
+      { namespace: 'learnings', key: 'corrupt-lesson', content: CORRUPT },
+    ]);
+
+    const report = importTeamArtifact({ projectRoot: root, artifactPath });
+
+    expect(report.skippedCorrupt).toBe(1);
+    expect(report.imported).toBe(1);
+    expect(localKeys(memoryDbPath(root))).toEqual(['clean-lesson']);
+  });
+
+  it('still applies a tombstone — a deletion must propagate', async () => {
+    // Tombstones carry no content, so the content check must not swallow them.
+    const root = await makeRoot();
+    await seed(memoryDbPath(root), [{ key: 'retired', content: 'gone soon' }]);
+    const artifactPath = join(root, '.moflo', 'shared', 'learnings.jsonl');
+    writeLines(artifactPath, [{
+      namespace: TOMBSTONE_NAMESPACE,
+      key: 'retired',
+      deleted: { namespace: 'learnings', key: 'retired', at: 1_800_000_000_000 },
+    }]);
+
+    const report = importTeamArtifact({ projectRoot: root, artifactPath });
+
+    expect(report.skippedCorrupt).toBe(0);
+    expect(report.deleted).toBe(1);
+    expect(localKeys(memoryDbPath(root))).toEqual([]);
+  });
+});

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -2891,6 +2891,12 @@ const teamExportCommand: Command = {
       if (report.skippedMalformed > 0) {
         output.printWarning(`${report.skippedMalformed} malformed line${report.skippedMalformed === 1 ? '' : 's'} skipped.`);
       }
+      if (report.skippedCorrupt > 0) {
+        output.printWarning(
+          `${report.skippedCorrupt} entr${report.skippedCorrupt === 1 ? 'y' : 'ies'} NOT shared — captured tool-call markup in the value (#1467). `
+          + `Run \`flo memory list --namespace learnings\` to find and rewrite them.`,
+        );
+      }
       if (!report.wrote) {
         output.printInfo('Nothing changed — the artifact was left untouched.');
       }
@@ -2946,6 +2952,11 @@ const teamImportCommand: Command = {
       }
       if (report.skippedMalformed > 0) {
         output.printWarning(`${report.skippedMalformed} malformed line${report.skippedMalformed === 1 ? '' : 's'} skipped.`);
+      }
+      if (report.skippedCorrupt > 0) {
+        output.printWarning(
+          `${report.skippedCorrupt} artifact line${report.skippedCorrupt === 1 ? '' : 's'} NOT imported — captured tool-call markup in the content (#1467).`,
+        );
       }
       if (report.skippedNonDurable > 0) {
         output.printWarning(`${report.skippedNonDurable} non-durable entr${report.skippedNonDurable === 1 ? 'y' : 'ies'} skipped (only learnings/knowledge are shared).`);

--- a/src/cli/memory/entries-write.ts
+++ b/src/cli/memory/entries-write.ts
@@ -29,6 +29,7 @@ import { writeThroughDurable } from '../services/durable-sync.js';
 import { archiveDurableRow, isDurableNamespace } from '../services/durable-store-io.js';
 import { resolveStateRoot } from '../services/project-root.js';
 import { generateId } from '../shared/utils/id.js';
+import { detectToolCallMarkup, markupCheckDisabled, toolCallMarkupError } from './tool-call-markup.js';
 
 /**
  * Propagate a just-persisted durable write to the shared store (#1232). The
@@ -68,6 +69,32 @@ export async function storeEntry(options: {
   embedding?: { dimensions: number; model: string };
   error?: string;
 }> {
+  // #1467 — reject a value that carries captured tool-call markup. Every
+  // model-authored write lands here: the CLI (`flo memory store`), the MCP tool
+  // (`memory_store`), and the daemon's own RPC handler. The check runs before
+  // the routing preamble below and before any embedding, so a rejected value
+  // never crosses the wire, produces a vector, or reaches disk.
+  //
+  // `storeEntries` (bulk) is deliberately NOT checked on its bridge path. Its
+  // one production caller is the pattern pre-trainer, whose content is derived
+  // from code rather than written by a model — so it cannot carry this
+  // corruption, and it is exactly where a truncated XML snippet ending on
+  // `</value>` would legitimately arrive. See the blind-spot note in
+  // tool-call-markup.ts.
+  if (!markupCheckDisabled()) {
+    const hit = detectToolCallMarkup(options.value);
+    if (hit) {
+      // Returned, not logged: every caller surfaces `error` in its own idiom
+      // (the CLI prints it, MCP returns it), and a console.error here would
+      // print the same refusal twice on the path users actually see.
+      return {
+        success: false,
+        id: '',
+        error: toolCallMarkupError(hit, options.value, options.namespace ?? 'default', options.key),
+      };
+    }
+  }
+
   // Soft-redirect: `knowledge` is a deprecated alias for `learnings`. Writes
   // are accepted but routed to learnings with provenance tags so future
   // decay/prune treats user-forced entries as locked. Old consumer DBs that

--- a/src/cli/memory/tool-call-markup.ts
+++ b/src/cli/memory/tool-call-markup.ts
@@ -1,0 +1,249 @@
+/**
+ * Detect Claude Code tool-call markup captured into a memory value (#1467).
+ *
+ * A model emitting a `memory_store` call can have the harness' own parameter
+ * markup spill into the `value` string it is writing. The value then arrives at
+ * moflo already malformed, always as a fragment the text trails off into:
+ *
+ *     ...the actual lesson text.",
+ *     <parameter name="tags">["a","b","source:manual"]
+ *
+ * moflo does not cause this — the markup exists only in the model/harness layer —
+ * but it is the last component that can catch it. Left alone it is written to
+ * disk, embedded (so it degrades the vector for that entry and every search that
+ * would have matched it), and shared to the team artifact, at which point it is
+ * permanent and propagates to every machine that imports.
+ *
+ * ## Why the detector is anchored rather than a bare marker match
+ *
+ * The naive test — "does the value contain `</value>` or `<parameter name=`" —
+ * rejects the lesson that documents this very bug, and every guidance doc that
+ * quotes the markup. So a marker only counts when it is *structurally broken*
+ * AND *trailing*:
+ *
+ * | Rule | Fires on | Passes |
+ * |---|---|---|
+ * | A — trailing unmatched closer | value ends on a `</value>` / `</parameter>` that never had an opener | balanced `<value>x</value>` prose; a closer mentioned mid-text |
+ * | B — unterminated trailing opener | an opener with no closer, on its own line, within the last {@link TRAILING_WINDOW} chars | an opener quoted inline in a sentence; one explained in the 200+ chars that follow |
+ *
+ * A value that discusses the markup explains it, and the explanation is the
+ * anchor. A value that was *cut off by* the markup has nothing after it.
+ *
+ * ## Accepted blind spots
+ *
+ * The detector is deliberately tuned to miss rather than over-reject, because a
+ * false reject blocks a legitimate write in every consumer while a miss only
+ * leaves one entry as bad as it is today:
+ *
+ * - A captured fragment longer than {@link TRAILING_WINDOW}. Every fragment
+ *   observed in #1467 is under 60 characters; widening the window would start
+ *   rejecting docs that quote the markup.
+ * - A value that quotes `<value>` earlier and is *then* truncated by a stray
+ *   `</value>`: the quotation's opener absorbs the closer and both rules go
+ *   quiet. Matching by tag name is what makes the balanced-prose cases pass.
+ * - A value that begins with markup, having lost all of its own text.
+ *
+ * Rule A's one accepted false positive is the mirror image: a truncated XML
+ * snippet that happens to end on an unmatched `</value>`. It is refusable by
+ * design — the ticket asks for that shape — and {@link MARKUP_OVERRIDE_ENV} is
+ * the way through. Bulk writes (`storeEntries`, whose only caller is the
+ * pattern pre-trainer) are not checked at all, which is where machine-generated
+ * XML-bearing content actually arrives.
+ *
+ * Pure string logic — no fs, no db, no platform surface (Rule #1).
+ *
+ * @module memory/tool-call-markup
+ */
+
+/**
+ * How close to the end of the value an unterminated opener must sit to count as
+ * a captured fragment rather than a quotation. Observed fragments are short —
+ * `<parameter name="tags">["a","b","source:manual"]` is 47 characters — while
+ * prose that quotes an opener goes on to say something about it.
+ */
+export const TRAILING_WINDOW = 200;
+
+/** Escape hatch for a value that is genuinely shaped like the corruption. */
+export const MARKUP_OVERRIDE_ENV = 'MOFLO_ALLOW_TOOL_CALL_MARKUP';
+
+/** How much of the offending tail the error message quotes back. */
+const EXCERPT_LIMIT = 120;
+
+export interface ToolCallMarkupHit {
+  /** The exact markup that tripped the detector, e.g. `</value>`. */
+  marker: string;
+  /** Offset of `marker` within the value. */
+  index: number;
+  /** Which rule fired — see the table in the module header. */
+  reason: 'trailing-closer' | 'unterminated-opener';
+}
+
+/** One `<value>` / `<parameter name="…">` token found in the text. */
+interface Token {
+  name: 'value' | 'parameter';
+  kind: 'open' | 'close';
+  text: string;
+  index: number;
+}
+
+/**
+ * Matches the four token shapes the harness emits. `[^"]*` for the attribute
+ * keeps the pattern linear — no nested quantifier, so no backtracking blow-up
+ * on a long value. Built per scan rather than shared, so no `lastIndex` state
+ * outlives a call.
+ */
+function tokenPattern(): RegExp {
+  return /<(\/?)(value|parameter)(\s+name="[^"]*")?\s*>/g;
+}
+
+/**
+ * Visit every token in `text` at or after `from`. Streaming rather than
+ * array-returning: Rule A has to see the whole value, and a 1 MB value of
+ * repeated `<value>` would otherwise build a token object per match.
+ */
+function scanTokens(text: string, from: number, visit: (token: Token) => void): void {
+  const re = tokenPattern();
+  re.lastIndex = from;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    const [full, slash, name, attr] = match;
+    // `<parameter>` without a name, or `<value name="x">`, is neither shape the
+    // harness emits; ignoring them keeps the detector to what it can justify.
+    if (name === 'parameter' && !slash && !attr) continue;
+    if (name === 'value' && attr) continue;
+    visit({
+      name: name as 'value' | 'parameter',
+      kind: slash ? 'close' : 'open',
+      text: full,
+      index: match.index,
+    });
+  }
+}
+
+/**
+ * True when `index` starts a line that already had text before it.
+ *
+ * Both halves matter. The harness always puts the captured fragment on its own
+ * line, so prose that quotes an opener mid-sentence is excluded by the line
+ * break. And a value that *starts* at index 0 with markup never had text to be
+ * cut off from, so it is not the shape this detects — without the second half
+ * every value shorter than {@link TRAILING_WINDOW} that opens with markup would
+ * be rejected no matter what followed it.
+ */
+function startsOwnLineAfterText(text: string, index: number): boolean {
+  for (let i = index - 1; i >= 0; i--) {
+    const ch = text[i];
+    if (ch === '\n' || ch === '\r') return text.slice(0, i).trim().length > 0;
+    if (ch !== ' ' && ch !== '\t') return false;
+  }
+  return false; // reached the start of the value with no text before the markup
+}
+
+/**
+ * Return the captured-markup fragment in `value`, or `null` when the value is
+ * clean. See the module header for what "captured" means and why a value that
+ * merely quotes the markup is not.
+ */
+export function detectToolCallMarkup(value: string): ToolCallMarkupHit | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  if (!value.includes('<')) return null;
+
+  const trimmed = value.trimEnd();
+
+  // Rule A — the value ends on a closing tag that never had an opener. This is
+  // the `</value>` shape: the harness closed the parameter and the closer
+  // landed inside the text it was closing. Two counters, no allocation, so the
+  // cost of a pathological value is time only.
+  const depth: Record<'value' | 'parameter', number> = { value: 0, parameter: 0 };
+  let trailingCloser: Token | null = null;
+  scanTokens(trimmed, 0, (token) => {
+    if (token.kind === 'open') {
+      depth[token.name]++;
+      return;
+    }
+    if (depth[token.name] > 0) {
+      depth[token.name]--;
+      return;
+    }
+    trailingCloser = token.index + token.text.length === trimmed.length ? token : null;
+  });
+  if (trailingCloser) {
+    // The cast is for the narrowing only: TypeScript cannot see that the
+    // callback above assigns, so it holds `trailingCloser` at its initial
+    // `null` type. `scanTokens` is fully synchronous, so the assignment has
+    // certainly happened by here.
+    const hit = trailingCloser as Token;
+    return { marker: hit.text, index: hit.index, reason: 'trailing-closer' };
+  }
+
+  // Rule B — an opener that is never closed, on its own line, near the end.
+  // This is the `<parameter name="tags">` shape: the value was cut off and the
+  // next parameter of the same call was appended to it.
+  //
+  // Scanned over the trailing window alone: nothing follows the end of the
+  // value, so an opener inside the window can only be closed inside it, and the
+  // cost is bounded no matter how large the value is.
+  //
+  // Not quite identical to a whole-value scan, in one direction only. A tag
+  // that straddles `windowStart` is invisible to this scan, so if its closer
+  // falls inside the window that closer reads as unmatched and can absorb a
+  // genuinely unterminated opener found later in the backward walk. That is a
+  // miss, never a false reject — the same direction every trade-off in this
+  // module leans.
+  const windowStart = Math.max(0, trimmed.length - TRAILING_WINDOW);
+  const windowTokens: Token[] = [];
+  scanTokens(trimmed, windowStart, (token) => { windowTokens.push(token); });
+
+  const pendingClosers: Record<'value' | 'parameter', number> = { value: 0, parameter: 0 };
+  for (let i = windowTokens.length - 1; i >= 0; i--) {
+    const token = windowTokens[i];
+    if (token.kind === 'close') {
+      pendingClosers[token.name]++;
+      continue;
+    }
+    if (pendingClosers[token.name] > 0) {
+      pendingClosers[token.name]--;
+      continue;
+    }
+    // First unmatched opener found scanning backwards — the last one in the
+    // value, and the only one that can be the captured fragment: a fragment
+    // runs to the end, so anything after it is part of it. Stopping here rather
+    // than continuing to earlier openers is the miss-biased choice on purpose —
+    // if the text running to the end started mid-sentence, it is prose.
+    if (startsOwnLineAfterText(trimmed, token.index)) {
+      return { marker: token.text, index: token.index, reason: 'unterminated-opener' };
+    }
+    break;
+  }
+
+  return null;
+}
+
+/** True when the operator has explicitly opted this process out of the check. */
+export function markupCheckDisabled(): boolean {
+  return process.env[MARKUP_OVERRIDE_ENV] === '1';
+}
+
+/**
+ * The rejection message. It quotes the offending tail back so the caller can
+ * see exactly what leaked and re-send the write — the silent `{success: true}`
+ * this replaces is why 68 corrupted entries accumulated unnoticed.
+ */
+export function toolCallMarkupError(
+  hit: ToolCallMarkupHit,
+  value: string,
+  namespace: string,
+  key: string,
+): string {
+  const tail = value.trimEnd().slice(hit.index);
+  const excerpt = tail.length > EXCERPT_LIMIT ? `${tail.slice(0, EXCERPT_LIMIT)}…` : tail;
+  const shape = hit.reason === 'trailing-closer'
+    ? 'the value ends on a closing tag that was never opened'
+    : 'the value trails off into an unclosed opening tag';
+  return (
+    `Refusing to store ${namespace}/${key}: the value contains captured tool-call markup — `
+    + `${shape}. Offending text at offset ${hit.index}: ${JSON.stringify(excerpt)}. `
+    + `Re-send the write with the markup removed. `
+    + `(Set ${MARKUP_OVERRIDE_ENV}=1 to store it anyway.)`
+  );
+}

--- a/src/cli/services/team-artifact-sync.ts
+++ b/src/cli/services/team-artifact-sync.ts
@@ -84,6 +84,7 @@ import {
   applyDurableActions,
   type DurablePayload,
 } from './durable-store-io.js';
+import { detectToolCallMarkup } from '../memory/tool-call-markup.js';
 
 /** Allowed `type` values — the schema CHECK set. An out-of-set value would make
  *  INSERT OR IGNORE silently drop a hand-edited artifact row, so we coerce. */
@@ -174,6 +175,12 @@ export interface ExportReport {
   backfilled: number;
   /** Malformed JSONL lines skipped while reading the artifact. */
   skippedMalformed: number;
+  /**
+   * Local entries NOT shared because their value carries captured tool-call
+   * markup (#1467). Already-stored corruption stops propagating here, without
+   * waiting for anyone to run a local cleanup pass first.
+   */
+  skippedCorrupt: number;
   /** Live entries in the artifact after the merge. */
   total: number;
   /** Tombstone lines retained in the artifact after the merge. */
@@ -200,6 +207,12 @@ export interface ImportReport {
   skippedMalformed: number;
   /** Well-formed lines skipped for being outside the durable namespaces. */
   skippedNonDurable: number;
+  /**
+   * Artifact lines skipped because their content carries captured tool-call
+   * markup (#1467). The symmetric half of the export skip: a consumer whose
+   * artifact is already polluted stops re-importing the corruption.
+   */
+  skippedCorrupt: number;
 }
 
 /**
@@ -483,6 +496,26 @@ export function exportTeamArtifact(opts: {
     }
   }
 
+  // #1467 — a local row whose value carries captured tool-call markup is not
+  // shared. Dropping it from the SOURCE (rather than the artifact) means it is
+  // simply not propagated: `planReconcile` derives deletions from a local
+  // tombstone, never from an absent key, so this can't publish a retraction of
+  // someone else's line.
+  //
+  // Gated on `record.content`, which a tombstone does not have, NOT on the
+  // payload: archiving leaves `content` intact, so a payload lookup would still
+  // see the corrupt body of a row the user already deleted and would suppress
+  // its tombstone — making a corrupt line already in the artifact permanently
+  // unretractable. Deleting the current entry mid-iteration is well-defined for
+  // a Map, so no copy is needed.
+  let skippedCorrupt = 0;
+  for (const [id, record] of records) {
+    if (typeof record.content !== 'string' || !detectToolCallMarkup(record.content)) continue;
+    records.delete(id);
+    payloads.delete(id);
+    skippedCorrupt++;
+  }
+
   const { actions, summary } = planReconcile(records, target);
   for (const action of actions) {
     if (action.op === 'delete') {
@@ -540,6 +573,7 @@ export function exportTeamArtifact(opts: {
     prunedTombstones,
     backfilled,
     skippedMalformed: malformed,
+    skippedCorrupt,
     total: live,
     tombstones,
     wrote,
@@ -571,6 +605,7 @@ export function importTeamArtifact(opts: { projectRoot?: string; artifactPath: s
     considered: 0,
     skippedMalformed: 0,
     skippedNonDurable: 0,
+    skippedCorrupt: 0,
   };
 
   const { lines, records: parsed, malformed } = readArtifact(opts.artifactPath);
@@ -586,6 +621,13 @@ export function importTeamArtifact(opts: { projectRoot?: string; artifactPath: s
     // acting on it.
     if (!isDurableNamespace(record.namespace)) {
       report.skippedNonDurable++;
+      continue;
+    }
+    // #1467 — never write captured tool-call markup into the local store, even
+    // when a teammate on an older moflo already shared it. Tombstones carry no
+    // content and are always applied: a deletion must still propagate.
+    if (!isTombstoneLine(line) && detectToolCallMarkup(line.content)) {
+      report.skippedCorrupt++;
       continue;
     }
     report.considered++;


### PR DESCRIPTION
Closes #1467.

## What this fixes

A `memory_store` value that arrived carrying the harness' own parameter markup — the value cut off, with a `<parameter name="tags">` opener or a stray `</value>` appended to it — was persisted verbatim, embedded, and shared to the team artifact, all under a cheerful `{success: true, stored: true}`. One consumer store held 68 such entries in `learnings` alone, plus 2 in `verify` and 1 in `swarm-tasks`, across three machines, at an accelerating rate. The junk sits inside the field that gets embedded, so it degrades the vector for that entry and every search that would have matched it, and the tags the fragment was carrying never reach the `tags` column at all.

moflo does not cause this — the markup exists only in the model/harness layer, so the value arrives already malformed — but it is the last component that can catch it.

## The three standing considerations

**Rule #1 — cross-platform.** Pure string logic: no paths, no fs, no spawn, no shell-outs. CRLF is handled explicitly (`trimEnd` and the line-start scan both treat `\r`), which matters because a Windows-authored value is exactly where a `\r\n` boundary would otherwise slip past the line-start rule. Tests use `os.tmpdir()` with `fs.realpathSync` on the temp root so the macOS `/var` → `/private/var` symlink doesn't break root resolution.

**Rule #2 — consumer surface.** One new module, a guard at the top of `storeEntry`, two skips in `team-artifact-sync`, and two output lines in `memory.ts`. No `bin/`, no `.claude/scripts/`, no manifest or sync-layer change. Failure mode for someone upgrading: **a write that previously succeeded with a corrupt trailing fragment now fails** — the CLI exits non-zero, MCP returns `success: false`. That is the intent, but it is a behaviour change, so `MOFLO_ALLOW_TOOL_CALL_MARKUP=1` stores a flagged value anyway and the error message advertises it. No migration; existing `.moflo/` state parses unchanged and existing corrupt rows stay readable, they are simply no longer shared.

**Dogfooding.** The MCP server and daemon run from `node_modules/moflo/`, so this repo's own writes are unguarded until publish + reinstall. Nothing here changes the launcher, hooks or statusline, so there is no parity copy to keep in step.

## Design

**One chokepoint, two tested surfaces.** The ticket treats the CLI and the MCP tool as separate paths — worth checking, and they converge: `flo memory store`, `mcp__moflo__memory_store` and the daemon's RPC handler all call `storeEntry`. The guard sits at its top, above the #981 daemon-routing preamble and above any embedding, so a rejected value never crosses the wire, produces a vector, or reaches disk. Both surfaces still get an end-to-end test against a real store, because a surface that stopped reaching the chokepoint is exactly what would go unnoticed.

Bulk `storeEntries` is **deliberately** not guarded on its bridge path. Its one production caller is the pattern pre-trainer, whose content is derived from code rather than written by a model — so it cannot carry this corruption, and it is precisely where a truncated XML snippet ending on `</value>` would legitimately arrive.

**The detector — anchored *and* unbalanced.** The ticket suggests either; they are complementary, and each alone rejects the lesson that documents this bug:

| Rule | Fires on | Passes |
|---|---|---|
| A — trailing unmatched closer | value ends on a `</value>` / `</parameter>` that never had an opener | balanced `<value>x</value>` prose; a closer mentioned mid-text |
| B — unterminated trailing opener | an opener with no closer, on its own line **with text before it**, within the last 200 chars | an opener quoted inline; one explained in the 200+ chars that follow; a value that opens with markup and so lost no text |

A value that *discusses* the markup goes on to explain it, and the explanation is the anchor. A value *cut off by* the markup has nothing after it.

## Two things reviewers should look at

**Skipping must not read as deleting.** `team-export` drops a corrupt row from the **source snapshot**, not the artifact. `planReconcile` derives deletions from a local tombstone and never from an absent key, so a skip publishes nothing and cannot retract a teammate's line — pinned by `does not publish a tombstone for the skipped entry`. The mirror trap is sharper and the review caught it: archiving a row leaves `content` intact, so gating the skip on the row's **payload** would swallow the tombstone of a corrupt entry the user deleted, making a corrupt line already in the artifact permanently unretractable. The gate is `record.content`, which a tombstone does not have.

**Import is skipped too, beyond AC4.** AC4 alone stops a polluted store from *exporting*, but every teammate would still import the artifact's existing corruption on each session start — which leaves the headline problem alive for the machines that already have it. Tombstones are exempt: a deletion must still propagate.

## Accepted blind spots, documented in the module

Tuned to miss rather than over-reject, because a false reject blocks a legitimate write in every consumer while a miss leaves one entry no worse than it is today:

- A captured fragment longer than 200 characters. Every fragment in the reported data is under 60; widening the window starts rejecting docs that quote the markup.
- A value that quotes `<value>` earlier and is *then* truncated by a stray `</value>` — the quotation's opener absorbs the closer.
- Rule A's mirror-image false positive: a truncated XML snippet ending on an unmatched `</value>` is refused. That shape is what the ticket asks to reject; the override env is the way through, and the bulk exemption above is where such content actually arrives.

## Review

`/flo-simplify` classified this DEEP (804 LOC of new logic, 16 net-new declarations) and ran three Opus agents. Two independently found the tombstone-suppression bug above. Also fixed from that pass:

- Rule B rejected **any** value shorter than the window that began with an unmatched opener — the line-start check returned true at index 0, so the "explained in the 200+ chars that follow" promise did not hold for short values. Now requires text before the markup.
- The `storeEntry` comment claimed to be "the single chokepoint for every store", which was false — `storeEntries` bypasses it. The exemption is now stated and justified rather than implied.
- `detectToolCallMarkup` built a token object per match over the whole value, the diff's one unbounded structure. Rule A is now a two-counter streaming pass with no allocation, and Rule B scans only the trailing window (nothing follows the end of a value, so an opener inside the window can only be closed inside it — same answer, bounded cost). This also removed a sort that existed only to read its last element.
- `[...records]` copied the whole map; deleting the current entry mid-iteration is well-defined for a `Map`.
- A `console.error` that double-printed the refusal the CLI already prints.

A follow-up validation pass over the rewrite confirmed Rule A's trailing-closer reassignment, the backward walk's early `break`, and the mid-iteration `Map` delete, and caught one overclaimed comment: the windowed scan is *not* identical to a whole-value scan, because a tag straddling the window boundary is invisible to it. That is a miss and never a false reject — the direction every trade-off in the module leans — and the comment now says so.

Efficiency confirmed the rest is not worth changing: the regex is linear with no backtracking risk, the `includes('<')` fast path sits before `trimEnd()`, and the import skip already sits after the malformed and durable-namespace filters. Not taken: lifting the test-file fixture helpers into `_helpers/` — that is a refactor of an existing 800-line test file outside this diff.

## Verification

- Full suite **11,169 passed / 0 failed**; `tsc` and `eslint --max-warnings 0` clean.
- 33 new tests (16 pure-detector, 7 store-level, 3 surface, 7 team-artifact).
- `/verify` **PASS** on all four acceptance criteria, recorded as `verify:1467` at `e37f0ecdc`.
- Every pinning test mutation-checked: neutering the detector turns 8 red across three files; removing the export skip 2; removing the import skip 1; payload-gating the export skip 1.
- **AC3 carries the ticket's own suggested detector as its mutant.** Swapping in `/<\/(value|parameter)>|<parameter\s+name="/` turns 10 tests red — including every false-positive case, and the two corruption cases it also gets wrong.

Note on the suite runner: `npm test` exits 0 even when it reports failures, so the numbers above are read from the `Total failed:` summary line, not the exit status.
