### PR TITLE
fix(memory): stop the local HNSW path silently dropping search results (#1468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,32 @@ Code restart.
 The report this came from also flagged team-artifact first-write-wins as blocking corrections and
 deletions; that was #1463 and is already fixed. No action was needed.
 
+### Fixed — `npm test` no longer exits 0 on a run vitest failed
+
+The test-runner wrapper read vitest's JSON results and ignored its exit code. That is right for
+*test* failures — vitest exits non-zero when a worker fork dies of OOM even with everything green,
+which is why the exit code alone was never trusted — but the results file cannot express every way
+a run goes wrong. An unhandled rejection escaping a test makes vitest exit 1 and print the error
+while the JSON reports `numFailedTests: 0`, `numFailedTestSuites: 0` and `success: true`. The
+wrapper announced "✓ All tests passed" and exited 0, so CI went green on a failed run.
+
+Both signals now have to agree. A non-zero exit that names no failing test is reported as its own
+outcome — a runner fault, naming which pass and its exit code — and fails the run;
+`MOFLO_TEST_TOLERATE_RUNNER_EXIT=1` downgrades it to a warning for anyone genuinely chasing the OOM
+case. Failing by default is a deliberate policy change with owner sign-off: an OOM'd fork is a real
+problem and should be visible rather than silently green. A pass whose results file could not be
+read is a fault for the same reason even when vitest exited 0 — the wrapper verified nothing, and
+that case previously read as a clean run with zero tests passed. Alongside that: the failure count
+now matches the list printed under it (it summed
+`numFailedTests + numFailedTestSuites`, and vitest counts the file *and* each enclosing `describe`
+as suites, so one failing test read "Total failed: 3"); the results file is cleared before each run
+as well as after, so a run interrupted at the terminal cannot leave stale green results for a later
+crash to be judged against; and `main()` is no longer invoked bare, so a throw outside a test — a
+malformed `vitest.config.ts`, say — surfaces as the runner's own failure.
+
+Contributors only: `scripts/` is not in the published `files` list, so no consumer ships or runs
+this.
+
 ### Fixed — memory writes refuse captured tool-call markup
 
 A `memory_store` call whose `value` arrived carrying the harness' own parameter markup — the value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — the local HNSW path no longer silently drops search results
+
+Three defects in the approximate-nearest-neighbor path combined into non-deterministic recall
+(#1468). All three bite when the AgentDB bridge is unavailable, which is why they went unnoticed:
+`bridgeSearchHNSW` is a brute-force cosine scan that already carried the #1201 recency-cap fix, and
+`searchHNSWIndex` tries it first.
+
+- **The metadata map was capped at 10,000 rows with no `ORDER BY`.** `getHNSWIndex` populates the
+  map every hit is resolved through; which rows survived truncation was b-tree order under
+  `idx_memory_status` — arbitrary with respect to both recency and namespace. That is #1201
+  recurring in a sibling path: `entries-read.ts` and `memory-bridge.ts` were both fixed, the HNSW
+  loader was missed. It now uses the same recency-ordered `searchCandidateCap()`.
+- **A complete graph could be paired with a truncated map.** The binary sidecar is built over every
+  embedded row with no `LIMIT`, so past the cap a sidecar-loaded index held vectors with no metadata
+  row — and `searchHNSWIndex` skips a hit it cannot resolve. On a store measured at 13,825 vectors,
+  3,825 of them consumed graph space and ANN slots while being unreturnable, taking 28% of that
+  project's `learnings` out of reach of the fast path. The loader now drops any vector the metadata
+  load did not cover, so the two structures agree.
+- **One in-index hit suppressed the complete fallback.** `searchEntries` returned early on
+  `hnswResults.length > 0`, so a query that found a single ANN hit skipped the full brute-force
+  scan while a query that found none got correct and complete results — both reporting
+  `success: true` with no way to tell them apart. The fast path is now trusted only when it filled
+  the request; short of that the scan runs and the two result sets are merged by score.
+- **The namespace filter starved the ANN.** `searchHNSWIndex` retrieves `k * 2` neighbours from one
+  shared graph and filters by namespace *afterwards*, so a namespace holding a small share of the
+  store routinely lost every candidate to rows in other namespaces and answered empty — entries that
+  plainly exist. It now widens the retrieval to cover the graph when that happens, which is a cosine
+  pass over vectors already in memory rather than the SQL scan the shortfall would otherwise trigger.
+- **`deleteEntry` maintained no index.** The store path has always called `addToHNSWIndex`; the
+  delete path had no counterpart, and no removal function existed to call — though
+  `HnswLite.remove()` did. Because `entries` is an in-process map, the consequence was worse than an
+  orphaned vector: a deleted entry's metadata outlived its row and the local HNSW path kept
+  **returning deleted content** until the process restarted. `removeFromHNSWIndex(namespace, key)`
+  now runs on every successful delete, archived durable rows included.
+
+**Consumer impact.** Search recall improves and no state migration is needed, but the in-memory
+metadata map may now hold up to 25,000 rows where it previously held 10,000 — roughly 2.5× the
+per-process footprint for that map on a store large enough to reach the old cap. Stores below
+10,000 embedded rows are unaffected. `MOFLO_SEARCH_CANDIDATE_CAP` sets the bound for both this map
+and the brute-force scan, so a memory-constrained environment can lower it. Because the daemon and
+MCP server run from `node_modules/moflo/`, this takes effect after publish + reinstall + a Claude
+Code restart.
+
+The report this came from also flagged team-artifact first-write-wins as blocking corrections and
+deletions; that was #1463 and is already fixed. No action was needed.
+
 ### Fixed — memory writes refuse captured tool-call markup
 
 A `memory_store` call whose `value` arrived carrying the harness' own parameter markup — the value

--- a/scripts/test-runner-failures.mjs
+++ b/scripts/test-runner-failures.mjs
@@ -29,6 +29,59 @@ export function extractFailures(results) {
   return failures;
 }
 
+/**
+ * Decide whether a completed run is clean.
+ *
+ * Two independent signals have to agree, because neither one is sufficient:
+ *
+ * - **The JSON results** name which tests failed. This is the authority on
+ *   *test* failures, and the reason a bare exit code was never enough: vitest
+ *   exits non-zero when a worker fork dies (OOM), even with every test green.
+ * - **vitest's exit code**, which catches everything the results file cannot
+ *   express. An unhandled rejection escaping a test is the case that motivated
+ *   this (#1468 follow-up): vitest exits 1 and prints the error, while the JSON
+ *   reports `numFailedTests: 0`, `numFailedTestSuites: 0` and `success: true`.
+ *   Reading only the JSON, the wrapper announced "All tests passed" and exited
+ *   0 — so CI went green on a run vitest had already failed.
+ *
+ * Trusting only the JSON hides that class entirely; trusting only the exit code
+ * brings back the OOM false alarm. So a non-zero exit with no named failures is
+ * reported as its own outcome — a **runner fault** — rather than being either
+ * swallowed or mislabelled as a test failure. It fails the run, because a red
+ * signal is not background noise, and `MOFLO_TEST_TOLERATE_RUNNER_EXIT=1` is the
+ * documented way through for someone genuinely chasing the OOM case.
+ *
+ * A pass whose results file could not be read is a fault for the same reason,
+ * even when vitest exited 0: the wrapper verified nothing, and reporting success
+ * for a run it could not inspect is the very thing this function exists to stop.
+ *
+ * @param passes  One entry per vitest invocation:
+ *                `{ label, code, failures, verified }`. `verified: false` means
+ *                the results file was missing or unparseable.
+ * @param options `tolerateRunnerExit` downgrades a runner fault to a warning.
+ */
+export function classifyOutcome(passes, { tolerateRunnerExit = false } = {}) {
+  const list = Array.isArray(passes) ? passes : [];
+  const failures = list.flatMap((p) => p?.failures || []);
+  const faults = list
+    .filter((p) => p && (p.code !== 0 || p.verified === false))
+    .map((p) => ({
+      label: p.label || '(unnamed pass)',
+      code: p.code,
+      cause: p.verified === false ? 'results-unreadable' : 'nonzero-exit',
+    }));
+
+  // Named test failures outrank a fault: the operator needs the test list, and
+  // a failing test is itself the most likely reason for the non-zero exit.
+  if (failures.length > 0) return { ok: false, reason: 'test-failures', failures, faults };
+  if (faults.length > 0) {
+    return tolerateRunnerExit
+      ? { ok: true, reason: 'tolerated-runner-fault', failures, faults }
+      : { ok: false, reason: 'runner-fault', failures, faults };
+  }
+  return { ok: true, reason: 'clean', failures, faults };
+}
+
 export function printFailures(label, failures, log = console.log) {
   if (failures.length === 0) return;
   log(`\n  Failed in ${label}:`);

--- a/scripts/test-runner.mjs
+++ b/scripts/test-runner.mjs
@@ -7,8 +7,14 @@
  *    timeout under full-suite resource contention.
  * 3. Exits 0 only if both passes succeed.
  *
- * Vitest exits 1 when worker forks crash (OOM), even if every test
- * passes. The JSON output check distinguishes real failures from that.
+ * Vitest exits 1 when worker forks crash (OOM), even if every test passes, so
+ * the JSON results — not the exit code — are the authority on which tests
+ * failed. The exit code is still read, because the JSON cannot express every
+ * way a run goes wrong: an unhandled rejection escaping a test makes vitest
+ * exit 1 while the results file reports zero failures and `success: true`.
+ * Reading only the JSON, this wrapper printed "All tests passed" and exited 0
+ * on a run vitest had already failed. See `classifyOutcome` in
+ * ./test-runner-failures.mjs for the policy and the escape hatch.
  */
 
 import { spawn } from 'child_process';
@@ -16,7 +22,7 @@ import { readFileSync, unlinkSync, existsSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { loadIsolationTests } from './load-isolation-tests.mjs';
-import { extractFailures, printFailures } from './test-runner-failures.mjs';
+import { classifyOutcome, extractFailures, printFailures } from './test-runner-failures.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -25,10 +31,16 @@ const vitestBin = resolve(root, 'node_modules/vitest/vitest.mjs');
 const isolationConfig = resolve(root, 'vitest.isolation.config.ts');
 const env = { ...process.env, NODE_OPTIONS: '--max-old-space-size=8192' };
 
-/** Run vitest with given args, return { code, passed, failed, failures } */
-function runVitest(args, { config } = {}) {
+/** Run vitest with given args, return { label, code, passed, failed, failures } */
+function runVitest(label, args, { config } = {}) {
   const finalArgs = [vitestBin, ...args];
   if (config) finalArgs.push('--config', config);
+
+  // Clear the results file BEFORE the run, not only after. A previous run
+  // interrupted at the terminal never reaches its own cleanup, and a vitest
+  // that then dies before writing would leave this reading the last run's
+  // green results and calling the dead one clean.
+  cleanup();
 
   return new Promise((resolve) => {
     const child = spawn(process.execPath, finalArgs, {
@@ -41,20 +53,29 @@ function runVitest(args, { config } = {}) {
       let passed = 0;
       let failed = 0;
       let failures = [];
+      let verified = false;
 
       try {
         const raw = readFileSync(jsonFile, 'utf-8');
         const results = JSON.parse(raw);
-        failed = (results.numFailedTests || 0) + (results.numFailedTestSuites || 0);
-        passed = results.numPassedTests || 0;
         failures = extractFailures(results);
+        // Count the failures we can actually name, so the number and the list
+        // below it agree. `numFailedTests + numFailedTestSuites` did not:
+        // vitest counts the file AND each enclosing describe as suites, so one
+        // failing test reported "Total failed: 3".
+        failed = failures.length;
+        passed = results.numPassedTests || 0;
+        verified = true;
       } catch {
-        // JSON missing — treat non-zero exit as failure
+        // Results unreadable. `verified` stays false, which classifyOutcome
+        // treats as a fault on its own — a vitest that exits 0 without leaving
+        // results behind has told us nothing, and the old code called that a
+        // clean run with zero tests passed.
         if (code !== 0) failed = 1;
       }
 
       cleanup();
-      resolve({ code, passed, failed, failures });
+      resolve({ label, code, passed, failed, failures, verified });
     });
   });
 }
@@ -68,7 +89,7 @@ async function main() {
 
   // ── Pass 1: Main parallel suite ──
   console.log('\n━━ Pass 1: Parallel suite ━━\n');
-  const main = await runVitest([
+  const main = await runVitest('parallel suite', [
     'run',
     '--reporter=default',
     '--reporter=json',
@@ -78,6 +99,7 @@ async function main() {
   let totalPassed = main.passed;
   let totalFailed = main.failed;
   const allFailures = [...main.failures];
+  const passes = [main];
 
   if (main.failed > 0) {
     console.log(`\n✗ Parallel suite: ${main.failed} failure(s)`);
@@ -112,7 +134,7 @@ async function main() {
   } else if (presentIsolationTests.length > 0) {
     console.log(`\n━━ Pass 2: Isolation tests (${presentIsolationTests.length} files, single batch) ━━\n`);
 
-    const result = await runVitest([
+    const result = await runVitest('isolation batch', [
       'run',
       ...presentIsolationTests,
       '--reporter=default',
@@ -123,6 +145,7 @@ async function main() {
     totalPassed += result.passed;
     totalFailed += result.failed;
     allFailures.push(...result.failures);
+    passes.push(result);
 
     if (result.failed > 0) {
       console.log(`\n✗ Isolation batch: ${result.failed} failure(s)`);
@@ -133,18 +156,53 @@ async function main() {
   }
 
   // ── Summary ──
+  const tolerateRunnerExit = process.env.MOFLO_TEST_TOLERATE_RUNNER_EXIT === '1';
+  const outcome = classifyOutcome(passes, { tolerateRunnerExit });
+
   console.log('\n━━ Summary ━━');
   console.log(`  Total passed: ${totalPassed}`);
   console.log(`  Total failed: ${totalFailed}`);
 
-  if (totalFailed > 0) {
+  if (outcome.reason === 'test-failures') {
     printFailures('full run', allFailures);
     console.log('\n✗ Tests failed');
     process.exit(1);
   }
 
-  console.log('\n✓ All tests passed');
+  if (outcome.faults.length > 0) {
+    // No test is named, so say plainly what happened and where to look — the
+    // detail is in vitest's own output above, which the default reporter has
+    // already printed (commonly under "Unhandled Errors").
+    console.log('\n  A pass could not be confirmed clean:');
+    for (const fault of outcome.faults) {
+      console.log(
+        fault.cause === 'results-unreadable'
+          ? `    ✗ ${fault.label} — exit code ${fault.code}, and its results file was unreadable`
+          : `    ✗ ${fault.label} — exit code ${fault.code}`
+      );
+    }
+    console.log('  Scroll up for vitest\'s own output — an unhandled rejection,');
+    console.log('  a crashed worker, or a setup failure. Set');
+    console.log('  MOFLO_TEST_TOLERATE_RUNNER_EXIT=1 to downgrade this to a warning.');
+  }
+
+  if (!outcome.ok) {
+    console.log('\n✗ Test run failed');
+    process.exit(1);
+  }
+
+  console.log(
+    outcome.reason === 'tolerated-runner-fault'
+      ? '\n⚠ All tests passed, but vitest exited non-zero (tolerated)'
+      : '\n✓ All tests passed'
+  );
   process.exit(0);
 }
 
-main();
+main().catch((err) => {
+  // `main()` was previously called bare. Anything thrown outside a test — a
+  // malformed vitest.config.ts reaching loadIsolationTests, say — surfaced as
+  // an unhandled rejection rather than as this runner's own failure.
+  console.error('\n✗ Test runner crashed:', err?.stack || err);
+  process.exit(1);
+});

--- a/src/cli/__tests__/memory/hnsw-recall-1468.test.ts
+++ b/src/cli/__tests__/memory/hnsw-recall-1468.test.ts
@@ -1,0 +1,509 @@
+/**
+ * The local HNSW path stops silently dropping results (#1468).
+ *
+ * Three defects compounded into non-deterministic recall, and all three lived on
+ * the path taken when the AgentDB bridge is unavailable:
+ *
+ *   1. `getHNSWIndex` loaded the metadata map — the map `searchHNSWIndex`
+ *      resolves every hit through — under a bare `LIMIT 10000` with no
+ *      `ORDER BY`, so which rows survived was b-tree order. The sidecar is built
+ *      with no LIMIT at all, so a store past the cap paired a complete graph
+ *      with a truncated map and `searchHNSWIndex` skipped what it could not
+ *      resolve.
+ *   2. `searchEntries` returned early on `hnswResults.length > 0`, so ONE
+ *      in-index hit suppressed the complete brute-force scan while ZERO hits
+ *      produced correct and complete results.
+ *   3. `deleteEntry` maintained no index at all, so a deleted entry's metadata
+ *      outlived its row in an in-process map and kept being returned.
+ *
+ * The pins below are written so the pre-fix code fails each one: the cap is
+ * driven down via `MOFLO_SEARCH_CANDIDATE_CAP` (a literal `10000` keeps every
+ * seeded row and the size assertions go red), the fall-through is exercised with
+ * an ANN that returns exactly one hit, and the delete case asserts absence from
+ * the live map rather than from SQL.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { buildAndWriteHnswSidecar } from '../../memory/hnsw-persistence.js';
+import { openDaemonDatabase } from '../../memory/daemon-backend.js';
+import { MOFLO_DIR, MEMORY_DB_FILE } from '../../services/moflo-paths.js';
+
+const DIM = 8;
+
+/** Distinct, deterministic unit-ish vectors — enough for the graph to be built. */
+function vectorFor(seed: number): number[] {
+  return Array.from({ length: DIM }, (_, j) => Number(Math.sin(seed * 0.7 + j * 0.3).toFixed(6)));
+}
+
+/** A project root laid out the way `getHNSWIndex` expects: <root>/.moflo/memory.db. */
+function makeProject(): { root: string; dbPath: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-1468-'));
+  const dir = path.join(root, MOFLO_DIR);
+  fs.mkdirSync(dir, { recursive: true });
+  return { root, dbPath: path.join(dir, MEMORY_DB_FILE) };
+}
+
+/**
+ * Seed `count` active embedded rows. `created_at` ascends with the index, so
+ * row N-1 is the newest — which is what the recency assertions key on.
+ */
+function seed(dbPath: string, count: number, namespace = 'learnings'): void {
+  const db = openDaemonDatabase(dbPath);
+  try {
+    db.run(`CREATE TABLE IF NOT EXISTS memory_entries (
+      id TEXT PRIMARY KEY,
+      key TEXT,
+      namespace TEXT,
+      content TEXT,
+      metadata TEXT,
+      embedding TEXT,
+      created_at INTEGER,
+      updated_at INTEGER,
+      status TEXT
+    )`);
+    for (let i = 0; i < count; i++) {
+      db.run(
+        `INSERT INTO memory_entries
+           (id, key, namespace, content, metadata, embedding, created_at, updated_at, status)
+         VALUES (?, ?, ?, ?, NULL, ?, ?, ?, 'active')`,
+        [
+          `row-${String(i).padStart(3, '0')}`,
+          `key-${i}`,
+          namespace,
+          `content ${i}`,
+          JSON.stringify(vectorFor(i)),
+          1_700_000_000_000 + i * 1000,
+          1_700_000_000_000 + i * 1000,
+        ],
+      );
+    }
+  } finally {
+    db.close();
+  }
+}
+
+const ORIGINAL_CAP = process.env.MOFLO_SEARCH_CANDIDATE_CAP;
+const ORIGINAL_ROUTING = process.env.MOFLO_DISABLE_DAEMON_ROUTING;
+const roots: string[] = [];
+
+beforeEach(() => {
+  process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
+});
+
+afterEach(async () => {
+  bridgeStub = null;
+  if (ORIGINAL_CAP === undefined) delete process.env.MOFLO_SEARCH_CANDIDATE_CAP;
+  else process.env.MOFLO_SEARCH_CANDIDATE_CAP = ORIGINAL_CAP;
+  if (ORIGINAL_ROUTING === undefined) delete process.env.MOFLO_DISABLE_DAEMON_ROUTING;
+  else process.env.MOFLO_DISABLE_DAEMON_ROUTING = ORIGINAL_ROUTING;
+
+  const { clearHNSWIndex } = await import('../../memory/hnsw-singleton.js');
+  clearHNSWIndex();
+
+  while (roots.length) {
+    try {
+      fs.rmSync(roots.pop()!, { recursive: true, force: true });
+    } catch {
+      // Windows can hold a handle briefly; the tempdir is disposable either way.
+    }
+  }
+  vi.restoreAllMocks();
+});
+
+// The bridge short-circuits `searchHNSWIndex`, `searchEntries` and `deleteEntry`
+// before any of this code runs. It is absent in CI, but pinning it keeps a
+// developer machine with one installed from silently skipping every assertion.
+//
+// One hoisted mock reading a mutable stub, rather than a per-test `doMock`: a
+// `doMock` of this path survives into later tests in the same file, and the
+// tests that follow then hit a bridge that answers deletes but not searches.
+let bridgeStub: unknown = null;
+vi.mock('../../memory/bridge-loader.js', () => ({
+  getBridge: async () => bridgeStub,
+  isBridgeLoaded: () => bridgeStub !== null,
+}));
+
+describe('HNSW metadata load is capped by policy, not by a literal (#1468)', () => {
+  it('keeps the NEWEST rows when the cap truncates, not whichever the b-tree reached', async () => {
+    const { root, dbPath } = makeProject();
+    roots.push(root);
+    seed(dbPath, 6);
+
+    process.env.MOFLO_SEARCH_CANDIDATE_CAP = '3';
+    const { clearHNSWIndex, getHNSWIndex } = await import('../../memory/hnsw-singleton.js');
+    clearHNSWIndex();
+
+    const index = await getHNSWIndex({ dbPath, dimensions: DIM });
+    expect(index).not.toBeNull();
+
+    // The old loader had no ORDER BY and a literal 10000 — it kept all six, in
+    // insertion order. Both halves of this assertion were false before the fix.
+    expect(index!.entries.size).toBe(3);
+    expect([...index!.entries.values()].map(e => e.key).sort()).toEqual(['key-3', 'key-4', 'key-5']);
+  });
+
+  it('leaves no graph vector without a metadata row on the sidecar path', async () => {
+    const { root, dbPath } = makeProject();
+    roots.push(root);
+    seed(dbPath, 6);
+
+    // The sidecar is built over every embedded row — no LIMIT. This is the only
+    // configuration in which the graph and the map could ever disagree.
+    const built = await buildAndWriteHnswSidecar(dbPath, root, { dimensions: DIM });
+    expect(built.vectorCount).toBe(6);
+
+    process.env.MOFLO_SEARCH_CANDIDATE_CAP = '3';
+    const { clearHNSWIndex, getHNSWIndex } = await import('../../memory/hnsw-singleton.js');
+    clearHNSWIndex();
+
+    const index = await getHNSWIndex({ dbPath, dimensions: DIM });
+    expect(index).not.toBeNull();
+
+    // Pre-fix this was 6 vectors against a 10,000-row map that held all 6 — and
+    // at a realistic store size, 13,825 vectors against 10,000 rows, where the
+    // 3,825 remainder consumed ANN slots for hits that could never be returned.
+    expect(await index!.db.len()).toBe(index!.entries.size);
+    expect(await index!.db.len()).toBe(3);
+  });
+
+  it('caps graph and map together when no sidecar exists', async () => {
+    const { root, dbPath } = makeProject();
+    roots.push(root);
+    seed(dbPath, 6);
+
+    process.env.MOFLO_SEARCH_CANDIDATE_CAP = '4';
+    const { clearHNSWIndex, getHNSWIndex } = await import('../../memory/hnsw-singleton.js');
+    clearHNSWIndex();
+
+    // This path inserts each vector alongside its metadata row, so it was never
+    // capable of orphaning one. Pinned so the prune added for the sidecar path
+    // cannot quietly start removing vectors here.
+    const index = await getHNSWIndex({ dbPath, dimensions: DIM });
+    expect(await index!.db.len()).toBe(4);
+    expect(index!.entries.size).toBe(4);
+  });
+
+  it('does not empty the graph when the metadata load returns nothing', async () => {
+    const { root, dbPath } = makeProject();
+    roots.push(root);
+    seed(dbPath, 4);
+    await buildAndWriteHnswSidecar(dbPath, root, { dimensions: DIM });
+
+    // Archive every row: the loader's `status = 'active'` filter now matches
+    // none. An empty result is far more likely a read that went wrong than a
+    // store whose rows all vanished, so the prune declines to act on it —
+    // emptying the graph would be unrecoverable until the next rebuild.
+    const db = openDaemonDatabase(dbPath);
+    db.run(`UPDATE memory_entries SET status = 'archived'`);
+    db.close();
+
+    const { clearHNSWIndex, getHNSWIndex } = await import('../../memory/hnsw-singleton.js');
+    clearHNSWIndex();
+
+    const index = await getHNSWIndex({ dbPath, dimensions: DIM });
+    expect(index!.entries.size).toBe(0);
+    expect(await index!.db.len()).toBe(4);
+  });
+});
+
+describe('removeFromHNSWIndex keeps the in-process index in step (#1468)', () => {
+  it('is a no-op when this process holds no index', async () => {
+    const { clearHNSWIndex, removeFromHNSWIndex } = await import('../../memory/hnsw-singleton.js');
+    clearHNSWIndex();
+
+    // Must not throw, and must not force a load just to delete from it.
+    expect(removeFromHNSWIndex('learnings', 'key-0')).toBe(0);
+  });
+
+  it('drops the metadata row AND the graph vector', async () => {
+    const { root, dbPath } = makeProject();
+    roots.push(root);
+    seed(dbPath, 5);
+
+    const { clearHNSWIndex, getHNSWIndex, removeFromHNSWIndex } =
+      await import('../../memory/hnsw-singleton.js');
+    clearHNSWIndex();
+    const index = await getHNSWIndex({ dbPath, dimensions: DIM });
+    expect(index!.entries.size).toBe(5);
+
+    expect(removeFromHNSWIndex('learnings', 'key-2')).toBe(1);
+
+    expect([...index!.entries.values()].map(e => e.key)).not.toContain('key-2');
+    expect(index!.entries.size).toBe(4);
+    expect(await index!.db.len()).toBe(4);
+  });
+
+  it('only removes the entry in the named namespace', async () => {
+    const { root, dbPath } = makeProject();
+    roots.push(root);
+    seed(dbPath, 2, 'learnings');
+
+    const db = openDaemonDatabase(dbPath);
+    db.run(
+      `INSERT INTO memory_entries
+         (id, key, namespace, content, metadata, embedding, created_at, updated_at, status)
+       VALUES ('other', 'key-0', 'patterns', 'c', NULL, ?, ?, ?, 'active')`,
+      [JSON.stringify(vectorFor(9)), 1_700_000_000_000, 1_700_000_000_000],
+    );
+    db.close();
+
+    const { clearHNSWIndex, getHNSWIndex, removeFromHNSWIndex } =
+      await import('../../memory/hnsw-singleton.js');
+    clearHNSWIndex();
+    const index = await getHNSWIndex({ dbPath, dimensions: DIM });
+
+    // `key-0` exists in both namespaces; deleting one must not take the other.
+    expect(removeFromHNSWIndex('learnings', 'key-0')).toBe(1);
+    expect(index!.entries.get('other')?.namespace).toBe('patterns');
+  });
+
+  it('deleteEntry removes the entry when the bridge served the delete', async () => {
+    const { root, dbPath } = makeProject();
+    roots.push(root);
+    seed(dbPath, 3, 'patterns');
+
+    // The bridge returns before the direct-write path ever runs, so its branch
+    // needs its own coverage — a removal call added only to the direct path
+    // would leave every bridge-backed consumer exactly as broken as before.
+    // Reset first so `entries-write` and `hnsw-singleton` share one fresh module
+    // registry, and the singleton this test inspects is the one it mutates.
+    vi.resetModules();
+    bridgeStub = {
+      bridgeDeleteEntry: async (opts: { key: string; namespace?: string }) => ({
+        success: true,
+        deleted: true,
+        key: opts.key,
+        namespace: opts.namespace ?? 'default',
+        remainingEntries: 0,
+      }),
+    };
+
+    const { clearHNSWIndex, getHNSWIndex } = await import('../../memory/hnsw-singleton.js');
+    clearHNSWIndex();
+    const index = await getHNSWIndex({ dbPath, dimensions: DIM });
+    expect(index!.entries.size).toBe(3);
+
+    const { deleteEntry } = await import('../../memory/entries-write.js');
+    expect((await deleteEntry({ key: 'key-2', namespace: 'patterns', dbPath })).deleted).toBe(true);
+
+    expect([...index!.entries.values()].map(e => e.key)).not.toContain('key-2');
+    expect(await index!.db.len()).toBe(2);
+  });
+
+  it('leaves the index alone when the bridge reports nothing was deleted', async () => {
+    const { root, dbPath } = makeProject();
+    roots.push(root);
+    seed(dbPath, 3, 'patterns');
+
+    vi.resetModules();
+    bridgeStub = {
+      bridgeDeleteEntry: async (opts: { key: string; namespace?: string }) => ({
+        success: true,
+        deleted: false,
+        key: opts.key,
+        namespace: opts.namespace ?? 'default',
+        remainingEntries: 3,
+      }),
+    };
+
+    const { clearHNSWIndex, getHNSWIndex } = await import('../../memory/hnsw-singleton.js');
+    clearHNSWIndex();
+    const index = await getHNSWIndex({ dbPath, dimensions: DIM });
+
+    const { deleteEntry } = await import('../../memory/entries-write.js');
+    expect((await deleteEntry({ key: 'key-2', namespace: 'patterns', dbPath })).deleted).toBe(false);
+
+    // `deleted: false` means the row was already gone, not that this one should
+    // leave the index — the entry is still live and must stay searchable.
+    expect(index!.entries.size).toBe(3);
+    expect(await index!.db.len()).toBe(3);
+  });
+
+  it('deleteEntry removes the entry from a loaded index', async () => {
+    const { root, dbPath } = makeProject();
+    roots.push(root);
+    seed(dbPath, 3, 'patterns');
+
+    const { clearHNSWIndex, getHNSWIndex } = await import('../../memory/hnsw-singleton.js');
+    clearHNSWIndex();
+    const index = await getHNSWIndex({ dbPath, dimensions: DIM });
+    expect(index!.entries.size).toBe(3);
+
+    const { deleteEntry } = await import('../../memory/entries-write.js');
+    const result = await deleteEntry({ key: 'key-1', namespace: 'patterns', dbPath });
+    expect(result.deleted).toBe(true);
+
+    // The row is gone from SQL either way — what regressed was the in-process
+    // map, which kept serving the deleted entry until the process restarted.
+    expect([...index!.entries.values()].map(e => e.key)).not.toContain('key-1');
+    expect(await index!.db.len()).toBe(2);
+  });
+});
+
+describe('searchHNSWIndex widens when the namespace filter starves it (#1468)', () => {
+  /** `[1, 0…]` for the query and the crowd; `[0…, 1]` for the sparse namespace. */
+  function axis(last: boolean): number[] {
+    const v = new Array(DIM).fill(0);
+    v[last ? DIM - 1 : 0] = 1;
+    return v;
+  }
+
+  it('returns a sparse namespace the global top-k would have crowded out', async () => {
+    const { root, dbPath } = makeProject();
+    roots.push(root);
+
+    const db = openDaemonDatabase(dbPath);
+    db.run(`CREATE TABLE memory_entries (
+      id TEXT PRIMARY KEY, key TEXT, namespace TEXT, content TEXT,
+      metadata TEXT, embedding TEXT, created_at INTEGER, updated_at INTEGER, status TEXT
+    )`);
+    // 27 rows sitting on the query's own axis, 3 orthogonal to it. The graph is
+    // shared, so a `k * 2` retrieval is filled entirely by the crowd and the
+    // namespace filter then throws all of it away.
+    for (let i = 0; i < 30; i++) {
+      const sparse = i >= 27;
+      db.run(
+        `INSERT INTO memory_entries
+           (id, key, namespace, content, metadata, embedding, created_at, updated_at, status)
+         VALUES (?, ?, ?, ?, NULL, ?, ?, ?, 'active')`,
+        [
+          `row-${String(i).padStart(3, '0')}`,
+          `key-${i}`,
+          sparse ? 'learnings' : 'patterns',
+          `content ${i}`,
+          JSON.stringify(axis(sparse)),
+          1_700_000_000_000 + i * 1000,
+          1_700_000_000_000 + i * 1000,
+        ],
+      );
+    }
+    db.close();
+
+    const { clearHNSWIndex, getHNSWIndex, searchHNSWIndex } =
+      await import('../../memory/hnsw-singleton.js');
+    clearHNSWIndex();
+    const index = await getHNSWIndex({ dbPath, dimensions: DIM });
+    expect(await index!.db.len()).toBe(30);
+
+    const hits = await searchHNSWIndex(axis(false), { k: 5, namespace: 'learnings' });
+
+    // Pre-fix this came back empty, and `searchEntries` read that as "the index
+    // cannot serve this" — sending every query on that namespace to a SQL scan.
+    expect(hits!.map(h => h.key).sort()).toEqual(['key-27', 'key-28', 'key-29']);
+  });
+});
+
+describe('searchEntries falls through and merges instead of short-circuiting (#1468)', () => {
+  /** Load `searchEntries` with `searchHNSWIndex` stubbed to `hits`. */
+  async function searchWithAnn(
+    hits: Array<{ id: string; key: string; content: string; score: number; namespace: string }>,
+    dbPath: string,
+    limit = 5,
+  ) {
+    vi.resetModules();
+    bridgeStub = null;
+    vi.doMock('../../memory/hnsw-singleton.js', async () => {
+      const actual = await vi.importActual<typeof import('../../memory/hnsw-singleton.js')>(
+        '../../memory/hnsw-singleton.js',
+      );
+      return { ...actual, searchHNSWIndex: vi.fn(async () => hits) };
+    });
+    vi.doMock('../../memory/embedding-model.js', async () => {
+      const actual = await vi.importActual<typeof import('../../memory/embedding-model.js')>(
+        '../../memory/embedding-model.js',
+      );
+      return { ...actual, generateEmbedding: vi.fn(async () => ({ embedding: vectorFor(0) })) };
+    });
+    const { searchEntries } = await import('../../memory/entries-read.js');
+    return searchEntries({ query: 'q', namespace: 'learnings', limit, threshold: -1, dbPath });
+  }
+
+  it('a single ANN hit yields the same complete set as no ANN hit at all', async () => {
+    const { root, dbPath } = makeProject();
+    roots.push(root);
+    seed(dbPath, 5);
+
+    const one = await searchWithAnn(
+      [{ id: 'row-000', key: 'key-0', content: 'content 0', score: 0.9, namespace: 'learnings' }],
+      dbPath,
+    );
+    const none = await searchWithAnn([], dbPath);
+
+    // This is the whole defect: pre-fix, `one` returned a single result and
+    // `none` returned all five, with no way for the caller to tell which it got.
+    expect(one.results.map(r => r.key).sort()).toEqual(none.results.map(r => r.key).sort());
+    expect(one.results).toHaveLength(5);
+  });
+
+  it('does not double-count an id both paths returned', async () => {
+    const { root, dbPath } = makeProject();
+    roots.push(root);
+    seed(dbPath, 5);
+
+    const merged = await searchWithAnn(
+      [{ id: 'row-000', key: 'key-0', content: 'content 0', score: 0.99, namespace: 'learnings' }],
+      dbPath,
+    );
+
+    const ids = merged.results.map(r => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('keeps the higher score when the two paths disagree', async () => {
+    const { root, dbPath } = makeProject();
+    roots.push(root);
+    seed(dbPath, 5);
+
+    // The query embedding is `vectorFor(0)`, so the scan scores `row-001` well
+    // below 1 — leaving room for a higher ANN score on the same id to win.
+    const scanOnly = await searchWithAnn([], dbPath);
+    const scanScore = scanOnly.results.find(r => r.id === 'row-001')!.score;
+    expect(scanScore).toBeLessThan(1);
+
+    const merged = await searchWithAnn(
+      [{ id: 'row-001', key: 'key-1', content: 'content 1', score: 1, namespace: 'learnings' }],
+      dbPath,
+    );
+
+    expect(merged.results.find(r => r.id === 'row-001')?.score).toBe(1);
+  });
+
+  it('contributes an ANN hit the capped scan never saw', async () => {
+    const { root, dbPath } = makeProject();
+    roots.push(root);
+    seed(dbPath, 5);
+
+    // Cap the scan below the store size so the oldest row falls outside it, then
+    // hand that row back through the ANN. Discarding the ANN results on
+    // fall-through would trade the old non-determinism for a different gap.
+    process.env.MOFLO_SEARCH_CANDIDATE_CAP = '2';
+    const merged = await searchWithAnn(
+      [{ id: 'row-000', key: 'key-0', content: 'content 0', score: 0.7, namespace: 'learnings' }],
+      dbPath,
+    );
+
+    expect(merged.results.map(r => r.key)).toContain('key-0');
+  });
+
+  it('still short-circuits when the ANN filled the request', async () => {
+    const { root, dbPath } = makeProject();
+    roots.push(root);
+    seed(dbPath, 5);
+
+    const hits = [0, 1].map(i => ({
+      id: `ann-${i}`,
+      key: `ann-key-${i}`,
+      content: 'x',
+      score: 0.8,
+      namespace: 'learnings',
+    }));
+    const result = await searchWithAnn(hits, dbPath, 2);
+
+    // The fast path must survive the fix — a fall-through on every query would
+    // make the index pointless.
+    expect(result.results.map(r => r.key)).toEqual(['ann-key-0', 'ann-key-1']);
+  });
+});

--- a/src/cli/memory/entries-read.ts
+++ b/src/cli/memory/entries-read.ts
@@ -110,9 +110,32 @@ export async function searchEntries(options: {
     const queryEmb = await generateEmbedding(query);
     const queryEmbedding = queryEmb.embedding;
 
-    // Try HNSW search first (approximate-nearest-neighbor)
+    // Try HNSW search first (approximate-nearest-neighbor).
+    //
+    // #1468 — the short-circuit used to be `length > 0`, which made recall
+    // non-deterministic. Whenever the index could serve only part of the store —
+    // a truncated metadata map, or an index merely stale between rebuilds — a
+    // query that found ONE in-index hit suppressed the complete scan below,
+    // while a query that found zero got correct and complete results. Both
+    // shapes returned `success: true`, so the caller could not tell them apart.
+    //
+    // The ANN is now trusted only when it FILLED the request. Short of that we
+    // fall through and merge, so a partial fast path can add to the answer but
+    // never replace it. The test is on the raw count, before the threshold
+    // filter: what matters is whether the index could supply the candidates at
+    // all, not how similar they turned out to be.
+    //
+    // A namespace holding fewer than `limit` entries therefore falls through on
+    // every query, permanently. That is intended and its cost is proportionate:
+    // the scan below filters by the same namespace, so it parses that
+    // namespace's handful of embeddings, not the whole cap. The expensive scan
+    // is reserved for `all` and for namespaces large enough to fill the request
+    // in the first place — which do not reach it. `searchHNSWIndex` widens its
+    // retrieval before answering short (#1468), so a shortfall here means the
+    // entries genuinely are not in the index rather than that the namespace
+    // filter starved a global top-k.
     const hnswResults = await searchHNSWIndex(queryEmbedding, { k: limit, namespace });
-    if (hnswResults && hnswResults.length > 0) {
+    if (hnswResults && hnswResults.length >= limit) {
       // Filter by threshold
       const filtered = hnswResults.filter(r => r.score >= threshold);
       return {
@@ -178,6 +201,27 @@ export async function searchEntries(options: {
     }
 
     db.close();
+
+    // #1468 — merge the partial ANN hits in rather than discarding them. The
+    // scan is capped at `searchCandidateCap()` and the index is not, so each
+    // side can hold something the other misses; keeping only one of them would
+    // trade the old non-determinism for a different gap. Same id from both keeps
+    // the higher score — the scan's is exact, the ANN's approximate, and
+    // `Math.max` picks the exact one whenever they disagree in its favour.
+    if (hnswResults) {
+      const byId = new Map(results.map(r => [r.id, r]));
+      for (const hit of hnswResults) {
+        if (hit.score < threshold) continue;
+        const existing = byId.get(hit.id);
+        if (!existing) {
+          byId.set(hit.id, hit);
+        } else if (hit.score > existing.score) {
+          existing.score = hit.score;
+        }
+      }
+      results.length = 0;
+      results.push(...byId.values());
+    }
 
     // Sort by score
     results.sort((a, b) => b.score - a.score);

--- a/src/cli/memory/entries-write.ts
+++ b/src/cli/memory/entries-write.ts
@@ -18,7 +18,7 @@ import { findProjectRoot } from '../services/project-root.js';
 import { openDaemonDatabase } from './daemon-backend.js';
 import { ensureSchemaColumns } from './schema.js';
 import { generateEmbedding } from './embedding-model.js';
-import { addToHNSWIndex } from './hnsw-singleton.js';
+import { addToHNSWIndex, removeFromHNSWIndex } from './hnsw-singleton.js';
 import { getBridge } from './bridge-loader.js';
 import { tryDaemonStore, tryDaemonDelete } from './daemon-write-client.js';
 import { EMBEDDING_MODEL_OPT_OUT, getBridgeEmbedder, isEphemeralNamespace } from './bridge-embedder.js';
@@ -429,6 +429,15 @@ export async function deleteEntry(options: {
         key: options.key,
       });
       if (routed.routed && routed.ok) {
+        // #1468 — the row left the daemon's DB; drop it from any index THIS
+        // process holds too. Usually nothing (a CLI invocation loads no index
+        // before routing), but a long-lived client that routes its writes and
+        // still searches locally would otherwise keep serving the deleted entry.
+        // Gated on `deleted` for the same reason the bridge branch below is: a
+        // daemon can report success for a key that was already gone.
+        if (routed.deleted ?? true) {
+          removeFromHNSWIndex(options.namespace ?? 'default', options.key);
+        }
         return {
           success: true,
           deleted: routed.deleted ?? true,
@@ -460,7 +469,13 @@ export async function deleteEntry(options: {
   const bridge = await getBridge();
   if (bridge) {
     const bridgeResult = await bridge.bridgeDeleteEntry(options);
-    if (bridgeResult) return bridgeResult;
+    if (bridgeResult) {
+      // #1468 — see the note on the direct path below.
+      if (bridgeResult.deleted) {
+        removeFromHNSWIndex(options.namespace ?? 'default', options.key);
+      }
+      return bridgeResult;
+    }
   }
 
   // Fallback: direct node:sqlite write via the unified factory.
@@ -541,6 +556,14 @@ export async function deleteEntry(options: {
 
     // WAL persisted the DELETE incrementally — no whole-file dump needed.
     db.close();
+
+    // #1468 — keep the in-process index in step with the row. The store path
+    // has always called `addToHNSWIndex`; the delete path called nothing, so a
+    // deleted entry's metadata outlived it in `hnswIndex.entries` and the local
+    // HNSW path kept returning it until the process restarted. Archived rows
+    // count: the index loads `status = 'active'`, so an archived entry has to
+    // leave it exactly as a hard-deleted one does.
+    removeFromHNSWIndex(namespace, key);
 
     return {
       success: true,

--- a/src/cli/memory/hnsw-singleton.ts
+++ b/src/cli/memory/hnsw-singleton.ts
@@ -21,6 +21,7 @@ import { parseEmbeddingJson } from './controllers/_shared.js';
 import { memoryDbPath } from '../services/moflo-paths.js';
 import { openDaemonDatabase } from './daemon-backend.js';
 import { getBridge, isBridgeLoaded } from './bridge-loader.js';
+import { searchCandidateCap } from './bridge-core.js';
 import { resolveStateRoot } from '../services/project-root.js';
 
 interface HNSWEntry {
@@ -94,6 +95,7 @@ export async function getHNSWIndex(options?: {
         return hnsw.search(query.vector, query.k);
       },
       len: async () => hnsw.size,
+      remove: (id: string) => hnsw.remove(id),
     };
 
     const entries = new Map<string, HNSWEntry>();
@@ -118,11 +120,17 @@ export async function getHNSWIndex(options?: {
         const sqlDb = openDaemonDatabase(dbPath);
 
         const cols = sidecarLoaded ? SELECT_METADATA_ONLY : SELECT_WITH_EMBEDDING;
+        // #1468 — recency-ordered candidate cap, the same one `entries-read.ts`
+        // and `memory-bridge.ts` already use. This load was a bare `LIMIT 10000`,
+        // so which rows survived was b-tree order under `idx_memory_status` —
+        // arbitrary with respect to both recency and namespace. That is #1201
+        // recurring here; the sibling paths got the fix and this loader did not.
         const result = sqlDb.exec(`
           SELECT ${cols}
           FROM memory_entries
           WHERE status = 'active' AND embedding IS NOT NULL
-          LIMIT 10000
+          ORDER BY created_at DESC
+          LIMIT ${searchCandidateCap()}
         `);
 
         let parseSkipped = 0;
@@ -154,6 +162,35 @@ export async function getHNSWIndex(options?: {
         }
         if (parseSkipped > 0) {
           console.warn(`[memory-initializer] skipped ${parseSkipped} rows with malformed embeddings`);
+        }
+
+        // #1468 — drop graph vectors the metadata load did not cover, so the two
+        // structures agree.
+        //
+        // Only the sidecar path can disagree. When the sidecar is absent the loop
+        // above inserts each vector alongside its metadata row, so the cap bounds
+        // both together. `hnsw-persistence` builds the sidecar over every embedded
+        // row with no LIMIT, so a store past the cap pairs a complete graph with a
+        // truncated map — and `searchHNSWIndex` silently skips a hit it cannot
+        // resolve (`if (!entry) continue`). Those vectors are unreachable by
+        // construction: they consume graph space and ANN slots that would
+        // otherwise hold a result the caller can actually receive. Rows past the
+        // cap stay reachable through the complete brute-force scan in
+        // `entries-read.ts`, which now runs whenever the ANN under-fills.
+        //
+        // Guarded on a non-empty map, which covers the SELECT that succeeds and
+        // returns nothing: far more likely a read that went wrong than a store
+        // whose rows all vanished, and emptying the graph on that reading is
+        // unrecoverable until the next rebuild. A read that *throws* needs no
+        // guard — it exits to the catch below and never reaches here, leaving the
+        // graph exactly as the sidecar supplied it. Both ways out leave a stale
+        // graph rather than an empty one, which is the cheaper mistake.
+        if (sidecarLoaded && hnswIndex.entries.size > 0) {
+          const orphaned: string[] = [];
+          for (const id of hnsw.ids()) {
+            if (!hnswIndex.entries.has(id)) orphaned.push(id);
+          }
+          for (const id of orphaned) hnsw.remove(id);
         }
 
         sqlDb.close();
@@ -207,6 +244,48 @@ export async function addToHNSWIndex(
 }
 
 /**
+ * Remove an entry from the in-process HNSW index — graph vector and metadata
+ * row both (#1468).
+ *
+ * `deleteEntry` used to delete the row and stop there. The store path maintains
+ * the index (`addToHNSWIndex`); the delete path had no counterpart and there was
+ * no removal function to call, even though `HnswLite.remove` has always existed.
+ * `entries` is an in-process map rebuilt from SQL, so the consequence was not
+ * merely an orphaned vector: the deleted entry's metadata outlived the row and
+ * the local HNSW path could keep **returning deleted content** until the process
+ * restarted. A curation pass had no way to see that.
+ *
+ * Addressed by (namespace, key) rather than id because that is what every caller
+ * of `deleteEntry` has. The scan is linear, which is fine — deletes are rare and
+ * searches are not, so the cost belongs here rather than in a second index.
+ *
+ * Never forces a load. When this process holds no initialized index there is
+ * nothing stale to correct, and the next load reads a DB the row is already gone
+ * from. Returns the number of entries removed.
+ */
+export function removeFromHNSWIndex(namespace: string, key: string): number {
+  const index = hnswIndex;
+  if (!index?.initialized) return 0;
+
+  const ids: string[] = [];
+  for (const [id, entry] of index.entries) {
+    if (entry.key === key && entry.namespace === namespace) ids.push(id);
+  }
+
+  for (const id of ids) {
+    index.entries.delete(id);
+    try {
+      index.db.remove?.(id);
+    } catch {
+      // A graph that refuses the removal leaves an unreachable vector, which is
+      // the pre-#1468 state and strictly better than the metadata row surviving.
+    }
+  }
+
+  return ids.length;
+}
+
+/**
  * Search HNSW index (approximate-nearest-neighbor; scales sub-linearly vs. brute-force)
  * Returns results sorted by similarity (highest first)
  */
@@ -227,15 +306,13 @@ export async function searchHNSWIndex(
   const index = await getHNSWIndex({ dimensions: queryEmbedding.length });
   if (!index) return null;
 
-  try {
-    const vector = new Float32Array(queryEmbedding);
-    const k = options?.k ?? 10;
+  const k = options?.k ?? 10;
 
-    // HNSW search returns results with cosine distance (lower = more similar)
-    const results = await index.db.search({ vector, k: k * 2 }); // Get extra for filtering
+  type Hit = { id: string; key: string; content: string; score: number; namespace: string; metadata?: string };
 
-    const filtered: Array<{ id: string; key: string; content: string; score: number; namespace: string; metadata?: string }> = [];
-
+  /** Resolve raw graph hits through the metadata map, applying the namespace filter. */
+  const collect = (results: Array<{ id: string; score: number }>): Hit[] => {
+    const hits: Hit[] = [];
     for (const result of results) {
       const entry = index.entries.get(result.id);
       if (!entry) continue;
@@ -249,7 +326,7 @@ export async function searchHNSWIndex(
       // Cosine distance: 0 = identical, 2 = opposite
       const score = 1 - (result.score / 2);
 
-      filtered.push({
+      hits.push({
         id: entry.id.substring(0, 12),
         key: entry.key || entry.id.substring(0, 15),
         content: entry.content.substring(0, 60) + (entry.content.length > 60 ? '...' : ''),
@@ -258,7 +335,36 @@ export async function searchHNSWIndex(
         metadata: entry.metadata
       });
 
-      if (filtered.length >= k) break;
+      if (hits.length >= k) break;
+    }
+    return hits;
+  };
+
+  try {
+    const vector = new Float32Array(queryEmbedding);
+
+    // HNSW search returns results with cosine distance (lower = more similar)
+    let filtered = collect(await index.db.search({ vector, k: k * 2 })); // Get extra for filtering
+
+    // #1468 — widen once when a namespace filter starved the result.
+    //
+    // The graph is one shared structure and the namespace filter runs AFTER
+    // retrieval, so a namespace holding a small share of the store routinely
+    // loses most of its `k * 2` candidates to rows in other namespaces and comes
+    // back short. That shortfall is not a signal about the store — those entries
+    // exist and a full scan would find them — and `searchEntries` reads a short
+    // result as "the index could not serve this", which would send every
+    // namespaced query on to a SQL scan that JSON.parses thousands of embeddings.
+    //
+    // `HnswLite.search` brute-forces whenever `k * 2` reaches the graph size, so
+    // passing the size guarantees complete coverage. It is a cosine pass over
+    // Float32Arrays already resident in memory — far cheaper than the SQL
+    // fallback it replaces. Skipped when the first search already covered the
+    // whole graph, since a second identical pass would add nothing.
+    const graphSize: number = await index.db.len();
+    const namespaced = Boolean(options?.namespace && options.namespace !== 'all');
+    if (namespaced && filtered.length < k && graphSize > k * 2) {
+      filtered = collect(await index.db.search({ vector, k: graphSize }));
     }
 
     // Sort by score descending (highest similarity first)

--- a/tests/bin/test-runner-failures.test.ts
+++ b/tests/bin/test-runner-failures.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { extractFailures, printFailures } from '../../scripts/test-runner-failures.mjs';
+import { classifyOutcome, extractFailures, printFailures } from '../../scripts/test-runner-failures.mjs';
 
 describe('extractFailures', () => {
   it('returns [] for an empty / clean run', () => {
@@ -128,5 +128,123 @@ describe('printFailures', () => {
     expect(calls.join('\n')).toContain('foo > b');
     expect(calls.join('\n')).toContain('/abs/bar.test.ts');
     expect(calls.join('\n')).toContain('bar > x');
+  });
+});
+
+/**
+ * `npm test` announced "All tests passed" and exited 0 on a run vitest had
+ * already failed (#1468 follow-up).
+ *
+ * The wrapper read only the JSON results, which is correct for *test* failures
+ * — vitest exits non-zero on an OOM'd worker fork with everything green, which
+ * is why the exit code alone was never trusted. But the JSON cannot express an
+ * unhandled rejection escaping a test: vitest exits 1 and prints the error while
+ * the results report `numFailedTests: 0`, `numFailedTestSuites: 0` and
+ * `success: true`. Verified against real vitest output before this was written.
+ *
+ * Both signals now have to agree. The shapes below are the four the runner can
+ * actually see; the third is the one that used to pass.
+ */
+describe('classifyOutcome', () => {
+  const failure = { file: '/abs/a.test.ts', name: 'a > fails' };
+
+  it('is clean when every pass exited 0 with no failures', () => {
+    const outcome = classifyOutcome([
+      { label: 'parallel suite', code: 0, failures: [], verified: true },
+      { label: 'isolation batch', code: 0, failures: [], verified: true },
+    ]);
+
+    expect(outcome.ok).toBe(true);
+    expect(outcome.reason).toBe('clean');
+    expect(outcome.faults).toEqual([]);
+  });
+
+  it('reports named test failures as test-failures', () => {
+    const outcome = classifyOutcome([{ label: 'parallel suite', code: 1, failures: [failure] }]);
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.reason).toBe('test-failures');
+    expect(outcome.failures).toEqual([failure]);
+  });
+
+  it('fails a non-zero exit that named no failing test', () => {
+    // The regression. An unhandled rejection lands here: exit 1, zero failures.
+    const outcome = classifyOutcome([{ label: 'parallel suite', code: 1, failures: [] }]);
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.reason).toBe('runner-fault');
+    expect(outcome.faults).toEqual([{ label: 'parallel suite', code: 1, cause: 'nonzero-exit' }]);
+  });
+
+  it('faults a pass whose results file was unreadable, even on a zero exit', () => {
+    // vitest exited 0 but left no results to inspect. The wrapper verified
+    // nothing, and used to call that a clean run with zero tests passed.
+    const outcome = classifyOutcome([
+      { label: 'parallel suite', code: 0, failures: [], verified: false },
+    ]);
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.reason).toBe('runner-fault');
+    expect(outcome.faults).toEqual([
+      { label: 'parallel suite', code: 0, cause: 'results-unreadable' },
+    ]);
+  });
+
+  it('does not fault a pass that read its results cleanly', () => {
+    const outcome = classifyOutcome([
+      { label: 'parallel suite', code: 0, failures: [], verified: true },
+    ]);
+
+    expect(outcome.ok).toBe(true);
+    expect(outcome.reason).toBe('clean');
+  });
+
+  it('names the pass that faulted, not just that one did', () => {
+    const outcome = classifyOutcome([
+      { label: 'parallel suite', code: 0, failures: [] },
+      { label: 'isolation batch', code: 1, failures: [] },
+    ]);
+
+    expect(outcome.faults).toEqual([{ label: 'isolation batch', code: 1, cause: 'nonzero-exit' }]);
+  });
+
+  it('downgrades a fault to a pass under MOFLO_TEST_TOLERATE_RUNNER_EXIT', () => {
+    const outcome = classifyOutcome([{ label: 'parallel suite', code: 1, failures: [] }], {
+      tolerateRunnerExit: true,
+    });
+
+    // Still reported, still visible — the escape hatch exists for the OOM case
+    // the exit code cannot be told apart from, not to make the signal vanish.
+    expect(outcome.ok).toBe(true);
+    expect(outcome.reason).toBe('tolerated-runner-fault');
+    expect(outcome.faults).toEqual([{ label: 'parallel suite', code: 1, cause: 'nonzero-exit' }]);
+  });
+
+  it('never lets the escape hatch suppress a real test failure', () => {
+    const outcome = classifyOutcome([{ label: 'parallel suite', code: 1, failures: [failure] }], {
+      tolerateRunnerExit: true,
+    });
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.reason).toBe('test-failures');
+  });
+
+  it('prefers the test list when a pass both failed tests and exited non-zero', () => {
+    const outcome = classifyOutcome([
+      { label: 'parallel suite', code: 1, failures: [failure] },
+      { label: 'isolation batch', code: 1, failures: [] },
+    ]);
+
+    // The operator needs the named test first; the fault is still carried so the
+    // runner can print it, but it must not displace the failure list.
+    expect(outcome.reason).toBe('test-failures');
+    expect(outcome.failures).toEqual([failure]);
+    expect(outcome.faults).toHaveLength(2);
+  });
+
+  it('tolerates a malformed pass list rather than throwing mid-summary', () => {
+    expect(classifyOutcome([]).ok).toBe(true);
+    expect(classifyOutcome(undefined as never).ok).toBe(true);
+    expect(classifyOutcome([null as never, { label: 'x', code: 0 }]).ok).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #1468.

## What this fixes

Five defects in the local approximate-nearest-neighbor path combined into
non-deterministic search recall. All of them bite when the AgentDB bridge is
unavailable, which is why they went unnoticed: `bridgeSearchHNSW` is a
brute-force cosine scan that already carried the #1201 recency-cap fix, and
`searchHNSWIndex` tries it first.

**The metadata map was capped at 10,000 with no `ORDER BY`.** `getHNSWIndex`
populates the map every hit is resolved through; which rows survived truncation
was b-tree order under `idx_memory_status` — arbitrary with respect to both
recency and namespace. This is #1201 recurring in a sibling path: `entries-read.ts`
and `memory-bridge.ts` were both fixed, and the HNSW loader was missed. It now
uses the same `searchCandidateCap()`.

**A complete graph could be paired with a truncated map.** The binary sidecar is
built over every embedded row with no `LIMIT`, so past the cap a sidecar-loaded
index held vectors with no metadata row — and `searchHNSWIndex` skips a hit it
cannot resolve (`if (!entry) continue`). On the store this was reported from,
3,825 of 13,825 vectors consumed graph space and ANN slots while being
unreturnable, taking 28% of that project's `learnings` out of the fast path's
reach. The loader now drops vectors the metadata load did not cover.

**One in-index hit suppressed the complete fallback.** `searchEntries` returned
early on `hnswResults.length > 0`, so a query finding a single ANN hit skipped
the full scan while a query finding none got correct and complete results — both
reporting `success: true` with no way to tell them apart. The fast path is now
trusted only when it filled the request; short of that the scan runs and the two
result sets merge by score.

**The namespace filter starved the ANN.** `searchHNSWIndex` retrieves `k * 2`
neighbours from one shared graph and filters by namespace *afterwards*, so a
namespace holding a small share of the store routinely lost every candidate to
other namespaces and answered empty. Left alone this would have turned the fix
above into a permanent SQL scan for those namespaces. It now widens retrieval to
cover the graph in that case — a cosine pass over resident `Float32Array`s, far
cheaper than the scan it avoids.

**`deleteEntry` maintained no index.** The store path has always called
`addToHNSWIndex`; the delete path had no counterpart and no removal function to
call, though `HnswLite.remove()` existed. Because `entries` is an in-process map,
the consequence was worse than an orphaned vector: a deleted entry's metadata
outlived its row and the local path kept **returning deleted content** until the
process restarted. `removeFromHNSWIndex(namespace, key)` now runs on every
successful delete — direct-write, bridge-served, and archived durable rows.

## Corrections to the original report

The ticket arrived as a generalized four-part amalgam from a consumer project.
Two of its stated mechanisms were wrong in ways that changed the fix:

- **The orphaning is sidecar-specific.** Without a sidecar, vectors are inserted
  inside the same capped loop — graph and map stop together and nothing is
  orphaned. Only the sidecar path pairs a complete graph with a capped map. The
  prune is therefore gated on `sidecarLoaded`, and a regression test pins that
  the non-sidecar path is left alone.
- **`bridgeSearchHNSW` is not HNSW.** It is a brute-force cosine scan tried
  *before* the local index, which is why the reporter's excluded keys still came
  back at rank 7. That reframes all of this as bridge-unavailable-path work.

**The report's fourth item is already fixed and is not in this PR.**
Team-artifact first-write-wins blocking corrections and deletions was #1463,
fixed in `d309e2c74`; `team-artifact-sync.ts` now runs last-writer-wins
`planReconcile` in both directions with tombstones. Verified against `main`
before dropping it from scope.

## Consumer impact (Rule #2)

- **Surface touched:** `src/cli/memory/` — the search path every `memory_search`
  goes through in every consumer session.
- **Failure mode on upgrade:** none. Recall improves, no `.moflo/` state changes,
  no migration, hooks unaffected. The one behavioural cost is memory: the
  in-process metadata map may hold up to 25,000 rows where it held 10,000 —
  roughly 2.5x that map's footprint on a store large enough to have reached the
  old cap. Stores under 10,000 embedded rows are unaffected.
  `MOFLO_SEARCH_CANDIDATE_CAP` bounds both this map and the brute-force scan, so
  a memory-constrained environment can lower it.
- **Round-trip cost:** publish + reinstall + Claude Code restart. The daemon and
  MCP server run from `node_modules/moflo/`, so this does nothing for moflo's own
  searches until then.

## Cross-platform (Rule #1)

Pure TypeScript, SQL and in-memory data structures — no paths constructed, no
shell-outs, no process introspection, no EOL-sensitive output. The tests build
their project roots with `path.join` under `os.tmpdir()` and tolerate a Windows
handle still being held at cleanup.

## Testing

16 new tests in `src/cli/__tests__/memory/hnsw-recall-1468.test.ts`, **each
mutation-checked against the pre-fix code** — reverting the cap, the prune, the
removal, the fall-through, the widen, or the bridge-branch call each turns the
corresponding pins red.

Full suite **11,185 passed / 0 failed**. `tsc --noEmit` clean.
`eslint --max-warnings 0` clean.

`/flo-simplify` ran at NORMAL (three sonnet reviewers). Findings applied: the
daemon-routed delete now honours `routed.deleted` to match the bridge branch's
contract; the namespace-starvation widen was added after a reviewer showed the
fall-through would otherwise force a full SQL scan on every sparse-namespace
query; and two comments that overclaimed what their guards cover were corrected.

`/verify` PASS on all five acceptance criteria — recorded as `verify:1468`.

---

## Also in this PR — `npm test` exited 0 on a run vitest failed

Folded in at the owner's request. Different subsystem, same defect class: a component reporting
success for work that did not succeed.

`scripts/test-runner.mjs` read vitest's JSON results and ignored its exit code. That is right for
*test* failures — vitest exits non-zero when a worker fork dies of OOM even with everything green,
which is why the exit code alone was never trusted — but the results file cannot express every way
a run goes wrong. **Reproduced before changing anything:** a test that leaves an unhandled rejection
behind makes vitest exit 1 and print the error, while the JSON reports `numFailedTests: 0`,
`numFailedTestSuites: 0` and `success: true`. The wrapper printed "✓ All tests passed" and exited 0.

**Three suspected paths are not broken** — probed and confirmed: an ordinary failing test, a
collection/import error, and a failure in the isolation pass all exit 1 correctly. The defect was
narrower than the symptom suggested.

Both signals now have to agree, via a new pure `classifyOutcome`. Named test failures stay the
authority; a non-zero exit naming no failing test becomes its own outcome — a **runner fault**,
reported with the pass and its exit code — and fails the run; a pass whose results file could not be
read faults for the same reason even on a zero exit, because the wrapper verified nothing.

**Policy change, with explicit owner sign-off.** An OOM'd fork and an escaped rejection are
indistinguishable from the exit code, so tolerating one means hiding the other. Failing by default
was chosen deliberately: an OOM in CI is a real problem and belongs in the open, not silently green.
`MOFLO_TEST_TOLERATE_RUNNER_EXIT=1` is the documented way through and can never suppress a named
test failure. Reviewers: this is the intended behaviour change, not an oversight.

**Three adjacent defects fixed here rather than filed** (per `moflo-inline-fixes.md`): the failure
count summed `numFailedTests + numFailedTestSuites` and vitest counts the file *and* each enclosing
`describe` as suites, so one failing test nested two describes deep read "Total failed: 4" above a
list naming one; the results file was cleared only *after* a run, so a run interrupted at the
terminal left stale green results for a later crash to be judged against; and `main()` was invoked
bare, so a throw outside a test surfaced as an unhandled rejection rather than the runner's own
failure.

Not consumer surface — `scripts/` is absent from `package.json` `files` apart from three install
scripts. It is, however, the gate every PR's green check runs through.

10 new tests, mutation-checked, plus all four end-to-end shapes verified against real vitest output
at the final commit: unhandled rejection exits 1 naming the pass, the escape hatch exits 0 with a
warning, an ordinary failure reports "Total failed: 1", a clean run is unchanged.

Combined suite **11,195 passed / 0 failed**. `/verify` PASS on all nine acceptance criteria.