### PR TITLE
feat(memory): dead-path nomination bucket for audit-learnings (#1479)

### DIFF
--- a/src/cli/__tests__/commands/memory-audit-learnings.test.ts
+++ b/src/cli/__tests__/commands/memory-audit-learnings.test.ts
@@ -515,4 +515,60 @@ describe('flo memory audit-learnings (#1466)', () => {
     expect((result.data as { archived: number }).archived).toBe(0);
     expect(statusOf('stale-retire')).toBe('active');
   });
+
+  it('nominates entries citing paths that no longer resolve, and names them (#1479)', async () => {
+    // A real tree under the project root — the point of this case over the pure
+    // ones is that resolution goes through the filesystem, separator and all.
+    fs.mkdirSync(path.join(tmp, 'src', 'cli'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'src', 'cli', 'output.ts'), '', 'utf-8');
+    fs.mkdirSync(path.join(tmp, 'packages', 'api', 'src', 'routes'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'packages', 'api', 'src', 'routes', 'foo.ts'), '', 'utf-8');
+    fs.writeFileSync(
+      path.join(tmp, 'package.json'),
+      JSON.stringify({ name: 'fixture', workspaces: ['packages/*'] }),
+      'utf-8',
+    );
+
+    seed([
+      { key: 'live-keep', content: 'the writer is src/cli/output.ts', accessCount: 5, updatedAt: now },
+      // Authored from inside the workspace: correct as written, must NOT flag.
+      { key: 'workspace-keep', content: 'the handler is src/routes/foo.ts', accessCount: 5, updatedAt: now },
+      { key: 'dead-keep', content: 'the writer was src/cli/removed.ts', accessCount: 5, updatedAt: now },
+    ]);
+
+    const result = await auditLearningsCommand.action(ctx());
+    const printed = written.join('\n');
+    const data = result.data as {
+      counts: { deadPath: number };
+      deadPaths: Array<{ key: string; paths: string[] }>;
+    };
+
+    expect(printed).toContain('Dead path reference');
+    expect(data.counts.deadPath).toBe(1);
+    expect(data.deadPaths).toEqual([{ key: 'dead-keep', paths: ['src/cli/removed.ts'] }]);
+
+    // The report names the path, because a reader cannot tell a moved file from
+    // a deleted one without seeing it.
+    const log = JSON.parse(fs.readFileSync(judgeLog, 'utf-8')) as { keys: string[]; promptLength: number };
+    expect(log.keys).toEqual(['dead-keep']);
+
+    fs.rmSync(path.join(tmp, 'package.json'), { force: true });
+    fs.rmSync(path.join(tmp, 'packages'), { recursive: true, force: true });
+  });
+
+  it('--no-dead-paths skips the pass and says so, so a 0 is never mistaken for a clean tree', async () => {
+    const parser = new CommandParser();
+    parser.registerCommand(auditLearningsCommand);
+    const parsed = parser.parse(['audit-learnings', '--no-dead-paths', '--no-judge']);
+
+    expect(parsed.flags.deadPaths).toBe(false);
+    seed([{ key: 'dead-keep', content: 'the writer was src/cli/removed.ts', accessCount: 5, updatedAt: now }]);
+
+    const result = await auditLearningsCommand.action({ ...ctx(), flags: parsed.flags });
+    const data = result.data as { counts: { deadPath: number }; deadPathsScanned: boolean };
+
+    expect(data.counts.deadPath).toBe(0);
+    expect(data.deadPathsScanned).toBe(false);
+    expect(written.join('\n')).toContain('dead-path resolution skipped');
+  });
 });

--- a/src/cli/__tests__/memory/learnings-audit.test.ts
+++ b/src/cli/__tests__/memory/learnings-audit.test.ts
@@ -387,3 +387,94 @@ describe('selectArchivable', () => {
     expect(selectArchivable(plan.candidates, new Map())).toEqual([]);
   });
 });
+
+describe('buildAuditPlan — dead-path bucket (#1479)', () => {
+  const resolves = (known: string[]) => (p: string) => known.includes(p);
+
+  it('nominates a citing entry and carries the unresolved paths as evidence', () => {
+    const rows = [
+      row({ key: 'cites-live', content: 'the check is in src/cli/output.ts' }),
+      row({ key: 'cites-dead', content: 'the check was in src/cli/removed.ts' }),
+    ];
+
+    const plan = buildAuditPlan(rows, {
+      now: NOW,
+      deadPaths: { resolves: resolves(['src/cli/output.ts']) },
+    });
+
+    expect(plan.counts.deadPath).toBe(1);
+    expect(plan.candidates.map((c) => c.key)).toEqual(['cites-dead']);
+    expect(plan.candidates[0].buckets).toEqual(['dead-path']);
+    expect(plan.candidates[0].deadPaths).toEqual(['src/cli/removed.ts']);
+  });
+
+  it('does not run the pass at all when no resolver is supplied', () => {
+    // A caller with no tree to resolve against — a unit test, a store audited
+    // away from its repo — must get no nominations rather than every cited path
+    // read as dead.
+    const plan = buildAuditPlan([row({ key: 'cites', content: 'see src/cli/anything.ts' })], { now: NOW });
+
+    expect(plan.counts.deadPath).toBe(0);
+    expect(plan.candidates).toEqual([]);
+  });
+
+  it('ranks an entry two passes agree on above one only the path pass flagged', () => {
+    const rows = [
+      row({ key: 'path-only', content: 'see src/cli/gone.ts', accessCount: 4, updatedAt: NOW }),
+      row({
+        key: 'path-and-unused',
+        content: 'see src/cli/also-gone.ts',
+        accessCount: 0,
+        updatedAt: NOW - 300 * DAY,
+      }),
+    ];
+
+    const plan = buildAuditPlan(rows, { now: NOW, deadPaths: { resolves: () => false } });
+
+    expect(plan.counts.deadPath).toBe(2);
+    expect(plan.counts.unused).toBe(1);
+    expect(plan.candidates.map((c) => c.key)).toEqual(['path-and-unused', 'path-only']);
+    expect(plan.candidates[0].buckets.sort()).toEqual(['dead-path', 'unused']);
+  });
+
+  it('skips entries a prior --apply already decided, like every other pass', () => {
+    const decided = new Map([
+      ['judged', { verdict: 'KEEP' as AuditVerdict, hash: 'h', at: NOW }],
+    ]);
+    const plan = buildAuditPlan(
+      [row({ key: 'judged', content: 'see src/cli/gone.ts' })],
+      { now: NOW, decided, hashContent: () => 'h', deadPaths: { resolves: () => false } },
+    );
+
+    expect(plan.alreadyDecided).toBe(1);
+    expect(plan.counts.deadPath).toBe(0);
+  });
+});
+
+describe('buildJudgePrompt — dead paths (#1479)', () => {
+  function promptFor(content: string): string {
+    const plan = buildAuditPlan([row({ key: 'cites-dead', content })], {
+      now: NOW,
+      deadPaths: { resolves: () => false },
+    });
+    return buildJudgePrompt(plan.candidates, NOW);
+  }
+
+  it('names the unresolved paths as the evidence', () => {
+    const prompt = promptFor('the guard was in src/cli/old-home/guard.ts');
+
+    expect(prompt).toContain('resolve nowhere in the tree');
+    expect(prompt).toContain('src/cli/old-home/guard.ts');
+  });
+
+  it('tells the judge the moved-file case is COMPRESS, never RETIRE on sight', () => {
+    // The whole reason this bucket nominates rather than decides: treating a
+    // dead path as a deletion throws away lessons that are still entirely true.
+    const prompt = promptFor('the guard was in src/cli/old-home/guard.ts');
+
+    expect(prompt).toContain('FOUR possible causes');
+    expect(prompt).toContain('Never read one as RETIRE on sight');
+    expect(prompt).toMatch(/The file MOVED.*COMPRESS/);
+    expect(prompt).toMatch(/historical record.*KEEP/);
+  });
+});

--- a/src/cli/__tests__/memory/learnings-dead-paths.test.ts
+++ b/src/cli/__tests__/memory/learnings-dead-paths.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Unit tests for the dead-path nomination pass (#1479).
+ *
+ * The extraction rules are where every false positive would come from, so they
+ * are driven directly at prose rather than inferred from a plan's counts: a
+ * detector that flags more innocent entries than real ones gets ignored
+ * wholesale, which costs the audit's other three buckets their audience too.
+ *
+ * Resolution is a predicate here, exactly as the module takes it — no temp
+ * directories, no repo. `commands/memory-audit-learnings.test.ts` covers the
+ * real-filesystem half.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_DEAD_PATHS_PER_ENTRY,
+  extractCandidatePaths,
+  findDeadPaths,
+  resolvesInTree,
+} from '../../memory/learnings-dead-paths.js';
+import type { AuditRow } from '../../memory/learnings-audit.js';
+
+const NOW = 1_800_000_000_000;
+
+function row(key: string, content: string): AuditRow {
+  return {
+    id: `id-${key}`,
+    key,
+    content,
+    embedding: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    accessCount: 1,
+  };
+}
+
+/** Resolution backed by a fixed set of paths — the tree, without a tree. */
+function tree(...paths: string[]): (p: string) => boolean {
+  const known = new Set(paths);
+  return (p) => known.has(p);
+}
+
+describe('extractCandidatePaths', () => {
+  it('pulls paths out of prose, backticks, and parentheses', () => {
+    const found = extractCandidatePaths(
+      'The guard lives in `src/cli/guards/leak.ts` and its fixture is '
+      + 'tests/fixtures/leak.json (see docs/internal/leaks.md).',
+    );
+
+    expect(found).toEqual([
+      'src/cli/guards/leak.ts',
+      'tests/fixtures/leak.json',
+      'docs/internal/leaks.md',
+    ]);
+  });
+
+  it('drops sentence punctuation that rode along on the path', () => {
+    expect(extractCandidatePaths('Fixed in src/cli/output.ts.')).toEqual(['src/cli/output.ts']);
+    expect(extractCandidatePaths('Both src/a.ts, src/b.ts; and src/c.ts!')).toEqual([
+      'src/a.ts',
+      'src/b.ts',
+      'src/c.ts',
+    ]);
+  });
+
+  it('keeps a file:line reference as the file', () => {
+    expect(extractCandidatePaths('see src/cli/daemon-lock.ts:214 for the shape')).toEqual([
+      'src/cli/daemon-lock.ts',
+    ]);
+  });
+
+  it('accepts a Windows-authored path and normalises the separator', () => {
+    // Rule #1: the entry's separator is whatever its author typed. The wire
+    // format downstream is always forward-slash.
+    expect(extractCandidatePaths('broke in src\\cli\\memory\\hnsw.ts on the CI box')).toEqual([
+      'src/cli/memory/hnsw.ts',
+    ]);
+  });
+
+  it('accepts a directory reference with a trailing separator', () => {
+    expect(extractCandidatePaths('everything under .claude/guidance/shipped/ is indexed')).toEqual([
+      '.claude/guidance/shipped/',
+    ]);
+  });
+
+  it('never scores a URL, even one ending in a file extension', () => {
+    // A URL's own tail tokenises perfectly well as `docs/spec.md`, which is why
+    // URLs are blanked before tokenising rather than filtered afterwards.
+    expect(extractCandidatePaths('per https://example.com/docs/spec.md the flag is required')).toEqual([]);
+    expect(extractCandidatePaths('see http://localhost:3000/api/v1/health')).toEqual([]);
+  });
+
+  it('never scores a node_modules path', () => {
+    // Whether it resolves says whether anyone ran an install, not whether the
+    // entry is still true.
+    expect(extractCandidatePaths('patched node_modules/moflo/dist/cli.js by hand')).toEqual([]);
+    expect(extractCandidatePaths('lives at packages/api/node_modules/dep/index.js')).toEqual([]);
+  });
+
+  it('never scores a glob, which has nothing to look up', () => {
+    expect(extractCandidatePaths('every .claude/guidance/**/*.md file is indexed')).toEqual([]);
+    expect(extractCandidatePaths('matched by src/cli/*.ts')).toEqual([]);
+  });
+
+  it('never scores a path that is not repo-relative', () => {
+    expect(extractCandidatePaths('wrote it to /tmp/moflo/scratch.json')).toEqual([]);
+    expect(extractCandidatePaths('lives at ~/.claude/settings.json')).toEqual([]);
+    expect(extractCandidatePaths('C:\\Users\\dev\\project\\src\\app.ts failed')).toEqual([]);
+    expect(extractCandidatePaths('imported ../../shared/util.ts')).toEqual([]);
+  });
+
+  it('ignores prose that merely contains a slash', () => {
+    expect(extractCandidatePaths('the KEEP/RETIRE call is the readers, and/or the judges')).toEqual([]);
+    expect(extractCandidatePaths('roughly 20/30 entries were stale')).toEqual([]);
+  });
+
+  it('ignores a bare filename — one segment is too ambiguous to score', () => {
+    expect(extractCandidatePaths('bumped package.json and tsconfig.json')).toEqual([]);
+  });
+
+  it('deduplicates repeats, preserving first-seen order', () => {
+    expect(extractCandidatePaths('src/b.ts then src/a.ts then src/b.ts again')).toEqual([
+      'src/b.ts',
+      'src/a.ts',
+    ]);
+  });
+});
+
+describe('resolvesInTree', () => {
+  it('resolves a path that exists as written', () => {
+    expect(resolvesInTree('src/app.ts', tree('src/app.ts'))).toBe(true);
+  });
+
+  it('retries under each workspace prefix before declaring a path dead', () => {
+    // The load-bearing case: learnings are authored from inside a workspace and
+    // cite `src/routes/foo.ts` meaning `packages/api/src/routes/foo.ts`. Without
+    // this retry every such citation reads as dead.
+    const resolves = tree('packages/api/src/routes/foo.ts');
+
+    expect(resolvesInTree('src/routes/foo.ts', resolves)).toBe(false);
+    expect(resolvesInTree('src/routes/foo.ts', resolves, ['apps/web', 'packages/api'])).toBe(true);
+  });
+
+  it('does not re-prefix a path that already carries the prefix', () => {
+    const asked: string[] = [];
+    const resolves = (p: string): boolean => {
+      asked.push(p);
+      return false;
+    };
+
+    resolvesInTree('packages/api/src/gone.ts', resolves, ['packages/api']);
+
+    // `packages/api/packages/api/src/gone.ts` is never a real question.
+    expect(asked).toEqual(['packages/api/src/gone.ts']);
+  });
+
+  it('tolerates prefixes written with a trailing or leading marker', () => {
+    const resolves = tree('packages/api/src/foo.ts');
+
+    expect(resolvesInTree('src/foo.ts', resolves, ['packages/api/'])).toBe(true);
+    expect(resolvesInTree('src/foo.ts', resolves, ['./packages/api'])).toBe(true);
+    expect(resolvesInTree('src/foo.ts', resolves, ['packages\\api'])).toBe(true);
+    expect(resolvesInTree('src/foo.ts', resolves, [''])).toBe(false);
+  });
+
+  it('reports a path that resolves nowhere', () => {
+    expect(resolvesInTree('src/gone.ts', tree('src/here.ts'), ['packages/api'])).toBe(false);
+  });
+});
+
+describe('findDeadPaths', () => {
+  it('nominates only the entries whose citations resolve nowhere', () => {
+    const rows = [
+      row('alive', 'the check is in src/cli/output.ts'),
+      row('dead', 'the check was in src/cli/removed.ts'),
+      row('no-paths', 'always realpath both sides before comparing'),
+    ];
+
+    const found = findDeadPaths(rows, { resolves: tree('src/cli/output.ts') });
+
+    expect(found.map((f) => f.row.key)).toEqual(['dead']);
+    expect(found[0].deadPaths).toEqual(['src/cli/removed.ts']);
+  });
+
+  it('does NOT nominate a workspace-relative citation — the file did not move', () => {
+    // The expensive false positive this pass has to avoid: the entry is correct
+    // as written from inside its workspace, and nothing has been deleted.
+    const rows = [row('workspace-relative', 'the handler is src/routes/foo.ts')];
+
+    const found = findDeadPaths(rows, {
+      resolves: tree('packages/api/src/routes/foo.ts'),
+      workspacePrefixes: ['packages/api'],
+    });
+
+    expect(found).toEqual([]);
+  });
+
+  it('DOES nominate a genuinely moved file, so a reader can correct the path', () => {
+    // The file exists at a new path, which no prefix retry reaches. Nominating
+    // is right; RETIRING would be wrong, and `buildJudgePrompt` is what says so.
+    const rows = [row('moved', 'the guard is in src/cli/old-home/guard.ts')];
+
+    const found = findDeadPaths(rows, {
+      resolves: tree('src/cli/new-home/guard.ts'),
+      workspacePrefixes: ['packages/api'],
+    });
+
+    expect(found.map((f) => f.row.key)).toEqual(['moved']);
+    expect(found[0].deadPaths).toEqual(['src/cli/old-home/guard.ts']);
+  });
+
+  it('records several dead paths from one entry, deduplicated', () => {
+    const rows = [row('multi', 'both src/a.ts and src/b.ts went away; src/a.ts especially')];
+
+    const found = findDeadPaths(rows, { resolves: () => false });
+
+    expect(found[0].deadPaths).toEqual(['src/a.ts', 'src/b.ts']);
+  });
+
+  it('caps the evidence recorded per entry', () => {
+    const content = Array.from({ length: 12 }, (_, i) => `src/gone-${i}.ts`).join(' ');
+    const rows = [row('many', content)];
+
+    expect(findDeadPaths(rows, { resolves: () => false })[0].deadPaths).toHaveLength(
+      DEFAULT_DEAD_PATHS_PER_ENTRY,
+    );
+    expect(findDeadPaths(rows, { resolves: () => false, maxPathsPerEntry: 2 })[0].deadPaths).toEqual([
+      'src/gone-0.ts',
+      'src/gone-1.ts',
+    ]);
+  });
+
+  it('asks the filesystem about each distinct path once across the whole store', () => {
+    // One lookup per prefix per miss, times a store where the same file is cited
+    // by dozens of entries, is the difference between a pass and a sweep.
+    const asked: string[] = [];
+    const rows = [
+      row('a', 'see src/gone.ts'),
+      row('b', 'also src/gone.ts'),
+      row('c', 'and src/gone.ts again'),
+    ];
+
+    findDeadPaths(rows, {
+      resolves: (p) => {
+        asked.push(p);
+        return false;
+      },
+      workspacePrefixes: ['packages/api'],
+    });
+
+    expect(asked).toEqual(['src/gone.ts', 'packages/api/src/gone.ts']);
+  });
+
+  it('nominates nothing for an empty store', () => {
+    expect(findDeadPaths([], { resolves: () => false })).toEqual([]);
+  });
+});
+
+describe('extractCandidatePaths — environment-rooted paths (#1479)', () => {
+  it('never scores a path rooted at an environment variable', () => {
+    // It resolves to wherever the variable points, which is not this tree.
+    expect(extractCandidatePaths('the hook reads CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs')).toEqual([]);
+    expect(extractCandidatePaths('written to XDG_DATA_HOME/moflo/state.json')).toEqual([]);
+  });
+
+  it('still scores an ordinary shouted directory', () => {
+    // The underscore is what marks a variable; a shouted directory has none.
+    expect(extractCandidatePaths('documented in API/v1.json')).toEqual(['API/v1.json']);
+  });
+});
+
+describe('extractCandidatePaths — degenerate input (#1479)', () => {
+  it('rejects a single-segment token left behind by ./ stripping', () => {
+    // `./foo` tokenises as a two-segment path and normalises to one segment,
+    // which every downstream rule has to survive being handed.
+    expect(extractCandidatePaths('wrote ./foo and ./bar/')).toEqual([]);
+  });
+
+  it('reads empty and whitespace-only content as citing nothing', () => {
+    expect(extractCandidatePaths('')).toEqual([]);
+    expect(extractCandidatePaths('   \n\t ')).toEqual([]);
+  });
+});

--- a/src/cli/__tests__/memory/learnings-tree.test.ts
+++ b/src/cli/__tests__/memory/learnings-tree.test.ts
@@ -1,0 +1,192 @@
+/**
+ * The filesystem half of the dead-path pass (#1479).
+ *
+ * `learnings-dead-paths.test.ts` drives the rules against a predicate; this
+ * drives the predicate against a real directory tree, because the two ways this
+ * half can be wrong — a path joined with the wrong separator, a workspace layout
+ * that yields no prefixes — are both invisible to a stubbed resolver.
+ *
+ * Cross-platform (Rule #1): every fixture path is built with `path.join`, the
+ * tree is `os.tmpdir()`-rooted, and the resolver is fed the forward-slash form
+ * entries are authored with on all three platforms.
+ */
+
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  MAX_WORKSPACE_PREFIXES,
+  listWorkspacePrefixes,
+  makeTreeResolver,
+} from '../../memory/learnings-tree.js';
+
+let root: string;
+
+function makeRoot(): string {
+  // realpath: macOS os.tmpdir() is a symlink into /private/var (Rule #1).
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-1479-')));
+}
+
+function touch(dir: string, ...segments: string[]): void {
+  const file = path.join(dir, ...segments);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, '', 'utf-8');
+}
+
+beforeAll(() => {
+  root = makeRoot();
+});
+
+afterAll(() => {
+  try {
+    fs.rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  } catch {
+    /* best-effort — Windows can hold a brief handle */
+  }
+});
+
+describe('makeTreeResolver', () => {
+  it('resolves a forward-slash path against the host separator', () => {
+    const dir = path.join(root, 'resolver');
+    touch(dir, 'src', 'cli', 'output.ts');
+    const resolves = makeTreeResolver(dir);
+
+    expect(resolves('src/cli/output.ts')).toBe(true);
+    expect(resolves('src/cli/missing.ts')).toBe(false);
+  });
+
+  it('counts a directory, not only a file — a moved directory is the same finding', () => {
+    const dir = path.join(root, 'dirs');
+    touch(dir, 'guidance', 'shipped', 'rules.md');
+    const resolves = makeTreeResolver(dir);
+
+    expect(resolves('guidance/shipped/')).toBe(true);
+    expect(resolves('guidance/shipped')).toBe(true);
+    expect(resolves('guidance/internal/')).toBe(false);
+  });
+
+  it('refuses a traversal segment rather than answering about a path outside the repo', () => {
+    const dir = path.join(root, 'traversal', 'nested');
+    fs.mkdirSync(dir, { recursive: true });
+    touch(path.join(root, 'traversal'), 'outside.ts');
+
+    expect(makeTreeResolver(dir)('../outside.ts')).toBe(false);
+  });
+
+  it('reads an empty or dot-only path as unresolved rather than as the project root', () => {
+    const resolves = makeTreeResolver(root);
+
+    expect(resolves('')).toBe(false);
+    expect(resolves('.')).toBe(false);
+    expect(resolves('./')).toBe(false);
+  });
+});
+
+describe('listWorkspacePrefixes', () => {
+  it('offers the top-level directories of a flat repo', () => {
+    const dir = path.join(root, 'flat');
+    for (const name of ['src', 'tests', 'docs']) fs.mkdirSync(path.join(dir, name), { recursive: true });
+
+    expect(listWorkspacePrefixes(dir)).toEqual(['docs', 'src', 'tests']);
+  });
+
+  it('keeps dot directories and drops only the ones that say nothing about the entry', () => {
+    const dir = path.join(root, 'skips');
+    for (const name of ['src', 'node_modules', 'dist', 'build', 'out', 'coverage', '.git', '.claude']) {
+      fs.mkdirSync(path.join(dir, name), { recursive: true });
+    }
+
+    // A stale `dist/` would resolve a path whose source has been deleted, which
+    // is the one answer this pass must never give. `.claude/` is the opposite —
+    // learnings cite it constantly, so excluding every dot directory would cost
+    // real resolutions.
+    expect(listWorkspacePrefixes(dir)).toEqual(['.claude', 'src']);
+  });
+
+  it('expands a declared workspace glob ahead of the bare directory walk', () => {
+    const dir = path.join(root, 'monorepo');
+    fs.mkdirSync(path.join(dir, 'packages', 'api'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'packages', 'web'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ name: 'mono', workspaces: ['packages/*'] }),
+      'utf-8',
+    );
+
+    // `packages/api` is a more specific answer than the bare `packages` the walk
+    // offers, so it has to be tried first.
+    expect(listWorkspacePrefixes(dir)).toEqual(['packages/api', 'packages/web', 'packages']);
+  });
+
+  it('reads the npm/yarn object form of the workspaces field', () => {
+    const dir = path.join(root, 'mono-object');
+    fs.mkdirSync(path.join(dir, 'apps', 'web'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ workspaces: { packages: ['apps/*', 'tools/cli'] } }),
+      'utf-8',
+    );
+
+    expect(listWorkspacePrefixes(dir)).toEqual(['apps/web', 'tools/cli', 'apps']);
+  });
+
+  it('leaves a ** glob to the directory walk instead of walking the whole tree', () => {
+    const dir = path.join(root, 'deep-glob');
+    fs.mkdirSync(path.join(dir, 'packages', 'api'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ workspaces: ['packages/**'] }),
+      'utf-8',
+    );
+
+    // The glob contributes nothing; `packages/api` is here because the ordinary
+    // two-level walk reaches it, not because `**` was expanded.
+    expect(listWorkspacePrefixes(dir)).toEqual(['packages', 'packages/api']);
+  });
+
+  it('descends one level below the top, where the source root usually is', () => {
+    // `src/cli/commands/x.ts` cited as `commands/x.ts` is the shape this exists
+    // for: the directory a learning writes relative to is nested inside a
+    // top-level container, not the container itself.
+    const dir = path.join(root, 'nested-root');
+    fs.mkdirSync(path.join(dir, 'src', 'cli', 'commands'), { recursive: true });
+
+    const prefixes = listWorkspacePrefixes(dir);
+
+    expect(prefixes).toEqual(['src', 'src/cli']);
+    // Depth 3 would start resolving paths by coincidence rather than by layout.
+    expect(prefixes).not.toContain('src/cli/commands');
+  });
+
+  it('refuses to descend into a wide directory, so one scratch dir cannot starve the budget', () => {
+    // A container holds one or two entries; a directory holding thirty is
+    // already the source root and its children are not prefixes anybody writes
+    // relative to. Measured on this repo, a `tmp/` full of test fixtures took
+    // every slot after the top level.
+    const dir = path.join(root, 'wide-child');
+    for (let i = 0; i < 30; i++) fs.mkdirSync(path.join(dir, 'tmp', `fixture-${i}`), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'src', 'cli'), { recursive: true });
+
+    expect(listWorkspacePrefixes(dir)).toEqual(['src', 'tmp', 'src/cli']);
+  });
+
+  it('survives a missing or unparseable manifest', () => {
+    const dir = path.join(root, 'bad-manifest');
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'package.json'), '{ not json', 'utf-8');
+
+    expect(listWorkspacePrefixes(dir)).toEqual(['src']);
+    expect(listWorkspacePrefixes(path.join(root, 'does-not-exist'))).toEqual([]);
+  });
+
+  it('caps the prefix list — every unresolved path costs one lookup per prefix', () => {
+    const dir = path.join(root, 'wide');
+    for (let i = 0; i < MAX_WORKSPACE_PREFIXES + 10; i++) {
+      fs.mkdirSync(path.join(dir, `pkg-${String(i).padStart(3, '0')}`), { recursive: true });
+    }
+
+    expect(listWorkspacePrefixes(dir)).toHaveLength(MAX_WORKSPACE_PREFIXES);
+  });
+});

--- a/src/cli/commands/memory-audit-learnings.ts
+++ b/src/cli/commands/memory-audit-learnings.ts
@@ -12,6 +12,10 @@
  * deletion carries a tombstone the #1463 reconciler can propagate instead of
  * being silently re-imported on the next session start.
  *
+ * The dead-path pass (#1479) follows the same split: the detector is pure and
+ * takes a `resolves` predicate, and `memory/learnings-tree.ts` supplies it from
+ * a real checkout. This file only decides whether the pass runs at all.
+ *
  * Cross-platform (Rule #1): `path.join` throughout, `child_process.spawn` with
  * an argument array (no shell), `windowsHide` on the child, and no POSIX-only
  * utilities.
@@ -33,6 +37,7 @@ import { findProjectRoot } from '../services/project-root.js';
 import { hasMemoryEntriesTable } from '../services/cherry-pick-learnings.js';
 import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
 import { hashContent } from '../memory/auto-memory-bridge.js';
+import { listWorkspacePrefixes, makeTreeResolver } from '../memory/learnings-tree.js';
 import {
   LEARNINGS_NAMESPACE,
   buildAuditPlan,
@@ -242,7 +247,7 @@ function unusedMinAgeMs(flag: unknown): number {
   return Number.isFinite(days) && days > 0 ? days * 24 * 60 * 60 * 1000 : DEFAULT_UNUSED_MIN_AGE_MS;
 }
 
-function printPlan(plan: AuditPlan): void {
+function printPlan(plan: AuditPlan, deadPathsScanned: boolean): void {
   output.writeln();
   output.writeln(output.bold('Nominations'));
   output.printTable({
@@ -254,6 +259,7 @@ function printPlan(plan: AuditPlan): void {
       { bucket: 'Near-duplicate', count: plan.counts.duplicate },
       { bucket: 'Unused and old', count: plan.counts.unused },
       { bucket: 'Superseded vocabulary', count: plan.counts.superseded },
+      { bucket: 'Dead path reference', count: plan.counts.deadPath },
       { bucket: output.bold('To judge'), count: output.bold(String(plan.candidates.length)) },
     ],
   });
@@ -274,10 +280,34 @@ function printPlan(plan: AuditPlan): void {
   if (plan.withoutEmbedding > 0) {
     notes.push(`${plan.withoutEmbedding} have no stored vector — invisible to the duplicate pass`);
   }
+  if (!deadPathsScanned) {
+    // A zero in the table has to be distinguishable from a pass that never ran.
+    notes.push('dead-path resolution skipped (--no-dead-paths) — that bucket reads 0 regardless');
+  }
   if (plan.overflow > 0) {
     notes.push(`${plan.overflow} nomination(s) over the judge limit — they resurface next run`);
   }
   output.printList(notes);
+}
+
+/**
+ * Name the unresolved paths that nominated an entry.
+ *
+ * The verdict table gets the counts; this gets the evidence, because a reader
+ * cannot tell a moved file from a deleted one without seeing the path — and
+ * that distinction is the whole difference between COMPRESS and RETIRE.
+ */
+function printDeadPaths(plan: AuditPlan): void {
+  const cited = plan.candidates.filter((c) => (c.deadPaths?.length ?? 0) > 0);
+  if (cited.length === 0) return;
+
+  output.writeln();
+  output.printInfo(
+    `${cited.length} entr${cited.length === 1 ? 'y cites a path' : 'ies cite paths'} that resolve nowhere in the tree. `
+    + 'A moved file reads exactly like a deleted one here — check `git log --diff-filter=D -- <path>` '
+    + 'before treating any of these as stale:',
+  );
+  output.printList(cited.map((c) => `${c.key} — ${(c.deadPaths ?? []).join(', ')}`));
 }
 
 function printVerdicts(
@@ -345,6 +375,15 @@ export const auditLearningsCommand: Command = {
       default: true,
     },
     {
+      // Declared positively for the same reason as `judge` above: the parser
+      // turns `--no-<x>` into `<x> = false`, so an option named `no-dead-paths`
+      // would be unreachable.
+      name: 'dead-paths',
+      description: 'Nominate entries citing paths that no longer resolve (--no-dead-paths to skip)',
+      type: 'boolean',
+      default: true,
+    },
+    {
       name: 'recheck',
       description: 'Re-examine entries that already carry a recorded verdict',
       type: 'boolean',
@@ -381,6 +420,7 @@ export const auditLearningsCommand: Command = {
   examples: [
     { command: 'flo memory audit-learnings', description: 'Dry run — nominate, judge, and report' },
     { command: 'flo memory audit-learnings --no-judge', description: 'Mechanical nominations only, no model call' },
+    { command: 'flo memory audit-learnings --no-dead-paths', description: 'Skip the path-resolution pass' },
     { command: 'flo memory audit-learnings --apply', description: 'Archive the entries judged RETIRE' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
@@ -400,6 +440,7 @@ async function runAudit(ctx: CommandContext): Promise<CommandResult> {
     const apply = ctx.flags.apply === true;
     const judge = ctx.flags.judge !== false;
     const recheck = ctx.flags.recheck === true;
+    const scanDeadPaths = ctx.flags.deadPaths !== false;
     const force = ctx.flags.force === true;
     const asJson = ctx.flags.format === 'json';
 
@@ -432,12 +473,19 @@ async function runAudit(ctx: CommandContext): Promise<CommandResult> {
       judgeLimit: toPositiveNumber(ctx.flags.judgeLimit, DEFAULT_JUDGE_LIMIT),
       decided: decidedForPlan,
       unusedMinAgeMs: unusedMinAgeMs(ctx.flags.unusedMinAgeDays),
+      // Injected rather than reached for: the detector is pure, so the tree it
+      // resolves against is this layer's to supply. Omitted under
+      // `--no-dead-paths`, which is what makes the pass not run at all.
+      deadPaths: scanDeadPaths
+        ? { resolves: makeTreeResolver(projectRoot), workspacePrefixes: listWorkspacePrefixes(projectRoot) }
+        : undefined,
       hashContent,
     });
 
     if (!asJson) {
       if (!apply) output.writeln(output.warning('DRY RUN - No changes will be made'));
-      printPlan(plan);
+      printPlan(plan, scanDeadPaths);
+      printDeadPaths(plan);
     }
 
     // Report the number sent for a verdict on every path, including the paths
@@ -480,6 +528,10 @@ async function runAudit(ctx: CommandContext): Promise<CommandResult> {
       counts: plan.counts,
       nominated: plan.candidates.length,
       overflow: plan.overflow,
+      deadPathsScanned: scanDeadPaths,
+      deadPaths: plan.candidates
+        .filter((c) => (c.deadPaths?.length ?? 0) > 0)
+        .map((c) => ({ key: c.key, paths: c.deadPaths ?? [] })),
       judged,
       judgeSkipped: !judge,
       judgeError,

--- a/src/cli/memory/learnings-audit.ts
+++ b/src/cli/memory/learnings-audit.ts
@@ -10,10 +10,16 @@
  *
  * The shape that makes this affordable at that size is **mechanical filters
  * first, model judgement last**. The filters here do not decide anything — they
- * nominate. Three cheap passes (near-duplicate clustering over the embeddings
- * already stored on the row, least-used-and-old ranking, and retired-vocabulary
- * matching) narrow ~1,500 entries to a few dozen, and only those go to a model.
- * A full-store LLM sweep is the design this exists to avoid.
+ * nominate. Four cheap passes (near-duplicate clustering over the embeddings
+ * already stored on the row, least-used-and-old ranking, retired-vocabulary
+ * matching, and dead-path resolution) narrow ~1,500 entries to a few dozen, and
+ * only those go to a model. A full-store LLM sweep is the design this exists to
+ * avoid.
+ *
+ * The dead-path pass (#1479) is the only one grounded in ground truth rather
+ * than prose shape — a repo-relative path either resolves in the tree or it does
+ * not. It is carved into `memory/learnings-dead-paths.ts` and re-exported from
+ * here; its filesystem half is `memory/learnings-tree.ts`.
  *
  * This module is pure by construction: no filesystem, no database, no spawning.
  * Rows come in, a plan comes out. The command layer
@@ -22,6 +28,20 @@
  *
  * @module memory/learnings-audit
  */
+
+// The dead-path pass lives in its own module so this one stays the place the
+// passes are ASSEMBLED. Re-exported here because `learnings-audit.js` is the
+// audit's public surface — a caller configuring the pass should not have to
+// know which file the detector was carved into.
+import { findDeadPaths, type DeadPathScanOptions } from './learnings-dead-paths.js';
+
+export {
+  DEFAULT_DEAD_PATHS_PER_ENTRY,
+  extractCandidatePaths,
+  findDeadPaths,
+  resolvesInTree,
+  type DeadPathScanOptions,
+} from './learnings-dead-paths.js';
 
 /** The namespace this audit is scoped to. */
 export const LEARNINGS_NAMESPACE = 'learnings';
@@ -44,7 +64,7 @@ export interface AuditRow {
 }
 
 /** Why an entry was nominated. An entry can be nominated by more than one pass. */
-export type AuditBucket = 'duplicate' | 'unused' | 'superseded';
+export type AuditBucket = 'duplicate' | 'unused' | 'superseded' | 'dead-path';
 
 /**
  * The verdict vocabulary, taken verbatim from the auto-memory decision table in
@@ -105,6 +125,12 @@ export interface AuditCandidate {
   similarity?: number;
   /** For a `superseded` nomination, the retired terms found in the content. */
   supersededTerms?: SupersededTerm[];
+  /**
+   * For a `dead-path` nomination, the cited paths that resolved nowhere — as
+   * written and under every workspace prefix. Evidence for a reader, never a
+   * verdict: see {@link findDeadPaths}.
+   */
+  deadPaths?: string[];
 }
 
 /** Per-bucket nomination counts, reported before any model is involved. */
@@ -112,6 +138,7 @@ export interface AuditBucketCounts {
   duplicate: number;
   unused: number;
   superseded: number;
+  deadPath: number;
 }
 
 /**
@@ -173,6 +200,13 @@ export interface AuditPlanOptions {
   judgeLimit?: number;
   /** Retired vocabulary to match against. Defaults to the (empty) shipped table. */
   vocabulary?: readonly SupersededTerm[];
+  /**
+   * Enables the dead-path pass. Omitted, the pass does not run at all — this
+   * module cannot reach a filesystem, so a caller with no tree to resolve
+   * against (a unit test, a store audited away from its repo) gets no
+   * nominations rather than every cited path read as dead.
+   */
+  deadPaths?: DeadPathScanOptions;
   /** Verdicts recorded by a previous `--apply`, keyed by entry key. */
   decided?: ReadonlyMap<string, DecidedEntry>;
   /** Stable content hash, injected so the module stays free of `node:crypto`. */
@@ -305,7 +339,7 @@ export function findSuperseded(
 }
 
 /**
- * Run the three mechanical passes and assemble the candidate set.
+ * Run the mechanical passes and assemble the candidate set.
  *
  * Entries with a recorded verdict whose content has not changed since are
  * dropped before any pass runs — that is what makes a second run immediately
@@ -382,10 +416,20 @@ export function buildAuditPlan(
     candidate.supersededTerms = hit.terms;
   }
 
+  // Runs over `pending` rather than every row: unlike clustering, this pass
+  // reads one entry at a time and has no representative to protect, so a
+  // previously-judged entry contributes nothing to another entry's nomination.
+  const deadPaths = options.deadPaths ? findDeadPaths(pending, options.deadPaths) : [];
+  for (const hit of deadPaths) {
+    const candidate = nominate(hit.row, 'dead-path');
+    candidate.deadPaths = hit.deadPaths;
+  }
+
   const counts: AuditBucketCounts = {
     duplicate: duplicates.length,
     unused: unused.length,
     superseded: superseded.length,
+    deadPath: deadPaths.length,
   };
 
   // Most-nominated first, then oldest — an entry three passes agree on is the
@@ -419,6 +463,8 @@ function describeBuckets(candidate: AuditCandidate): string {
       );
     } else if (bucket === 'unused') {
       parts.push('never returned by a search since usage recording began');
+    } else if (bucket === 'dead-path') {
+      parts.push(`cites path(s) that resolve nowhere in the tree: ${(candidate.deadPaths ?? []).join(', ')}`);
     } else {
       const terms = (candidate.supersededTerms ?? [])
         .map((t) => `"${t.from}" → "${t.to}"`)
@@ -476,6 +522,16 @@ export function buildJudgePrompt(candidates: readonly AuditCandidate[], now: num
     '',
     'A near-duplicate flag is evidence, not a verdict: two entries can restate one rule',
     '(MERGE) or cover genuinely different cases that merely read alike (KEEP).',
+    '',
+    'A dead-path flag is evidence with FOUR possible causes, and only reading the entry tells',
+    'them apart. Never read one as RETIRE on sight — the moved-file case is the common one:',
+    '',
+    '| Why the cited path does not resolve | Verdict |',
+    '|---|---|',
+    '| The file MOVED; the lesson still holds | COMPRESS — keep the rule, correct or drop the path |',
+    '| Deleted, and the lesson was about that code | RETIRE |',
+    '| Deleted, but the lesson generalises past it | COMPRESS — drop the path, keep the rule |',
+    '| The entry is a historical record, correct as written | KEEP |',
     '',
     `Answer with exactly ${candidates.length} line(s), nothing else. One line per entry:`,
     '',

--- a/src/cli/memory/learnings-dead-paths.ts
+++ b/src/cli/memory/learnings-dead-paths.ts
@@ -1,0 +1,240 @@
+/**
+ * Dead-path nomination for the learnings audit (#1479).
+ *
+ * The audit's other three passes read prose shape — how similar two entries
+ * are, how long one has gone unused, whether it speaks a retired word. This one
+ * reads ground truth: a repo-relative path an entry cites either resolves in the
+ * tree or it does not. That also makes it the only pass that is portable across
+ * consumers — it resolves against the consumer's own tree and carries no
+ * project-specific data, unlike a vocabulary list.
+ *
+ * **It nominates, it never decides.** A dead path has four causes and only a
+ * reader can tell them apart. See {@link findDeadPaths}.
+ *
+ * Pure by construction, like `learnings-audit.ts`: resolution is injected as a
+ * predicate, so nothing here touches a disk. The filesystem half lives in
+ * `memory/learnings-tree.ts`.
+ *
+ * @module memory/learnings-dead-paths
+ */
+
+// Pure string composition, no disk: `path.posix.join` puts a workspace prefix in
+// front of a cited path. `posix` specifically, because the separator inside a
+// learning is whatever its author typed — `/` on every platform in practice — so
+// it is a wire format, not a host path. The host separator is applied once, at
+// the filesystem boundary in `memory/learnings-tree.ts`, with `path.join` (Rule #1).
+import { posix as posixPath } from 'path';
+
+import type { AuditRow } from './learnings-audit.js';
+
+/**
+ * How many unresolved paths are recorded per entry.
+ *
+ * Evidence, not an inventory: an entry citing thirty dead paths is nominated by
+ * the first few just as decisively, and the rest would only inflate the judge
+ * prompt this whole design exists to keep bounded.
+ */
+export const DEFAULT_DEAD_PATHS_PER_ENTRY = 5;
+
+/** A URL is not a tree path, and plenty of them end in `.json` or `.md`. */
+const URL_LIKE = /\S+:\/\/\S+/g;
+
+/** A glob is a pattern; there is nothing to look up. */
+const GLOB_LIKE = /\S*\*\S*/g;
+
+/**
+ * A path-shaped token: two or more segments joined by a separator.
+ *
+ * Group 1 pins the character BEFORE the token and rejects the ones that mean
+ * "not repo-relative" — a leading separator (`/tmp/x.log`), a home marker
+ * (`~/.claude/settings.json`), a drive colon (`C:\Users\x\y.ts`), or a longer
+ * path this token is merely the tail of. Backslashes are accepted on input and
+ * normalised away, because a learning written on Windows says `src\cli\x.ts`.
+ */
+const PATH_TOKEN = /(^|[^A-Za-z0-9._~@+\-/\\:])([A-Za-z0-9._~@+-]+(?:[/\\][A-Za-z0-9._~@+-]+)+[/\\]?)/g;
+
+/** Sentence punctuation that rides along on a path at the end of a clause. */
+const TRAILING_PUNCTUATION = /[.,;:!?)\]}'"`]+$/;
+
+/** A file extension, which is what separates `src/foo.ts` from `and/or`. */
+const FILE_EXTENSION = /\.[A-Za-z0-9]{1,10}$/;
+
+/**
+ * An environment variable standing in for a path root —
+ * `CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs`. The underscore is required, so
+ * an ordinary shouted directory (`API/v1.json`, `README/notes.md`) is untouched.
+ */
+const ENV_VAR_SEGMENT = /^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$/;
+
+/**
+ * Normalise one matched token, or reject it as unscoreable.
+ *
+ * Rejections are the load-bearing half. A detector whose output is mostly false
+ * positives gets ignored wholesale, so anything whose resolution would say
+ * something about the environment rather than about the entry is dropped here:
+ *
+ * - `node_modules/...` resolves or not depending on whether anyone has run an
+ *   install in this checkout. That is a fact about the checkout, not the entry.
+ * - An absolute, home-relative, or parent-relative path is not repo-relative,
+ *   so resolving it against the project root would be meaningless.
+ * - A bare filename (`package.json`) and an extensionless pair (`and/or`,
+ *   `KEEP/RETIRE`) are too ambiguous to score at all.
+ * - A path rooted at an environment variable resolves to wherever that variable
+ *   points, which is not this tree.
+ */
+function normalizeCandidate(raw: string): string | null {
+  let candidate = raw.replace(TRAILING_PUNCTUATION, '').replace(/\\/g, '/');
+  if (candidate.startsWith('./')) candidate = candidate.slice(2);
+  if (!candidate || candidate.startsWith('/') || candidate.startsWith('~') || candidate.startsWith('../')) {
+    return null;
+  }
+  if (candidate.includes('//')) return null;
+
+  const lower = candidate.toLowerCase();
+  if (lower.startsWith('node_modules/') || lower.includes('/node_modules/')) return null;
+
+  if (ENV_VAR_SEGMENT.test(candidate.split('/')[0])) return null;
+
+  const isDirectory = candidate.endsWith('/');
+  const body = isDirectory ? candidate.slice(0, -1) : candidate;
+  if (!body.includes('/')) return null;
+  if (!isDirectory && !FILE_EXTENSION.test(body)) return null;
+  return candidate;
+}
+
+/**
+ * Pull the repo-relative paths an entry cites, deduplicated, in first-seen
+ * order.
+ *
+ * Exported because it is where every false positive would come from: the rules
+ * above are only checkable by driving prose at them directly.
+ */
+export function extractCandidatePaths(content: string): string[] {
+  // Blank URLs and globs out of the text BEFORE tokenising. Filtering them
+  // afterwards does not work — a URL's own path tail tokenises cleanly on its
+  // own and would survive as `docs/spec.md`.
+  const text = String(content ?? '').replace(URL_LIKE, ' ').replace(GLOB_LIKE, ' ');
+
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const match of text.matchAll(PATH_TOKEN)) {
+    const candidate = normalizeCandidate(match[2]);
+    if (!candidate || seen.has(candidate)) continue;
+    seen.add(candidate);
+    out.push(candidate);
+  }
+  return out;
+}
+
+/** Filesystem access for the dead-path pass, injected so this module stays pure. */
+export interface DeadPathScanOptions {
+  /**
+   * Does this repo-relative, forward-slash path resolve to anything in the
+   * tree? File or directory — a moved file and a moved directory are the same
+   * finding.
+   */
+  resolves: (relativePath: string) => boolean;
+  /**
+   * Workspace directories to retry an unresolved path under, e.g.
+   * `['packages/api', 'apps/web']`. See {@link resolvesInTree} for why this is
+   * not optional in practice.
+   */
+  workspacePrefixes?: readonly string[];
+  /** Per-entry evidence cap. Defaults to {@link DEFAULT_DEAD_PATHS_PER_ENTRY}. */
+  maxPathsPerEntry?: number;
+}
+
+/**
+ * Resolve a cited path as written, then under each workspace prefix.
+ *
+ * The second pass is what makes the detector usable rather than noise. A
+ * learning is authored from inside a workspace and routinely cites
+ * `src/routes/foo.ts` meaning `packages/api/src/routes/foo.ts`; without the
+ * retry every such citation reads as dead. The reference implementation this
+ * pass is ported from measured that single omission taking its findings from
+ * 103 entries to 261 — an auditor that is wrong more often than right gets
+ * ignored wholesale, which costs the other three buckets their audience too.
+ *
+ * A prefix the path already carries is skipped: retrying `packages/api/x.ts`
+ * under `packages/api` only ever asks about `packages/api/packages/api/x.ts`.
+ */
+export function resolvesInTree(
+  relativePath: string,
+  resolves: (relativePath: string) => boolean,
+  workspacePrefixes: readonly string[] = [],
+): boolean {
+  return resolvesUnder(relativePath, resolves, normalizePrefixes(workspacePrefixes));
+}
+
+/**
+ * Put a prefix list into the one form {@link resolvesUnder} can compose with.
+ *
+ * Hoisted out of the resolution loop deliberately: the prefix list is the same
+ * for every candidate in the store, so normalising inside the loop would repeat
+ * this work once per candidate per prefix for no answer that changes.
+ */
+function normalizePrefixes(workspacePrefixes: readonly string[]): string[] {
+  const out: string[] = [];
+  for (const raw of workspacePrefixes) {
+    const prefix = raw.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '');
+    if (prefix) out.push(prefix);
+  }
+  return out;
+}
+
+/** {@link resolvesInTree} over an already-normalised prefix list. */
+function resolvesUnder(
+  relativePath: string,
+  resolves: (relativePath: string) => boolean,
+  prefixes: readonly string[],
+): boolean {
+  if (resolves(relativePath)) return true;
+
+  for (const prefix of prefixes) {
+    if (relativePath === prefix || relativePath.startsWith(`${prefix}/`)) continue;
+    if (resolves(posixPath.join(prefix, relativePath))) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Nominate entries citing paths that resolve nowhere.
+ *
+ * **This nominates, it never decides.** A dead path has four causes and only a
+ * reader can tell them apart: the file moved and the lesson still holds, the
+ * file was deleted and the lesson was about that code, the file was deleted but
+ * the lesson generalises, or the entry is a historical record that is correct as
+ * written. The move case is the common one, which is why reading "dead path" as
+ * "retire" throws away lessons that are still entirely true. The verdict table
+ * goes to the model in {@link buildJudgePrompt}.
+ *
+ * Resolution is memoised across the whole store, not per entry: the same file is
+ * cited by many learnings, and every miss costs one lookup per workspace prefix.
+ */
+export function findDeadPaths(
+  rows: readonly AuditRow[],
+  options: DeadPathScanOptions,
+): Array<{ row: AuditRow; deadPaths: string[] }> {
+  const prefixes = normalizePrefixes(options.workspacePrefixes ?? []);
+  const maxPerEntry = Math.max(1, options.maxPathsPerEntry ?? DEFAULT_DEAD_PATHS_PER_ENTRY);
+  const resolved = new Map<string, boolean>();
+  const found: Array<{ row: AuditRow; deadPaths: string[] }> = [];
+
+  for (const row of rows) {
+    const deadPaths: string[] = [];
+    for (const candidate of extractCandidatePaths(row.content)) {
+      let alive = resolved.get(candidate);
+      if (alive === undefined) {
+        alive = resolvesUnder(candidate, options.resolves, prefixes);
+        resolved.set(candidate, alive);
+      }
+      if (alive) continue;
+      deadPaths.push(candidate);
+      if (deadPaths.length >= maxPerEntry) break;
+    }
+    if (deadPaths.length > 0) found.push({ row, deadPaths });
+  }
+
+  return found;
+}

--- a/src/cli/memory/learnings-tree.ts
+++ b/src/cli/memory/learnings-tree.ts
@@ -1,0 +1,189 @@
+/**
+ * The filesystem half of the dead-path pass (#1479).
+ *
+ * `memory/learnings-dead-paths.ts` decides what counts as a dead path and never
+ * touches a disk; this decides what "resolves" means against a real checkout.
+ * Kept out of the command so the split the audit is built on — pure judgement,
+ * injected I/O — survives having a second kind of I/O in it.
+ *
+ * Cross-platform (Rule #1): a cited path arrives in the forward-slash form
+ * entries are authored with on every platform and is re-joined with `path.join`,
+ * so the only string that reaches the filesystem carries the host separator.
+ *
+ * @module memory/learnings-tree
+ */
+
+import * as fs from 'fs';
+import * as pathModule from 'path';
+
+import { COMMON_WALK_SKIP_NAMES } from '../services/moflo-paths.js';
+
+/**
+ * Directories never offered as a workspace prefix.
+ *
+ * `COMMON_WALK_SKIP_NAMES` is exactly the right list and is shared rather than
+ * restated so a second copy cannot drift from it: `node_modules` is skipped for
+ * the same reason a `node_modules/` path is never scored — whether it resolves
+ * is a fact about the checkout, not the entry — and every build or vendor output
+ * in it (`dist`, `build`, `target`, `.next`, `vendor`, …) is skipped because a
+ * stale one would resolve a path whose source has been deleted, which is the one
+ * answer a dead-path pass must never give.
+ *
+ * Matched case-insensitively, as every other call site does: NTFS and APFS are
+ * case-insensitive by default, so `Dist/` is the same directory (Rule #1).
+ */
+const PREFIX_SCAN_SKIP = COMMON_WALK_SKIP_NAMES;
+
+/**
+ * How deep below the project root a prefix may reach.
+ *
+ * One level is not enough in practice. Measured against moflo's own store, a
+ * top-level-only retry left five of twelve nominations citing paths that plainly
+ * exist — `commands/index.ts` for `src/cli/commands/index.ts`, `fl/phases.md`
+ * for `.claude/skills/fl/phases.md` — because the source root a learning writes
+ * relative to is `src/cli`, not `src`. Two levels reaches those; a third starts
+ * resolving paths by coincidence rather than by layout, which costs real
+ * findings.
+ */
+const MAX_PREFIX_DEPTH = 2;
+
+/**
+ * The widest a directory may be and still be descended into.
+ *
+ * This is what makes depth 2 affordable AND useful, and it is a statement about
+ * layout rather than a budget. A directory holding one or two entries —
+ * `src/` over `cli/`, `packages/` over its packages — is a container, and the
+ * thing learnings write relative to is inside it. A directory holding thirty is
+ * already the source root, and its children are ordinary code directories that
+ * no one writes paths relative to.
+ *
+ * Without it, one wide scratch directory starves the whole prefix budget:
+ * measured on this repo, a `tmp/` full of test fixtures took every slot after
+ * the top level.
+ */
+const MAX_CHILDREN_TO_DESCEND = 12;
+
+/**
+ * Cap on workspace prefixes.
+ *
+ * Every unresolved path costs one `existsSync` per prefix. The list is built
+ * most-specific-first — declared workspaces, then depth 1, then depth 2 — so the
+ * cap truncates the least valuable end rather than an arbitrary one, and
+ * truncating only ever costs extra nominations, never a wrong archive.
+ */
+export const MAX_WORKSPACE_PREFIXES = 80;
+
+/** Immediate subdirectories of `dir`, sorted; unreadable reads as none. */
+function subdirectoryNames(dir: string): string[] {
+  try {
+    return fs
+      .readdirSync(dir, { withFileTypes: true })
+      .filter((e) => (e.isDirectory() || e.isSymbolicLink()) && !PREFIX_SCAN_SKIP.has(e.name.toLowerCase()))
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Workspace directories an unresolved path is retried under.
+ *
+ * Learnings are authored from inside a workspace and routinely cite
+ * `src/routes/foo.ts` meaning `packages/api/src/routes/foo.ts`. Declared
+ * workspaces come first because `packages/api` is a more specific answer than
+ * the bare `packages` a directory walk offers; the walk then covers the flat
+ * repo, which has no manifest entry to read, and goes {@link MAX_PREFIX_DEPTH}
+ * deep because the directory a learning writes relative to is usually a source
+ * root nested inside a top-level one.
+ *
+ * Dot directories are included: `.claude/` and `.github/` hold files learnings
+ * cite constantly, and the only one worth skipping is named in
+ * {@link PREFIX_SCAN_SKIP}.
+ *
+ * Returned in forward-slash form: this is the wire format
+ * `memory/learnings-dead-paths.ts` composes with, not a host path.
+ */
+export function listWorkspacePrefixes(projectRoot: string): string[] {
+  const prefixes: string[] = [];
+  const add = (value: string): void => {
+    const clean = value.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '');
+    if (clean && !prefixes.includes(clean)) prefixes.push(clean);
+  };
+
+  try {
+    const manifest = JSON.parse(fs.readFileSync(pathModule.join(projectRoot, 'package.json'), 'utf-8'));
+    const declared: unknown = Array.isArray(manifest?.workspaces)
+      ? manifest.workspaces
+      : manifest?.workspaces?.packages;
+    for (const glob of Array.isArray(declared) ? declared : []) {
+      // `**` is left to the directory walk: expanding it means walking the whole
+      // tree, and the one level `*` covers is the shape every workspace uses.
+      if (typeof glob !== 'string' || glob.includes('**')) continue;
+      const star = glob.indexOf('*');
+      if (star === -1) {
+        add(glob);
+        continue;
+      }
+      const base = glob.slice(0, star).replace(/\/+$/, '');
+      const baseDir = pathModule.join(projectRoot, ...base.split('/').filter(Boolean));
+      for (const child of subdirectoryNames(baseDir)) add(base ? pathModule.posix.join(base, child) : child);
+    }
+  } catch {
+    /* No manifest, or not JSON. The directory walk below still applies. */
+  }
+
+  // Breadth-first, so every depth-1 prefix is in the list before any depth-2 one
+  // and the cap below never trades a shallower prefix for a deeper one.
+  let frontier = subdirectoryNames(projectRoot);
+  for (const name of frontier) add(name);
+
+  for (let depth = 2; depth <= MAX_PREFIX_DEPTH && frontier.length > 0; depth++) {
+    const next: string[] = [];
+    for (const parent of frontier) {
+      // Every descent past the cap costs a `readdirSync` for a prefix the slice
+      // below is about to discard.
+      if (prefixes.length >= MAX_WORKSPACE_PREFIXES) break;
+      const children = subdirectoryNames(pathModule.join(projectRoot, ...parent.split('/')));
+      if (children.length > MAX_CHILDREN_TO_DESCEND) continue;
+      for (const child of children) {
+        const nested = pathModule.posix.join(parent, child);
+        next.push(nested);
+        add(nested);
+      }
+    }
+    frontier = next;
+  }
+
+  return prefixes.slice(0, MAX_WORKSPACE_PREFIXES);
+}
+
+/**
+ * Existence check for one repo-relative path cited by a learning.
+ *
+ * Rule #1: the path arrives in the forward-slash form entries are authored with
+ * on every platform, is split on that, and is re-joined with `path.join`, so the
+ * string reaching the filesystem carries the host separator and this file never
+ * writes one. A file OR a directory counts — a moved directory is the same
+ * finding as a moved file.
+ *
+ * Existence is the host's own answer, case-folding included, so a citation that
+ * differs from the real file only in case reads as alive on NTFS/APFS and dead
+ * on a case-sensitive filesystem. That is deliberate: matching the platform is
+ * the only defensible definition of "still in the tree", and the divergence can
+ * only change whether an entry is NOMINATED — never whether one is archived,
+ * which takes a model verdict either way.
+ */
+export function makeTreeResolver(projectRoot: string): (relativePath: string) => boolean {
+  return (relativePath: string): boolean => {
+    const segments = relativePath.split('/').filter((s) => s.length > 0 && s !== '.');
+    // A traversal segment would resolve outside the project entirely, so it can
+    // say nothing about whether the repo still contains the cited file.
+    if (segments.length === 0 || segments.includes('..')) return false;
+    try {
+      return fs.existsSync(pathModule.join(projectRoot, ...segments));
+    } catch {
+      return false;
+    }
+  };
+}


### PR DESCRIPTION
Closes #1479.

## What

`flo memory audit-learnings` nominated on three signals, and all three read prose shape: near-duplicate embeddings, unused-and-old, and retired vocabulary. `/optimize-learnings` carried dead paths only as a *reading* heuristic — a shape Claude spots by eye on an entry something else already nominated. Nothing nominated them.

This adds a fourth bucket grounded in ground truth instead: a repo-relative path an entry cites either resolves in the tree or it does not. Unlike a vocabulary list it is portable — it resolves against the consumer's own tree and carries no project-specific data, so it ships useful rather than empty.

## Shape

| File | Role |
|---|---|
| `memory/learnings-dead-paths.ts` | Pure detector. Extracts path-shaped tokens from an entry, asks an injected `resolves` predicate about each. No disk. |
| `memory/learnings-tree.ts` | The filesystem half. Workspace-prefix discovery and the one `existsSync` crossing. |
| `memory/learnings-audit.ts` | Assembles the four passes; re-exports the detector so `learnings-audit.js` stays the audit's public surface. |
| `commands/memory-audit-learnings.ts` | Decides whether the pass runs, wires the resolver, prints the evidence. |

The detector was carved into its own module rather than added inline: in place it would have taken `learnings-audit.ts` to 800 lines against the 500-line cap in `src/CLAUDE.md`.

## It nominates, it never decides

A dead path has four causes and only a reader can tell them apart, so the judge prompt carries the table rather than the verdict:

| Why the cited path does not resolve | Verdict |
|---|---|
| The file **moved**; the lesson still holds | COMPRESS — keep the rule, correct or drop the path |
| Deleted, and the lesson was about that code | RETIRE |
| Deleted, but the lesson generalises past it | COMPRESS — drop the path, keep the rule |
| The entry is a **historical record**, correct as written | KEEP |

The move case is the common one. Reading "dead path" as "retire" throws away lessons that are still entirely true, so `--apply` still archives on a RETIRE verdict only — nominations alone change nothing.

## What is never scored

Every one of these resolves (or fails to) for reasons that say nothing about the entry:

- `node_modules/...` — whether it resolves says whether anyone ran an install
- anything containing `://` — a URL is not a tree path, and plenty end in `.json` or `.md`
- globs — a pattern has nothing to look up
- absolute, `~`-rooted, `../`-relative, and `SCREAMING_SNAKE/...` env-var-rooted paths — none are repo-relative
- bare filenames and extensionless pairs (`and/or`, `KEEP/RETIRE`) — too ambiguous to score

## Measured, not assumed

The full unit suite passed while the first real run over this repo's 139 learnings produced **12** nominations, 7 of them junk. Reading them surfaced two rejection classes the tests had not anticipated:

- citations relative to a nested source root — `commands/index.ts` meaning `src/cli/commands/index.ts` — which needed the prefix retry to go two directory levels deep, not one;
- env-var-rooted paths like `CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs`.

After both: **5 nominations from 139 entries**, all defensible. The prefix walk descends only into narrow container directories, so one wide scratch directory (`tmp/` full of test fixtures, here) cannot starve the prefix budget.

## Consumer impact

- **Surface**: `flo memory audit-learnings` — a hand-invoked curation command, not a hook or a hot path.
- **Failure mode for an existing consumer**: none. The bucket adds a table row and a `counts.deadPath` key to the JSON summary; nothing existing changes shape or meaning. `--apply` semantics are untouched, and archiving still requires a model verdict. `--no-dead-paths` skips the pass, and the report says so, so a `0` is never mistaken for a clean tree.
- **Round-trip**: publish-then-reinstall, like any CLI change.
- **Rule #3**: `SUPERSEDED_VOCABULARY` is untouched and still ships empty.

## Cross-platform (Rule #1)

The pure module composes with `path.posix.join` because the separator inside a learning is a wire format, not a host path; the single filesystem crossing re-joins with `path.join`. A backslash-authored path is normalised on input. The host's own case-folding is used deliberately and documented — it can only change whether an entry is *nominated*, never whether one is archived.

## Verification

- 52 new tests; full suite **11,290 passed / 0 failed**.
- `/flo-simplify` NORMAL tier (3 agents), then a validation pass. Fixed: reuse `COMMON_WALK_SKIP_NAMES` instead of a second skip-list that could drift; short-circuit the prefix walk at the cap instead of walking then slicing; hoist prefix normalisation out of the per-candidate loop; make the env-var first-segment test correct by construction; explicit re-exports over a wildcard.
- `/verify`: PASS on all six acceptance criteria.