### PR TITLE
feat(worktree): provisioned git worktrees via flo worktree (#1481)

### DIFF
--- a/.claude/guidance/shipped/moflo-cli-reference.md
+++ b/.claude/guidance/shipped/moflo-cli-reference.md
@@ -4,7 +4,7 @@
 
 ---
 
-## CLI Commands (26 Commands, 140+ Subcommands)
+## CLI Commands (27 Commands, 140+ Subcommands)
 
 ### Core Commands
 
@@ -40,6 +40,7 @@
 | `epic`        | 3           | Epic orchestrator — run/status/reset with single-branch or auto-merge strategy |
 | `doctor`      | 1           | System diagnostics with health checks                                         |
 | `completions` | 4           | Shell completions (bash, zsh, fish, powershell)                               |
+| `worktree`    | 3           | Provisioned git worktrees (add, list, remove) — alias `wt`                     |
 
 ### Quick Examples (MCP Preferred)
 
@@ -58,6 +59,49 @@ npx flo daemon start
 ```
 
 ---
+
+## Provisioned Worktrees (`flo worktree`)
+
+A bare `git worktree add` produces a valid checkout and an unrunnable workspace — no
+`node_modules`, none of the gitignored `.env` files, and dev servers that collide with the
+primary checkout on fixed ports. `flo worktree add` creates the worktree **and** provisions it.
+
+```bash
+flo worktree add feature/123-thing        # create + provision (this is what /flo -wt runs)
+flo worktree add feature/123 --json       # {"path":…,"branch":…,"index":0,"provisioned":true}
+flo worktree list                         # every worktree + its provisioning state
+flo worktree remove feature/123-thing     # refuses a dirty tree unless --force
+```
+
+Provisioning is driven by an optional `worktree:` block in `moflo.yaml`. **With no block, `add`
+creates the worktree and provisions nothing** — identical to a plain `git worktree add`.
+
+```yaml
+worktree:
+  dir: ../myrepo-worktrees   # default: <repo-parent>/<repo>-worktrees
+  copy: [".env", ".env.*"]   # gitignored files copied from the primary checkout
+  link: ["node_modules"]     # symlinked (junctioned on Windows) from the primary checkout
+  setup: "npm ci"            # run in the new worktree, with MOFLO_WORKTREE_INDEX in its env
+```
+
+| Key | Use it when | Watch out for |
+|-----|-------------|---------------|
+| `copy` | A fresh checkout is missing gitignored config a build needs | It relocates **secrets** outside the repo and outside its `.gitignore`. Sources must live inside the primary checkout; `../secrets` is rejected. |
+| `link` | `node_modules` is large and the project does not use npm workspaces | A symlinked root `node_modules` is fragile under npm/yarn workspaces — prefer `setup: npm ci` there. An existing destination is never clobbered. |
+| `setup` | Install/build steps must run per workspace | A non-zero exit marks the provision failed but leaves the worktree in place. |
+
+**Port collisions.** moflo cannot rewrite a project's hardcoded ports. It gives each worktree a
+small stable integer — unique among live worktrees, reused when one is removed — as
+`MOFLO_WORKTREE_INDEX` in the `setup` command's environment. Offset your own ports from it:
+
+```yaml
+worktree:
+  setup: "npm ci && node -e \"require('fs').writeFileSync('.env.local','PORT='+(3500+Number(process.env.MOFLO_WORKTREE_INDEX)*20))\""
+```
+
+Memory needs no setup: durable learnings already converge across a repo's worktrees
+automatically. See `moflo-cross-install-memory-sharing.md` for the snapshot recipe that also
+skips the structural cold-start.
 
 ## Available Agents
 

--- a/.claude/guidance/shipped/moflo-cross-install-memory-sharing.md
+++ b/.claude/guidance/shipped/moflo-cross-install-memory-sharing.md
@@ -138,3 +138,4 @@ A foreign-writer warning from the Writers Audit check (`flo doctor -c writers`) 
 - `.claude/guidance/moflo-memory-strategy.md` — Namespaces, RAG indexing, and the durable-vs-derived split this doc builds on
 - `.claude/guidance/moflo-memory-protocol.md` — Search-and-traverse protocol for the shared `learnings` once it is populated
 - `.claude/guidance/moflo-core-guidance.md` — CLI, daemon, and `moflo.yaml` reference (the `memory` config block)
+- `.claude/guidance/moflo-cli-reference.md` — `flo worktree`, which provisions a new worktree's gitignored files, `node_modules`, and per-workspace port index (memory sharing needs no setup; the rest of the workspace does)

--- a/.claude/skills/fl/phases.md
+++ b/.claude/skills/fl/phases.md
@@ -106,30 +106,35 @@ implementation, tests, simplify, commit, and PR from inside it. The current chec
 untouched. Durable learnings still converge automatically — a worktree shares the repo's
 `<git-common-dir>/moflo/durable.db` (see `/memory-worktree`).
 
-Compute paths with Node, never string-concatenate — the branch name contains `/`, and the
-worktree dir must sit **outside** the checkout on every OS (Rule #1: no hardcoded separators,
-no `/tmp`, no `mkdir -p`):
+Use `flo worktree add`. It computes the path, creates the branch off the repo's default
+branch, and **provisions** the tree per the optional `worktree:` block in `moflo.yaml` — copying
+gitignored `.env` material, linking `node_modules`, running a `setup` command. A fresh worktree is
+otherwise a valid checkout and an unrunnable workspace. Do not hand-roll the path or shell
+`git worktree add` directly: the path computation and the copy/link/setup steps are
+platform-sensitive (Rule #1) and live in tested code.
 
 ```bash
-# 1. Fresh base — update main in the current checkout first (worktrees share objects).
-git fetch origin main
-
-# 2. Resolve a sibling worktree path: <repo-parent>/<repo>-worktrees/<slugged-branch>
-#    Slug the branch's "/" to "-" so the dir is flat and valid on Windows/macOS/Linux.
-node -e "const p=require('path'),cp=require('child_process');const root=cp.execSync('git rev-parse --show-toplevel').toString().trim();const branch=process.argv[1];const slug=branch.replace(/[\\\\/]/g,'-');const dir=p.join(p.dirname(root),p.basename(root)+'-worktrees',slug);console.log(dir)" "<type>/<issue-number>-<short-desc>"
-
-# 3. Create the worktree + branch off origin/main in one step (the printed path from step 2).
-git worktree add -b <type>/<issue-number>-<short-desc> "<computed-path>" origin/main
+flo worktree add "<type>/<issue-number>-<short-desc>" --json
 ```
 
-Then `cd "<computed-path>"` and run **every** remaining phase (implement → tests → simplify →
-commit → PR) from there. Report the worktree path to the user. Leave the worktree in place
-after the PR — the user may want to inspect it; note that `git worktree remove "<path>"` cleans
-it up when done.
+It prints one JSON object — read `path` from it:
 
-If `git worktree add` fails because the path already exists (a prior run), reuse it:
-`cd "<computed-path>" && git status` and continue, or pick a `-2` suffix — do not delete a dir
-you did not just create.
+```json
+{"path":"/abs/path/to/repo-worktrees/type-123-slug","branch":"type/123-slug","index":0,"provisioned":true}
+```
+
+Then `cd` to that `path` and run **every** remaining phase (implement → tests → simplify → commit →
+PR) from there. Report the worktree path to the user.
+
+Notes:
+- `--from <ref>` overrides the base ref (default: the repo's default branch via `origin/HEAD`).
+- `provisioned: false` means a copy/link/setup step failed — the worktree is still a usable
+  checkout. Surface the failing step to the user rather than silently continuing to run tests that
+  will fail for want of a dependency.
+- If the branch's worktree already exists (a prior run), `add` reuses it rather than deleting it.
+- Leave the worktree in place after the PR — the user may want to inspect it. Clean up with
+  `flo worktree remove "<branch>"` (it refuses a tree with uncommitted changes unless `--force`).
+  `flo worktree list` shows every worktree and its provisioning state.
 
 ### 3.3 Implement
 Follow the plan from the ticket.

--- a/.claude/skills/fl/phases.md
+++ b/.claude/skills/fl/phases.md
@@ -114,8 +114,13 @@ otherwise a valid checkout and an unrunnable workspace. Do not hand-roll the pat
 platform-sensitive (Rule #1) and live in tested code.
 
 ```bash
-flo worktree add "<type>/<issue-number>-<short-desc>" --json
+cd "<repo-root>" && flo worktree add "<type>/<issue-number>-<short-desc>" --json
 ```
+
+Bind the repo root to the call. `flo worktree` resolves the repo from its working directory, and in
+Claude Code that resets between calls — run it from the wrong place and it silently targets a
+different repository (`Not a registered worktree of this repo` on the good day, the wrong repo's
+worktree on the bad one).
 
 It prints one JSON object — read `path` from it:
 
@@ -123,8 +128,32 @@ It prints one JSON object — read `path` from it:
 {"path":"/abs/path/to/repo-worktrees/type-123-slug","branch":"type/123-slug","index":0,"provisioned":true}
 ```
 
-Then `cd` to that `path` and run **every** remaining phase (implement → tests → simplify → commit →
-PR) from there. Report the worktree path to the user.
+Then run **every** remaining phase (implement → tests → simplify → commit → PR) against that
+`path`, and report it to the user.
+
+**A bare `cd` does not stick.** In Claude Code the Bash working directory resets to the project root
+after each call, so `cd <path>` in one call and `npm test` in the next runs the test in the WRONG
+tree — the primary checkout — and everything looks fine until the PR contains no changes. Bind the
+directory to each command instead:
+
+- shell commands — put the `cd` in the *same* call: `cd "<path>" && npm test`
+- git — prefer `git -C "<path>" status` over cd'ing at all
+- file edits — use the absolute path under `<path>`; never a repo-relative one
+
+**Fallback — `flo worktree` not available.** The command ships in the same package as this skill,
+so normally they move together. They can still drift apart: a `flo` binary on PATH older than the
+synced `.claude/skills/`, or a moflo source checkout whose change has not been published and
+reinstalled yet. If the command errors with `Unknown command: worktree`, do NOT stop — create the
+worktree the plain way and continue the run, noting to the user that provisioning was skipped:
+
+```bash
+git fetch origin
+node -e "const p=require('path'),cp=require('child_process');const root=cp.execSync('git rev-parse --show-toplevel').toString().trim();const branch=process.argv[1];const dir=p.join(p.dirname(root),p.basename(root)+'-worktrees',branch.replace(/[\\/]/g,'-'));console.log(dir)" "<type>/<issue-number>-<short-desc>"
+git worktree add -b "<type>/<issue-number>-<short-desc>" "<computed-path>" origin/main
+```
+
+The tree is then a valid checkout with no `node_modules` and no gitignored `.env` files — fine for a
+typecheck-only ticket, and not for one that runs the app.
 
 Notes:
 - `--from <ref>` overrides the base ref (default: the repo's default branch via `origin/HEAD`).

--- a/README.md
+++ b/README.md
@@ -349,6 +349,89 @@ Inside Claude Code, the `/flo` (or `/fl`) slash command drives GitHub issue exec
 
 Flags compose: e.g. `/flo -sd -m <issue>` runs the SDD cycle and auto-merges. Each modifier has a `--no-*` form (`--no-sdd`, `--no-verify`, `--no-merge`) to override a `moflo.yaml` default for a single run — including `--no-verify`, since verify-before-done is on by default. For full options and details, type `/flo` with no arguments — Claude Code will display the complete skill documentation. Also available as `/fl`.
 
+### Provisioned worktrees (`-w` / `flo worktree`)
+
+Running two tickets at once means two worktrees, and a bare `git worktree add` gives you a valid
+checkout that you cannot actually run: no `node_modules`, none of your gitignored `.env` files, and
+dev servers that fight the primary checkout over the same ports. `/flo -w` drives `flo worktree add`,
+which creates the worktree **and** provisions it.
+
+Provisioning is opt-in per project. **With no `worktree:` block in `moflo.yaml`, `flo worktree add`
+creates the worktree and provisions nothing** — exactly what a plain `git worktree add` would do.
+
+```yaml
+worktree:
+  dir: ../myrepo-worktrees   # default: <repo-parent>/<repo>-worktrees
+  copy: [".env", ".env.*"]   # gitignored files copied from the primary checkout
+  link: ["node_modules"]     # symlinked (junctioned on Windows) from the primary checkout
+  setup: "npm ci"            # run inside the new worktree after copy/link
+```
+
+| Key | Reach for it when | Watch out for |
+|-----|-------------------|---------------|
+| `copy` | A fresh checkout is missing gitignored config your build needs | It relocates **secrets** outside the repo, and outside its `.gitignore`. Sources must live inside the primary checkout — `../secrets` is refused. |
+| `link` | `node_modules` is large and you are not using npm workspaces | A symlinked root `node_modules` is fragile under npm/yarn workspaces — prefer `setup: npm ci` there. An existing path is never clobbered. |
+| `setup` | Install or build steps must run per workspace | A non-zero exit marks the provision failed but leaves the worktree in place. |
+
+**Ports.** MoFlo cannot rewrite your hardcoded ports — it has no way to know which files hold them.
+Instead each worktree gets a small integer, unique among live worktrees and reused when one is
+removed, exported to the `setup` command as `MOFLO_WORKTREE_INDEX`. Offset your own ports from it:
+
+```yaml
+worktree:
+  setup: "npm ci && node -e \"require('fs').writeFileSync('.env.local','PORT='+(3000+Number(process.env.MOFLO_WORKTREE_INDEX)*20))\""
+```
+
+`flo worktree remove` refuses a tree with uncommitted changes unless you pass `--force`, and names
+any gitignored files it discarded that provisioning did not create. MoFlo's own
+`.moflo/worktree.json` never counts as "uncommitted work" — otherwise every worktree it created
+would demand `--force` — but un-pushed specs under `.moflo/specs/` do.
+
+Memory needs no setup at all: durable learnings already converge across a repo's worktrees
+automatically — see [Sharing learnings across installations](#sharing-learnings-across-installations).
+
+#### Running it inside a Claude session
+
+`flo worktree` is a plain CLI command with no MCP wrapper, so it works the same whether you type it
+in a terminal or Claude runs it through Bash. `/flo -w` takes the second path — that is all the flag
+does.
+
+One thing to know if you drive it yourself from a session, and the reason `/flo -w` handles it for
+you: **Claude Code resets the Bash working directory to the project root after every call.** Two
+consequences, both silent when you get them wrong:
+
+```bash
+# ✗ the cd is gone by the next call — this resolves the WRONG repo
+cd path/to/repo
+flo worktree add feature/42-thing --json
+
+# ✓ bind the directory to the call
+cd path/to/repo && flo worktree add feature/42-thing --json
+```
+
+```bash
+# ✗ runs the tests in the PRIMARY checkout; the run goes green and the PR is empty
+cd "$WORKTREE"
+npm test
+
+# ✓ bind it, or skip cd entirely where the tool supports it
+cd "$WORKTREE" && npm test
+git -C "$WORKTREE" status
+```
+
+`flo worktree` resolves the repository from its working directory, so a call made from the wrong
+place targets a different repository — usually reported as `Not a registered worktree of this repo`,
+occasionally as work landing somewhere you did not intend. When editing files in the worktree, use
+absolute paths under the path `add` printed rather than repo-relative ones.
+
+Read the worktree location from `--json` rather than reconstructing it; the sibling-directory
+convention lives in one tested function, and a second copy of that rule will drift from it.
+
+If you are on a `flo` older than the skills synced into `.claude/` — which happens in a MoFlo source
+checkout before a change is published, or when a global `flo` lags the project's devDependency —
+the command reports `Unknown command: worktree`. `/flo -w` falls back to a plain `git worktree add`
+and tells you provisioning was skipped, rather than failing the run.
+
 ### Spec-Driven Development (SDD)
 
 `/flo` can run the full **spec → plan → (review) → implement → verify** cycle — the 2026 agentic-coding pattern — with two independent modifiers. Turning SDD on is opt-in, but once a run is armed for it (via `-sd` or `sdd.default`) **both halves are enforced**: the front half by an implement gate, the back half by verify-before-done.
@@ -635,6 +718,17 @@ flo gate check-before-scan       # Blocks Glob/Grep if memory not searched
 flo gate check-before-agent      # Blocks Agent tool if no TaskCreate
 flo gate prompt-reminder         # Context bracket tracking
 flo gate session-reset           # Reset gate state
+```
+
+### Worktrees
+
+```bash
+flo worktree add feature/123-thing   # Create a worktree and provision it (alias: flo wt)
+flo worktree add feature/123 --json  # {"path":…,"branch":…,"index":0,"provisioned":true}
+flo worktree add feature/123 --from v2.1.0    # Branch off a specific ref
+flo worktree add feature/123 --no-provision   # Create it, skip copy/link/setup
+flo worktree list                    # Every worktree and its provisioning state
+flo worktree remove feature/123-thing         # Refuses a dirty tree unless --force
 ```
 
 ### Diagnostics

--- a/src/cli/__tests__/worktree-command-1481.test.ts
+++ b/src/cli/__tests__/worktree-command-1481.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Integration tests for `flo worktree` (#1481) — add / list / remove against a
+ * real temporary git repository.
+ *
+ * These drive the command's `action` directly rather than spawning `flo`, so a
+ * failure points at the handler instead of at CLI plumbing, and so the suite
+ * stays fast enough to run in the default pass. Everything happens under
+ * `os.tmpdir()`; nothing touches the developer's repo.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import worktreeCommand from '../commands/worktree.js';
+import type { CommandContext, CommandResult } from '../types.js';
+import { WORKTREE_STATE_FILE } from '../services/worktree-provision.js';
+
+let root: string;
+let repo: string;
+let logs: string[];
+
+function git(args: string[], cwd: string): void {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  if (result.status !== 0) throw new Error(`git ${args.join(' ')}: ${result.stderr}`);
+}
+
+/** Build a CommandContext the way the CLI parser would. */
+function ctx(args: string[], flags: Record<string, unknown> = {}, cwd = repo): CommandContext {
+  return { args, flags: { _: [], ...flags } as CommandContext['flags'], cwd, interactive: false };
+}
+
+const run = (c: CommandContext): Promise<CommandResult> =>
+  worktreeCommand.action!(c) as Promise<CommandResult>;
+
+/** The last JSON object printed to stdout by the command under test. */
+function lastJson<T = Record<string, unknown>>(): T {
+  return JSON.parse(logs[logs.length - 1]) as T;
+}
+
+beforeEach(() => {
+  logs = [];
+  vi.spyOn(console, 'log').mockImplementation((...parts: unknown[]) => {
+    logs.push(parts.map(String).join(' '));
+  });
+  root = mkdtempSync(join(tmpdir(), 'moflo-wtcmd-'));
+  repo = join(root, 'repo');
+  mkdirSync(repo, { recursive: true });
+  git(['init', '-q', '-b', 'main', '.'], repo);
+  git(['config', 'user.email', 'test@example.com'], repo);
+  git(['config', 'user.name', 'test'], repo);
+  writeFileSync(join(repo, 'README.md'), 'hi\n');
+  writeFileSync(join(repo, '.gitignore'), 'node_modules\n.env\n');
+  git(['add', '-A'], repo);
+  git(['commit', '-qm', 'init'], repo);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(root, { recursive: true, force: true });
+});
+
+const writeConfig = (yaml: string): void => {
+  writeFileSync(join(repo, 'moflo.yaml'), yaml);
+};
+
+// ============================================================================
+// AC1 — add
+// ============================================================================
+
+describe('#1481 flo worktree add (AC1)', () => {
+  it('creates the worktree at the sibling path and reports it as JSON', async () => {
+    const result = await run(ctx(['add', 'feature/1481-x'], { from: 'main', json: true }));
+    expect(result.success).toBe(true);
+    const out = lastJson<{ path: string; branch: string; index: number; provisioned: boolean }>();
+    expect(out.path).toBe(join(root, 'repo-worktrees', 'feature-1481-x'));
+    expect(out.branch).toBe('feature/1481-x');
+    expect(out.index).toBe(0);
+    expect(existsSync(join(out.path, 'README.md'))).toBe(true);
+  });
+
+  it('creates the branch, off the ref given by --from', async () => {
+    await run(ctx(['add', 'feature/a'], { from: 'main', json: true }));
+    const branches = spawnSync('git', ['branch', '--list', 'feature/a'], { cwd: repo, encoding: 'utf8' });
+    expect(branches.stdout).toContain('feature/a');
+  });
+
+  it('requires a branch name', async () => {
+    const result = await run(ctx(['add'], {}));
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Usage');
+  });
+
+  it('refuses a path that exists but is not a registered worktree', async () => {
+    mkdirSync(join(root, 'repo-worktrees', 'feature-x'), { recursive: true });
+    const result = await run(ctx(['add', 'feature/x'], { from: 'main' }));
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('not a registered worktree');
+  });
+
+  it('reuses an existing worktree for the same branch rather than recreating it', async () => {
+    const first = await run(ctx(['add', 'feature/reuse'], { from: 'main', json: true }));
+    expect(first.success).toBe(true);
+    const path = lastJson<{ path: string }>().path;
+    writeFileSync(join(path, 'in-progress.txt'), 'work');
+
+    const second = await run(ctx(['add', 'feature/reuse'], { from: 'main', json: true }));
+    expect(second.success).toBe(true);
+    // A prior run may have left work here; deleting it is never this command's call.
+    expect(readFileSync(join(path, 'in-progress.txt'), 'utf8')).toBe('work');
+  });
+});
+
+// ============================================================================
+// AC5 — no-config parity (the consumer-upgrade case)
+// ============================================================================
+
+describe('#1481 no worktree: block (AC5)', () => {
+  it('creates the worktree and provisions nothing', async () => {
+    writeFileSync(join(repo, '.env'), 'SECRET=1');
+    const result = await run(ctx(['add', 'feature/plain'], { from: 'main', json: true }));
+    expect(result.success).toBe(true);
+    const out = lastJson<{ path: string; steps: unknown[] }>();
+    expect(out.steps).toEqual([]);
+    // Behaviourally identical to the inline recipe this replaced.
+    expect(existsSync(join(out.path, '.env'))).toBe(false);
+    expect(existsSync(join(out.path, WORKTREE_STATE_FILE))).toBe(true);
+  });
+
+  it('exits 0 — nothing configured is not a failure', async () => {
+    const result = await run(ctx(['add', 'feature/plain'], { from: 'main' }));
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+// ============================================================================
+// AC4 — configured provisioning
+// ============================================================================
+
+describe('#1481 configured provisioning (AC4)', () => {
+  it('copies, links and runs setup', async () => {
+    writeFileSync(join(repo, '.env'), 'SECRET=1');
+    mkdirSync(join(repo, 'node_modules', 'pkg'), { recursive: true });
+    writeConfig(
+      'project:\n  name: t\nworktree:\n  copy: ".env"\n  link: "node_modules"\n' +
+        `  setup: "node -e \\"require('fs').writeFileSync('idx.txt', process.env.MOFLO_WORKTREE_INDEX)\\""\n`,
+    );
+    const result = await run(ctx(['add', 'feature/full'], { from: 'main', json: true }));
+    expect(result.success).toBe(true);
+    const path = lastJson<{ path: string }>().path;
+    // .env is gitignored, so the checkout cannot have supplied it.
+    expect(readFileSync(join(path, '.env'), 'utf8')).toBe('SECRET=1');
+    expect(existsSync(join(path, 'node_modules', 'pkg'))).toBe(true);
+    expect(readFileSync(join(path, 'idx.txt'), 'utf8')).toBe('0');
+  });
+
+  it('exits non-zero and reports the step when provisioning fails', async () => {
+    writeConfig('project:\n  name: t\nworktree:\n  setup: "node -e \\"process.exit(4)\\""\n');
+    const result = await run(ctx(['add', 'feature/failing'], { from: 'main', json: true }));
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    const out = lastJson<{ path: string; provisioned: boolean; steps: Array<{ status: string }> }>();
+    expect(out.provisioned).toBe(false);
+    expect(out.steps[0].status).toBe('failed');
+    // The worktree is a valid checkout either way — never unwound.
+    expect(existsSync(out.path)).toBe(true);
+  });
+
+  it('honors a configured dir', async () => {
+    writeConfig('project:\n  name: t\nworktree:\n  dir: ../trees\n');
+    await run(ctx(['add', 'feature/d'], { from: 'main', json: true }));
+    expect(lastJson<{ path: string }>().path).toBe(join(root, 'trees', 'feature-d'));
+  });
+});
+
+// ============================================================================
+// AC6 — index allocation across worktrees
+// ============================================================================
+
+describe('#1481 index allocation (AC6)', () => {
+  it('gives successive worktrees distinct indices and reuses a freed one', async () => {
+    await run(ctx(['add', 'feature/one'], { from: 'main', json: true }));
+    expect(lastJson<{ index: number }>().index).toBe(0);
+    await run(ctx(['add', 'feature/two'], { from: 'main', json: true }));
+    expect(lastJson<{ index: number }>().index).toBe(1);
+
+    await run(ctx(['remove', 'feature/one'], {}));
+    await run(ctx(['add', 'feature/three'], { from: 'main', json: true }));
+    // Reused, not incremented — consumers derive ports from this.
+    expect(lastJson<{ index: number }>().index).toBe(0);
+  });
+
+  it('skips provisioning on --no-provision but still records state and exits 0', async () => {
+    writeFileSync(join(repo, '.env'), 'SECRET=1');
+    writeConfig('project:\n  name: t\nworktree:\n  copy: ".env"\n');
+    // The parser turns `--no-provision` into `provision: false` (#1474).
+    const result = await run(ctx(['add', 'feature/skip'], { from: 'main', json: true, provision: false }));
+    expect(result.exitCode).toBe(0);
+    const out = lastJson<{ path: string; steps: unknown[] }>();
+    expect(out.steps).toEqual([]);
+    expect(existsSync(join(out.path, '.env'))).toBe(false);
+    expect(existsSync(join(out.path, WORKTREE_STATE_FILE))).toBe(true);
+  });
+});
+
+// ============================================================================
+// AC2 — list
+// ============================================================================
+
+describe('#1481 flo worktree list (AC2)', () => {
+  it('marks a moflo-created worktree managed and an external one unmanaged', async () => {
+    await run(ctx(['add', 'feature/managed'], { from: 'main', json: true }));
+    git(['worktree', 'add', '-b', 'feature/external', join(root, 'external'), 'main'], repo);
+
+    await run(ctx(['list'], { json: true }));
+    const entries = lastJson<Array<{ branch: string; managed: boolean; primary: boolean; index: number | null }>>();
+    const managed = entries.find(e => e.branch === 'feature/managed');
+    const external = entries.find(e => e.branch === 'feature/external');
+    expect(managed).toMatchObject({ managed: true, primary: false, index: 0 });
+    expect(external).toMatchObject({ managed: false, primary: false, index: null });
+  });
+
+  it('flags the primary working tree', async () => {
+    await run(ctx(['list'], { json: true }));
+    const entries = lastJson<Array<{ branch: string; primary: boolean }>>();
+    expect(entries[0]).toMatchObject({ branch: 'main', primary: true });
+  });
+});
+
+// ============================================================================
+// AC3 — remove
+// ============================================================================
+
+describe('#1481 flo worktree remove (AC3)', () => {
+  it('removes by branch name', async () => {
+    await run(ctx(['add', 'feature/gone'], { from: 'main', json: true }));
+    const path = lastJson<{ path: string }>().path;
+    const result = await run(ctx(['remove', 'feature/gone'], {}));
+    expect(result.success).toBe(true);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it('removes by path', async () => {
+    await run(ctx(['add', 'feature/bypath'], { from: 'main', json: true }));
+    const path = lastJson<{ path: string }>().path;
+    const result = await run(ctx(['remove', path], {}));
+    expect(result.success).toBe(true);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it('refuses a dirty worktree without --force, and removes it with', async () => {
+    await run(ctx(['add', 'feature/dirty'], { from: 'main', json: true }));
+    const path = lastJson<{ path: string }>().path;
+    writeFileSync(join(path, 'README.md'), 'changed\n');
+
+    const refused = await run(ctx(['remove', 'feature/dirty'], {}));
+    expect(refused.success).toBe(false);
+    expect(refused.message).toContain('uncommitted changes');
+    expect(existsSync(path)).toBe(true);
+
+    const forced = await run(ctx(['remove', 'feature/dirty'], { force: true }));
+    expect(forced.success).toBe(true);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("removes a freshly created worktree without --force (moflo's own .moflo/ is not user work)", async () => {
+    // Regression: `add` writes .moflo/worktree.json, which is untracked in a
+    // project that does not gitignore `.moflo/`. Counting that as a user change
+    // made every managed worktree unremovable without --force, which trains the
+    // user to always pass it and defeats the dirty-tree guard entirely.
+    await run(ctx(['add', 'feature/fresh'], { from: 'main', json: true }));
+    const path = lastJson<{ path: string }>().path;
+    expect(existsSync(join(path, WORKTREE_STATE_FILE))).toBe(true);
+    const status = spawnSync('git', ['status', '--porcelain'], { cwd: path, encoding: 'utf8' });
+    expect(status.stdout).toContain('.moflo');
+
+    const result = await run(ctx(['remove', 'feature/fresh'], {}));
+    expect(result.success).toBe(true);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it('still refuses when user work sits alongside the moflo state file', async () => {
+    await run(ctx(['add', 'feature/mixed'], { from: 'main', json: true }));
+    const path = lastJson<{ path: string }>().path;
+    writeFileSync(join(path, 'scratch.txt'), 'work');
+    const result = await run(ctx(['remove', 'feature/mixed'], {}));
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('scratch.txt');
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it('refuses a path that is not a registered worktree of this repo', async () => {
+    const stranger = join(root, 'stranger');
+    mkdirSync(stranger, { recursive: true });
+    const result = await run(ctx(['remove', stranger], {}));
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Not a registered worktree');
+    expect(existsSync(stranger)).toBe(true);
+  });
+
+  it('refuses to remove the primary working tree', async () => {
+    const result = await run(ctx(['remove', 'main'], {}));
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('primary working tree');
+    expect(existsSync(repo)).toBe(true);
+  });
+
+  it('requires an argument', async () => {
+    const result = await run(ctx(['remove'], {}));
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Usage');
+  });
+});
+
+// ============================================================================
+// AC10 — help surface
+// ============================================================================
+
+describe('#1481 help surface (AC10)', () => {
+  it('prints usage listing all three subcommands and exits 0 with no subcommand', async () => {
+    const result = await run(ctx([], {}));
+    expect(result.exitCode).toBe(0);
+    const help = logs.join('\n');
+    for (const sub of ['add', 'list', 'remove']) expect(help).toContain(sub);
+    expect(help).toContain('worktree:');
+  });
+
+  it('exits 1 on an unknown subcommand', async () => {
+    const result = await run(ctx(['bogus'], {}));
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+  });
+});

--- a/src/cli/__tests__/worktree-command-1481.test.ts
+++ b/src/cli/__tests__/worktree-command-1481.test.ts
@@ -110,6 +110,21 @@ describe('#1481 flo worktree add (AC1)', () => {
     // A prior run may have left work here; deleting it is never this command's call.
     expect(readFileSync(join(path, 'in-progress.txt'), 'utf8')).toBe('work');
   });
+
+  it('KEEPS the existing index when re-adding the same branch', async () => {
+    // Regression: `existing` includes the already-registered worktree, so
+    // allocating afresh handed a re-add a NEW index and rewrote worktree.json —
+    // silently shifting every port a consumer derived from MOFLO_WORKTREE_INDEX
+    // in a tree they were already working in.
+    await run(ctx(['add', 'feature/first'], { from: 'main', json: true }));
+    await run(ctx(['add', 'feature/second'], { from: 'main', json: true }));
+    expect(lastJson<{ index: number }>().index).toBe(1);
+
+    await run(ctx(['add', 'feature/first'], { from: 'main', json: true }));
+    expect(lastJson<{ index: number }>().index).toBe(0);
+    await run(ctx(['add', 'feature/second'], { from: 'main', json: true }));
+    expect(lastJson<{ index: number }>().index).toBe(1);
+  });
 });
 
 // ============================================================================
@@ -280,6 +295,21 @@ describe('#1481 flo worktree remove (AC3)', () => {
     expect(existsSync(path)).toBe(false);
   });
 
+  it('refuses when un-pushed SDD specs live in the worktree .moflo/ directory', async () => {
+    // Only .moflo/worktree.json is excused — never the whole .moflo/ directory.
+    // A worktree can hold un-pushed spec/plan work under .moflo/specs/, and
+    // `remove` forces past git's own check, so missing this would delete it.
+    await run(ctx(['add', 'feature/specs'], { from: 'main', json: true }));
+    const path = lastJson<{ path: string }>().path;
+    mkdirSync(join(path, '.moflo', 'specs', 'thing'), { recursive: true });
+    writeFileSync(join(path, '.moflo', 'specs', 'thing', 'spec.md'), '# spec\n');
+
+    const result = await run(ctx(['remove', 'feature/specs'], {}));
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('spec.md');
+    expect(existsSync(join(path, '.moflo', 'specs', 'thing', 'spec.md'))).toBe(true);
+  });
+
   it('still refuses when user work sits alongside the moflo state file', async () => {
     await run(ctx(['add', 'feature/mixed'], { from: 'main', json: true }));
     const path = lastJson<{ path: string }>().path;
@@ -288,6 +318,28 @@ describe('#1481 flo worktree remove (AC3)', () => {
     expect(result.success).toBe(false);
     expect(result.message).toContain('scratch.txt');
     expect(existsSync(path)).toBe(true);
+  });
+
+  it('names the gitignored paths it destroyed that provisioning did not create', async () => {
+    // `git status --porcelain` never lists ignored files, so the dirty gate
+    // cannot see them — but removing the worktree deletes them. Warn, never
+    // block: a project whose setup ran `npm ci` would otherwise be blocked on
+    // every single removal.
+    writeConfig('project:\n  name: t\nworktree:\n  copy: ".env"\n');
+    writeFileSync(join(repo, '.env'), 'SECRET=1');
+    await run(ctx(['add', 'feature/ignored'], { from: 'main', json: true }));
+    const path = lastJson<{ path: string }>().path;
+    writeFileSync(join(path, 'node_modules-note.txt'), 'x');
+    mkdirSync(join(path, 'node_modules'), { recursive: true });
+    writeFileSync(join(path, 'node_modules', 'installed.txt'), 'x');
+
+    const result = await run(ctx(['remove', 'feature/ignored'], { json: true, force: true }));
+    expect(result.success).toBe(true);
+    const out = lastJson<{ discardedIgnored: string[] }>();
+    // node_modules is gitignored and was NOT provisioned here, so it is named.
+    expect(out.discardedIgnored.some(p => p.startsWith('node_modules'))).toBe(true);
+    // .env was copied in by provisioning and still exists in the primary — noise.
+    expect(out.discardedIgnored).not.toContain('.env');
   });
 
   it('refuses a path that is not a registered worktree of this repo', async () => {

--- a/src/cli/__tests__/worktree-command-1481.test.ts
+++ b/src/cli/__tests__/worktree-command-1481.test.ts
@@ -342,6 +342,20 @@ describe('#1481 flo worktree remove (AC3)', () => {
     expect(out.discardedIgnored).not.toContain('.env');
   });
 
+  it('does not misattribute a GLOB-provisioned file as unprovisioned', async () => {
+    writeConfig('project:\n  name: t\nworktree:\n  copy: ".env.*"\n');
+    writeFileSync(join(repo, '.gitignore'), 'node_modules\n.env\n.env.*\n');
+    writeFileSync(join(repo, '.env.local'), 'A=1');
+    git(['commit', '-aqm', 'ignore env globs'], repo);
+    await run(ctx(['add', 'feature/globbed'], { from: 'main', json: true }));
+
+    const result = await run(ctx(['remove', 'feature/globbed'], { json: true, force: true }));
+    expect(result.success).toBe(true);
+    // `.env.*` must match the concrete `.env.local` git reports, or provisioning
+    // gets blamed for its own file on every removal.
+    expect(lastJson<{ discardedIgnored: string[] }>().discardedIgnored).not.toContain('.env.local');
+  });
+
   it('refuses a path that is not a registered worktree of this repo', async () => {
     const stranger = join(root, 'stranger');
     mkdirSync(stranger, { recursive: true });

--- a/src/cli/__tests__/worktree-provision-1481.test.ts
+++ b/src/cli/__tests__/worktree-provision-1481.test.ts
@@ -32,9 +32,9 @@ import {
   WORKTREE_STATE_FILE_POSIX,
   computeWorktreePath,
   isInside,
+  isProvisionedPath,
   linkTypeForPlatform,
   resolveForCompare,
-  samePath,
   provisionWorktree,
   readWorktreeState,
   slugifyBranch,
@@ -153,31 +153,33 @@ describe('#1481 isInside (AC7, AC8)', () => {
   });
 });
 
-describe('#1481 samePath / resolveForCompare (AC3, AC8)', () => {
-  it('identifies two spellings of the same directory', () => {
+describe('#1481 resolveForCompare (AC3, AC8)', () => {
+  it('produces the same key for two spellings of one directory', () => {
     mkdirSync(join(root, 'a', 'b'), { recursive: true });
-    expect(samePath(join(root, 'a', 'b'), join(root, 'a', '..', 'a', 'b'))).toBe(true);
-    expect(samePath(join(root, 'a'), join(root, 'a', 'b'))).toBe(false);
+    const key = resolveForCompare(join(root, 'a', 'b'));
+    expect(resolveForCompare(join(root, 'a', '..', 'a', 'b'))).toBe(key);
+    expect(resolveForCompare(join(root, 'a'))).not.toBe(key);
   });
 
   it('sees through a symlink on both sides', () => {
     const real = join(root, 'real');
     mkdirSync(real, { recursive: true });
     symlinkSync(real, join(root, 'linked'));
-    expect(samePath(real, join(root, 'linked'))).toBe(true);
+    expect(resolveForCompare(join(root, 'linked'))).toBe(resolveForCompare(real));
   });
 
-  it('produces a stable key so a caller can resolve its needle once', () => {
-    mkdirSync(join(root, 'a'), { recursive: true });
-    const key = resolveForCompare(join(root, 'a'));
-    expect(resolveForCompare(join(root, 'a', '..', 'a'))).toBe(key);
-    // Case-folded on the platforms whose filesystems are case-insensitive, so
-    // plain string equality on the key is a correct identity test there.
+  it('case-folds exactly on the platforms with a case-insensitive filesystem', () => {
+    // This is what makes plain string equality on the key a correct identity
+    // test on win32/APFS, where `C:\\Repo` and `C:\\repo` are one directory.
+    mkdirSync(join(root, 'MixedCase'), { recursive: true });
+    const key = resolveForCompare(join(root, 'MixedCase'));
     if (process.platform === 'win32' || process.platform === 'darwin') {
       expect(key).toBe(key.toLowerCase());
+    } else {
+      expect(key).toContain('MixedCase');
     }
   });
-});
+})
 
 // ============================================================================
 // AC7 — copy
@@ -541,6 +543,46 @@ describe('#1481 moflo.yaml worktree block (AC4, AC5)', () => {
   it('drops non-string entries from copy/link', () => {
     writeConfig('project:\n  name: t\nworktree:\n  copy: [".env", 42, null]\n');
     expect(loadMofloConfig(root).worktree).toEqual({ copy: ['.env'] });
+  });
+});
+
+// ============================================================================
+// AC3 — attributing a worktree path back to provisioning
+// ============================================================================
+
+describe('#1481 isProvisionedPath (AC3)', () => {
+  it('matches a GLOB copy entry against the concrete filename git reports', () => {
+    // The bug this exists to prevent: comparing `.env.*` literally against
+    // `.env.local` never matches, so `remove` blamed provisioning's own files
+    // on the user on every single removal.
+    const config = { copy: ['.env.*'] };
+    expect(isProvisionedPath('.env.local', config)).toBe(true);
+    expect(isProvisionedPath('.env.test', config)).toBe(true);
+    expect(isProvisionedPath('scratch.txt', config)).toBe(false);
+  });
+
+  it('matches literal file and directory entries', () => {
+    const config = { copy: ['.env'], link: ['node_modules'] };
+    expect(isProvisionedPath('.env', config)).toBe(true);
+    expect(isProvisionedPath('node_modules', config)).toBe(true);
+    // `git status -uall` reports a directory's files individually.
+    expect(isProvisionedPath('node_modules/pkg/index.js', config)).toBe(true);
+    expect(isProvisionedPath('node_modules-backup', config)).toBe(false);
+  });
+
+  it('claims the contents of a directory a glob entry matched', () => {
+    expect(isProvisionedPath('cfgs/a.json', { copy: ['cfg*'] })).toBe(true);
+    expect(isProvisionedPath('other/a.json', { copy: ['cfg*'] })).toBe(false);
+  });
+
+  it('matches a nested entry written with either separator', () => {
+    expect(isProvisionedPath('config/local.json', { copy: ['config/local.json'] })).toBe(true);
+    expect(isProvisionedPath('config/local.json', { copy: ['config\\local.json'] })).toBe(true);
+  });
+
+  it('claims nothing when no block is configured', () => {
+    expect(isProvisionedPath('.env', undefined)).toBe(false);
+    expect(isProvisionedPath('.env', {})).toBe(false);
   });
 });
 

--- a/src/cli/__tests__/worktree-provision-1481.test.ts
+++ b/src/cli/__tests__/worktree-provision-1481.test.ts
@@ -29,9 +29,12 @@ import { loadMofloConfig } from '../config/moflo-config.js';
 import {
   WORKTREE_STATE_FILE,
   allocateIndex,
+  WORKTREE_STATE_FILE_POSIX,
   computeWorktreePath,
   isInside,
   linkTypeForPlatform,
+  resolveForCompare,
+  samePath,
   provisionWorktree,
   readWorktreeState,
   slugifyBranch,
@@ -139,6 +142,41 @@ describe('#1481 isInside (AC7, AC8)', () => {
   it('works for a destination that does not exist yet', () => {
     expect(isInside(root, join(root, 'not', 'created', 'yet'))).toBe(true);
   });
+
+  it('treats a path as inside ITSELF even when the equality shortcut misses', () => {
+    // `path.relative` returns '' for two spellings of the same directory that
+    // string equality missed (case differences on win32/APFS). A `rel.length > 0`
+    // guard would call that "not inside" and break every identity test built on
+    // this — remove-by-path and the already-registered scan both depend on it.
+    expect(isInside(root, root)).toBe(true);
+    expect(isInside(join(root, 'a', '..'), root)).toBe(true);
+  });
+});
+
+describe('#1481 samePath / resolveForCompare (AC3, AC8)', () => {
+  it('identifies two spellings of the same directory', () => {
+    mkdirSync(join(root, 'a', 'b'), { recursive: true });
+    expect(samePath(join(root, 'a', 'b'), join(root, 'a', '..', 'a', 'b'))).toBe(true);
+    expect(samePath(join(root, 'a'), join(root, 'a', 'b'))).toBe(false);
+  });
+
+  it('sees through a symlink on both sides', () => {
+    const real = join(root, 'real');
+    mkdirSync(real, { recursive: true });
+    symlinkSync(real, join(root, 'linked'));
+    expect(samePath(real, join(root, 'linked'))).toBe(true);
+  });
+
+  it('produces a stable key so a caller can resolve its needle once', () => {
+    mkdirSync(join(root, 'a'), { recursive: true });
+    const key = resolveForCompare(join(root, 'a'));
+    expect(resolveForCompare(join(root, 'a', '..', 'a'))).toBe(key);
+    // Case-folded on the platforms whose filesystems are case-insensitive, so
+    // plain string equality on the key is a correct identity test there.
+    if (process.platform === 'win32' || process.platform === 'darwin') {
+      expect(key).toBe(key.toLowerCase());
+    }
+  });
 });
 
 // ============================================================================
@@ -174,6 +212,20 @@ describe('#1481 provision copy (AC7)', () => {
     expect(existsSync(join(worktree, '.env.test'))).toBe(true);
     // Anchored: `.env.*` must not match `my.env.backup`.
     expect(existsSync(join(worktree, 'my.env.backup'))).toBe(false);
+  });
+
+  it('does not let a dot in the pattern match an arbitrary character', () => {
+    // The `docs/*.md` matching `docsXmd` shape the shared translator was
+    // hardened against: the `.` must be escaped, not treated as a wildcard.
+    writeFileSync(join(root, '.envXlocal'), 'A');
+    provisionWorktree({
+      primaryRoot: root,
+      worktreePath: worktree,
+      branch: 'b',
+      index: 0,
+      config: { copy: ['.env.*'] },
+    });
+    expect(existsSync(join(worktree, '.envXlocal'))).toBe(false);
   });
 
   it('rejects a source resolving outside the primary checkout', () => {
@@ -287,6 +339,52 @@ describe('#1481 provision link (AC7, AC8)', () => {
     expect(result.steps[0]).toMatchObject({ kind: 'link', status: 'skipped' });
   });
 
+  it('rejects a link entry that escapes the primary checkout', () => {
+    const primary = join(root, 'primary');
+    mkdirSync(join(root, 'outside', 'nm'), { recursive: true });
+    mkdirSync(primary, { recursive: true });
+    const result = provisionWorktree({
+      primaryRoot: primary,
+      worktreePath: worktree,
+      branch: 'b',
+      index: 0,
+      config: { link: ['../outside/nm'] },
+    });
+    // Same guard runCopy has: without it the link is written outside the
+    // worktree and sources from outside the checkout.
+    expect(result.provisioned).toBe(false);
+    expect(result.steps[0]).toMatchObject({ kind: 'link', status: 'failed' });
+    expect(existsSync(join(root, 'outside', 'nm', 'x'))).toBe(false);
+  });
+
+  it('re-links cleanly on a RE-ADD, when the destination is already a symlink out of the tree', () => {
+    // Regression from the escape guard: realpathing the destination resolves an
+    // existing node_modules symlink back to the primary checkout, which reads as
+    // "outside the worktree" and rejects the very link provisioning just made.
+    mkdirSync(join(root, 'node_modules', 'pkg'), { recursive: true });
+    const config = { link: ['node_modules'] };
+    const first = provisionWorktree({ primaryRoot: root, worktreePath: worktree, branch: 'b', index: 0, config });
+    expect(first.provisioned).toBe(true);
+    const second = provisionWorktree({ primaryRoot: root, worktreePath: worktree, branch: 'b', index: 0, config });
+    expect(second.provisioned).toBe(true);
+    expect(second.steps[0]).toMatchObject({ kind: 'link', status: 'skipped', detail: 'already exists' });
+  });
+
+  it('links a primary path that is itself a symlink (pnpm / shared store)', () => {
+    const store = join(root, 'store');
+    mkdirSync(join(store, 'pkg'), { recursive: true });
+    symlinkSync(store, join(root, 'node_modules'));
+    const result = provisionWorktree({
+      primaryRoot: root,
+      worktreePath: worktree,
+      branch: 'b',
+      index: 0,
+      config: { link: ['node_modules'] },
+    });
+    expect(result.provisioned).toBe(true);
+    expect(existsSync(join(worktree, 'node_modules', 'pkg'))).toBe(true);
+  });
+
   it('skips a link source that does not exist', () => {
     const result = provisionWorktree({
       primaryRoot: root,
@@ -380,6 +478,13 @@ describe('#1481 worktree state file (AC2, AC6)', () => {
     expect(readWorktreeState(worktree)).toBeNull();
     writeFileSync(join(worktree, WORKTREE_STATE_FILE), '{"branch":1}');
     expect(readWorktreeState(worktree)).toBeNull();
+  });
+
+  it('exposes the state path in git spelling for porcelain comparison', () => {
+    // `git status --porcelain` reports forward slashes on every platform, so a
+    // caller comparing against it needs this form, not the host-separator one.
+    expect(WORKTREE_STATE_FILE_POSIX).toBe('.moflo/worktree.json');
+    expect(WORKTREE_STATE_FILE_POSIX).toBe(WORKTREE_STATE_FILE.split(sep).join('/'));
   });
 
   it('round-trips through writeWorktreeState', () => {

--- a/src/cli/__tests__/worktree-provision-1481.test.ts
+++ b/src/cli/__tests__/worktree-provision-1481.test.ts
@@ -25,7 +25,7 @@ import {
 } from 'node:fs';
 import { join, sep, dirname, basename, isAbsolute } from 'node:path';
 import { tmpdir } from 'node:os';
-import { loadMofloConfig } from '../config/moflo-config.js';
+import { generateMofloConfig, loadMofloConfig } from '../config/moflo-config.js';
 import {
   WORKTREE_STATE_FILE,
   allocateIndex,
@@ -541,6 +541,32 @@ describe('#1481 moflo.yaml worktree block (AC4, AC5)', () => {
   it('drops non-string entries from copy/link', () => {
     writeConfig('project:\n  name: t\nworktree:\n  copy: [".env", 42, null]\n');
     expect(loadMofloConfig(root).worktree).toEqual({ copy: ['.env'] });
+  });
+});
+
+// ============================================================================
+// AC10 — the generated moflo.yaml documents the surface
+// ============================================================================
+
+describe('#1481 moflo.yaml template (AC10)', () => {
+  const template = generateMofloConfig(root);
+
+  it('ships a commented worktree block naming every key', () => {
+    expect(template).toMatch(/# worktree:/);
+    for (const key of ['dir:', 'copy:', 'link:', 'setup:']) expect(template).toContain(key);
+  });
+
+  it('documents the port-offset contract and the secret-relocation caveat', () => {
+    // These two are the surprising parts: a consumer cannot discover the env
+    // var from the schema, and `copy:` moving secrets outside the repo is the
+    // kind of thing that must be stated where the user configures it.
+    expect(template).toContain('MOFLO_WORKTREE_INDEX');
+    expect(template).toMatch(/secret/i);
+  });
+
+  it('stays commented out, so a fresh project provisions nothing by default', () => {
+    const active = template.split(/\r?\n/).filter(l => /^worktree:/.test(l));
+    expect(active).toEqual([]);
   });
 });
 

--- a/src/cli/__tests__/worktree-provision-1481.test.ts
+++ b/src/cli/__tests__/worktree-provision-1481.test.ts
@@ -1,0 +1,498 @@
+/**
+ * Tests for worktree provisioning (#1481) — `src/cli/services/worktree-provision.ts`
+ * and the `worktree:` block in `moflo.yaml`.
+ *
+ * The service holds every platform-sensitive decision precisely so those
+ * branches are reachable from a unit test on any host (Rule #1): the Windows
+ * junction choice is a pure exported function asserted directly, rather than
+ * gated behind a Windows runner (an ESM `fs` export cannot be spied on). The
+ * containment guard is exercised through a symlinked tempdir so the macOS
+ * `/var/folders` → `/private/var/folders` shape (#1145) is covered on the Linux
+ * CI leg too.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+  readlinkSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+  realpathSync,
+} from 'node:fs';
+import { join, sep, dirname, basename, isAbsolute } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadMofloConfig } from '../config/moflo-config.js';
+import {
+  WORKTREE_STATE_FILE,
+  allocateIndex,
+  computeWorktreePath,
+  isInside,
+  linkTypeForPlatform,
+  provisionWorktree,
+  readWorktreeState,
+  slugifyBranch,
+  writeWorktreeState,
+} from '../services/worktree-provision.js';
+
+let root: string;
+let worktree: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'moflo-wt-'));
+  worktree = join(root, 'wt');
+  mkdirSync(worktree, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+// ============================================================================
+// AC1 — path computation
+// ============================================================================
+
+describe('#1481 computeWorktreePath (AC1)', () => {
+  it('defaults to a sibling <repo>-worktrees directory', () => {
+    const repo = join(root, 'myrepo');
+    const result = computeWorktreePath(repo, 'feature/1481-x');
+    expect(result).toBe(join(dirname(repo), 'myrepo-worktrees', 'feature-1481-x'));
+    // Built with path.*, so it carries the host separator and never a literal '/'.
+    expect(result.includes(sep)).toBe(true);
+  });
+
+  it('sits outside the checkout, never inside it', () => {
+    const repo = join(root, 'myrepo');
+    expect(isInside(repo, computeWorktreePath(repo, 'feature/x'))).toBe(false);
+  });
+
+  it('slugs both separators so the directory name is flat and NTFS-valid', () => {
+    expect(slugifyBranch('feature/1481-x')).toBe('feature-1481-x');
+    expect(slugifyBranch('feature\\1481-x')).toBe('feature-1481-x');
+    expect(basename(computeWorktreePath(join(root, 'r'), 'a/b/c'))).toBe('a-b-c');
+  });
+
+  it('honors a configured dir, resolving a relative one against the repo root', () => {
+    const repo = join(root, 'myrepo');
+    expect(computeWorktreePath(repo, 'x', join(root, 'elsewhere'))).toBe(join(root, 'elsewhere', 'x'));
+    expect(computeWorktreePath(repo, 'x', '../trees')).toBe(join(root, 'trees', 'x'));
+  });
+});
+
+// ============================================================================
+// AC6 — index allocation
+// ============================================================================
+
+describe('#1481 allocateIndex (AC6)', () => {
+  it('starts at 0 and increments while slots are taken', () => {
+    expect(allocateIndex([])).toBe(0);
+    expect(allocateIndex([0])).toBe(1);
+    expect(allocateIndex([0, 1, 2])).toBe(3);
+  });
+
+  it('reuses a freed slot rather than growing unbounded', () => {
+    // Consumers derive ports from this index; an ever-growing counter would
+    // eventually push a derived port out of range.
+    expect(allocateIndex([0, 2])).toBe(1);
+    expect(allocateIndex([1, 2, 3])).toBe(0);
+  });
+
+  it('ignores malformed entries', () => {
+    expect(allocateIndex([-1, 1.5, Number.NaN, 0] as number[])).toBe(1);
+  });
+});
+
+// ============================================================================
+// AC7/AC8 — containment guard, realpath both sides
+// ============================================================================
+
+describe('#1481 isInside (AC7, AC8)', () => {
+  it('accepts a path inside the root and the root itself', () => {
+    expect(isInside(root, join(root, 'a', 'b'))).toBe(true);
+    expect(isInside(root, root)).toBe(true);
+  });
+
+  it('rejects a sibling and a parent-escaping path', () => {
+    expect(isInside(join(root, 'a'), join(root, 'b'))).toBe(false);
+    expect(isInside(join(root, 'a'), join(root, 'a', '..', '..', 'secrets'))).toBe(false);
+  });
+
+  it('rejects a prefix-sharing sibling directory', () => {
+    // `/x/repo-worktrees` must not read as inside `/x/repo`.
+    expect(isInside(join(root, 'repo'), join(root, 'repo-worktrees', 'a'))).toBe(false);
+  });
+
+  it('resolves symlinks on BOTH sides (#1145 shape)', () => {
+    // The macOS /var/folders -> /private/var/folders case: an unresolved path
+    // compared against a resolved one made two identical paths look different.
+    const real = join(root, 'real');
+    mkdirSync(join(real, 'nested'), { recursive: true });
+    const linked = join(root, 'linked');
+    symlinkSync(real, linked);
+    expect(isInside(real, join(linked, 'nested'))).toBe(true);
+    expect(isInside(linked, join(real, 'nested'))).toBe(true);
+  });
+
+  it('works for a destination that does not exist yet', () => {
+    expect(isInside(root, join(root, 'not', 'created', 'yet'))).toBe(true);
+  });
+});
+
+// ============================================================================
+// AC7 — copy
+// ============================================================================
+
+describe('#1481 provision copy (AC7)', () => {
+  it('copies a literal gitignored file into the worktree', () => {
+    writeFileSync(join(root, '.env'), 'SECRET=1');
+    const result = provisionWorktree({
+      primaryRoot: root,
+      worktreePath: worktree,
+      branch: 'b',
+      index: 0,
+      config: { copy: ['.env'] },
+    });
+    expect(result.provisioned).toBe(true);
+    expect(readFileSync(join(worktree, '.env'), 'utf8')).toBe('SECRET=1');
+  });
+
+  it('expands a single trailing glob within one directory level', () => {
+    writeFileSync(join(root, '.env.local'), 'A');
+    writeFileSync(join(root, '.env.test'), 'B');
+    writeFileSync(join(root, 'my.env.backup'), 'C');
+    provisionWorktree({
+      primaryRoot: root,
+      worktreePath: worktree,
+      branch: 'b',
+      index: 0,
+      config: { copy: ['.env.*'] },
+    });
+    expect(existsSync(join(worktree, '.env.local'))).toBe(true);
+    expect(existsSync(join(worktree, '.env.test'))).toBe(true);
+    // Anchored: `.env.*` must not match `my.env.backup`.
+    expect(existsSync(join(worktree, 'my.env.backup'))).toBe(false);
+  });
+
+  it('rejects a source resolving outside the primary checkout', () => {
+    const outside = join(root, 'outside');
+    mkdirSync(outside, { recursive: true });
+    writeFileSync(join(outside, 'secrets'), 'leak');
+    const primary = join(root, 'primary');
+    mkdirSync(primary, { recursive: true });
+
+    const result = provisionWorktree({
+      primaryRoot: primary,
+      worktreePath: worktree,
+      branch: 'b',
+      index: 0,
+      config: { copy: ['../outside/secrets'] },
+    });
+    expect(result.provisioned).toBe(false);
+    expect(result.steps[0]).toMatchObject({ kind: 'copy', status: 'failed' });
+    expect(result.steps[0].detail).toContain('outside the primary checkout');
+    expect(existsSync(join(worktree, 'outside', 'secrets'))).toBe(false);
+  });
+
+  it('skips a missing source without failing the run', () => {
+    const result = provisionWorktree({
+      primaryRoot: root,
+      worktreePath: worktree,
+      branch: 'b',
+      index: 0,
+      config: { copy: ['.env.local'] },
+    });
+    // `.env.local` legitimately does not exist on every machine.
+    expect(result.provisioned).toBe(true);
+    expect(result.steps[0]).toMatchObject({ kind: 'copy', status: 'skipped' });
+  });
+
+  it('copies a directory recursively', () => {
+    mkdirSync(join(root, 'config', 'nested'), { recursive: true });
+    writeFileSync(join(root, 'config', 'nested', 'a.json'), '{}');
+    provisionWorktree({
+      primaryRoot: root,
+      worktreePath: worktree,
+      branch: 'b',
+      index: 0,
+      config: { copy: ['config'] },
+    });
+    expect(existsSync(join(worktree, 'config', 'nested', 'a.json'))).toBe(true);
+  });
+});
+
+// ============================================================================
+// AC7/AC8 — link, including the Windows junction branch
+// ============================================================================
+
+describe('#1481 provision link (AC7, AC8)', () => {
+  it('creates a real symlink whose target is ABSOLUTE', () => {
+    mkdirSync(join(root, 'node_modules', 'pkg'), { recursive: true });
+    const result = provisionWorktree({
+      primaryRoot: root,
+      worktreePath: worktree,
+      branch: 'b',
+      index: 0,
+      config: { link: ['node_modules'] },
+    });
+    expect(result.provisioned).toBe(true);
+    // A RELATIVE target silently produces a broken junction on Windows, so the
+    // target is resolved to absolute on every platform. Asserted against the
+    // link actually on disk rather than a spy.
+    const target = readlinkSync(join(worktree, 'node_modules'));
+    expect(isAbsolute(target)).toBe(true);
+    expect(realpathSync(target)).toBe(realpathSync(join(root, 'node_modules')));
+    expect(existsSync(join(worktree, 'node_modules', 'pkg'))).toBe(true);
+  });
+
+  it("selects type 'junction' on Windows and none on POSIX", () => {
+    // Junctions need no admin rights / developer mode, unlike 'dir' symlinks.
+    // The decision is a pure exported function precisely so this branch is
+    // assertable on a Linux or macOS runner — an ESM `fs` export cannot be
+    // spied on, and a Windows-only assertion would go unverified on the two CI
+    // legs that run most often.
+    expect(linkTypeForPlatform('win32')).toBe('junction');
+    expect(linkTypeForPlatform('linux')).toBeUndefined();
+    expect(linkTypeForPlatform('darwin')).toBeUndefined();
+  });
+
+  it('does not clobber an existing destination', () => {
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+    mkdirSync(join(worktree, 'node_modules'), { recursive: true });
+    writeFileSync(join(worktree, 'node_modules', 'mine.txt'), 'keep');
+    const result = provisionWorktree({
+      primaryRoot: root,
+      worktreePath: worktree,
+      branch: 'b',
+      index: 0,
+      config: { link: ['node_modules'] },
+    });
+    expect(result.steps[0]).toMatchObject({ kind: 'link', status: 'skipped' });
+    expect(readFileSync(join(worktree, 'node_modules', 'mine.txt'), 'utf8')).toBe('keep');
+  });
+
+  it('does not clobber a BROKEN symlink left by an earlier run', () => {
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+    symlinkSync(join(root, 'gone'), join(worktree, 'node_modules'));
+    const result = provisionWorktree({
+      primaryRoot: root,
+      worktreePath: worktree,
+      branch: 'b',
+      index: 0,
+      config: { link: ['node_modules'] },
+    });
+    // existsSync() follows the link and reports false; lstat is what catches this.
+    expect(result.steps[0]).toMatchObject({ kind: 'link', status: 'skipped' });
+  });
+
+  it('skips a link source that does not exist', () => {
+    const result = provisionWorktree({
+      primaryRoot: root,
+      worktreePath: worktree,
+      branch: 'b',
+      index: 0,
+      config: { link: ['node_modules'] },
+    });
+    expect(result.steps[0]).toMatchObject({ kind: 'link', status: 'skipped' });
+    expect(result.provisioned).toBe(true);
+  });
+});
+
+// ============================================================================
+// AC6 — setup command + MOFLO_WORKTREE_INDEX
+// ============================================================================
+
+describe('#1481 provision setup (AC6)', () => {
+  it('runs in the worktree with MOFLO_WORKTREE_INDEX in its environment', () => {
+    const result = provisionWorktree({
+      primaryRoot: root,
+      worktreePath: worktree,
+      branch: 'b',
+      index: 3,
+      // node -e, not a shell builtin: Windows has no `echo > file` equivalent
+      // on PATH, and this must run identically on all three platforms (Rule #1).
+      config: {
+        setup: `node -e "require('fs').writeFileSync('idx.txt', process.env.MOFLO_WORKTREE_INDEX)"`,
+      },
+      jsonMode: true,
+    });
+    expect(result.provisioned).toBe(true);
+    expect(readFileSync(join(worktree, 'idx.txt'), 'utf8')).toBe('3');
+  });
+
+  it('marks the provision failed on a non-zero exit but leaves the worktree in place', () => {
+    const result = provisionWorktree({
+      primaryRoot: root,
+      worktreePath: worktree,
+      branch: 'b',
+      index: 0,
+      config: { setup: 'node -e "process.exit(3)"' },
+      jsonMode: true,
+    });
+    expect(result.provisioned).toBe(false);
+    expect(result.steps[0]).toMatchObject({ kind: 'setup', status: 'failed' });
+    // A failed step must never unwind a tree the user may already be working in.
+    expect(existsSync(worktree)).toBe(true);
+    expect(readWorktreeState(worktree)?.provisioned).toBe(false);
+  });
+
+  it('runs copy and link before setup', () => {
+    writeFileSync(join(root, '.env'), 'A=1');
+    const result = provisionWorktree({
+      primaryRoot: root,
+      worktreePath: worktree,
+      branch: 'b',
+      index: 0,
+      config: {
+        copy: ['.env'],
+        setup: `node -e "if(!require('fs').existsSync('.env'))process.exit(1)"`,
+      },
+      jsonMode: true,
+    });
+    // setup (typically `npm ci`) may depend on the .env material copy brings in.
+    expect(result.provisioned).toBe(true);
+    expect(result.steps.map(s => s.kind)).toEqual(['copy', 'setup']);
+  });
+});
+
+// ============================================================================
+// AC2/AC6 — state file
+// ============================================================================
+
+describe('#1481 worktree state file (AC2, AC6)', () => {
+  it('records branch, index, primaryRoot and provisioned', () => {
+    provisionWorktree({ primaryRoot: root, worktreePath: worktree, branch: 'feature/x', index: 2 });
+    const state = readWorktreeState(worktree);
+    expect(state).toEqual({ branch: 'feature/x', index: 2, primaryRoot: root, provisioned: true });
+    expect(existsSync(join(worktree, WORKTREE_STATE_FILE))).toBe(true);
+  });
+
+  it('returns null for a worktree moflo did not create', () => {
+    // This is how `flo worktree list` reports an externally-created worktree.
+    expect(readWorktreeState(worktree)).toBeNull();
+  });
+
+  it('returns null for a malformed state file rather than throwing', () => {
+    mkdirSync(join(worktree, '.moflo'), { recursive: true });
+    writeFileSync(join(worktree, WORKTREE_STATE_FILE), 'not json');
+    expect(readWorktreeState(worktree)).toBeNull();
+    writeFileSync(join(worktree, WORKTREE_STATE_FILE), '{"branch":1}');
+    expect(readWorktreeState(worktree)).toBeNull();
+  });
+
+  it('round-trips through writeWorktreeState', () => {
+    writeWorktreeState(worktree, { branch: 'b', index: 7, primaryRoot: root, provisioned: false });
+    expect(readWorktreeState(worktree)).toMatchObject({ index: 7, provisioned: false });
+  });
+});
+
+// ============================================================================
+// AC4/AC5 — config parsing
+// ============================================================================
+
+describe('#1481 moflo.yaml worktree block (AC4, AC5)', () => {
+  const writeConfig = (yaml: string): void => writeFileSync(join(root, 'moflo.yaml'), yaml);
+
+  it('AC5: a config with NO worktree block loads and leaves the key undefined', () => {
+    // The consumer-upgrade case: this is what proves the change is non-breaking.
+    writeConfig('project:\n  name: t\n');
+    expect(loadMofloConfig(root).worktree).toBeUndefined();
+  });
+
+  it('AC5: no config file at all still loads', () => {
+    expect(loadMofloConfig(root).worktree).toBeUndefined();
+  });
+
+  it('parses dir, copy, link and setup', () => {
+    writeConfig(
+      'project:\n  name: t\nworktree:\n  dir: ../trees\n  copy: [".env"]\n  link: ["node_modules"]\n  setup: npm ci\n',
+    );
+    expect(loadMofloConfig(root).worktree).toEqual({
+      dir: '../trees',
+      copy: ['.env'],
+      link: ['node_modules'],
+      setup: 'npm ci',
+    });
+  });
+
+  it('accepts a bare string for copy and link', () => {
+    writeConfig('project:\n  name: t\nworktree:\n  copy: .env\n  link: node_modules\n');
+    expect(loadMofloConfig(root).worktree).toEqual({ copy: ['.env'], link: ['node_modules'] });
+  });
+
+  it('ignores unknown sub-keys rather than failing to parse', () => {
+    // A consumer's config must never fail to load on an unrecognised entry.
+    writeConfig('project:\n  name: t\nworktree:\n  copy: .env\n  future_key: yes\n');
+    expect(loadMofloConfig(root).worktree).toEqual({ copy: ['.env'] });
+  });
+
+  it('treats an empty or malformed block as absent', () => {
+    writeConfig('project:\n  name: t\nworktree:\n  copy: []\n  setup: "  "\n');
+    expect(loadMofloConfig(root).worktree).toBeUndefined();
+  });
+
+  it('drops non-string entries from copy/link', () => {
+    writeConfig('project:\n  name: t\nworktree:\n  copy: [".env", 42, null]\n');
+    expect(loadMofloConfig(root).worktree).toEqual({ copy: ['.env'] });
+  });
+});
+
+// ============================================================================
+// AC5 — no-config parity
+// ============================================================================
+
+describe('#1481 no-config parity (AC5)', () => {
+  it('provisions nothing but still records state when no block is configured', () => {
+    writeFileSync(join(root, '.env'), 'SECRET=1');
+    const result = provisionWorktree({
+      primaryRoot: root,
+      worktreePath: worktree,
+      branch: 'b',
+      index: 0,
+      config: undefined,
+    });
+    expect(result.steps).toEqual([]);
+    expect(result.provisioned).toBe(true);
+    // Behaviourally identical to the inline `git worktree add` recipe it replaced.
+    expect(existsSync(join(worktree, '.env'))).toBe(false);
+    expect(readWorktreeState(worktree)).not.toBeNull();
+  });
+});
+
+// ============================================================================
+// AC8 — Rule #1 static guard
+// ============================================================================
+
+describe('#1481 Rule #1 guard (AC8)', () => {
+  const sources = [
+    'src/cli/services/worktree-provision.ts',
+    'src/cli/commands/worktree.ts',
+  ];
+
+  it('shells out to no POSIX-only coreutils and hardcodes no paths', () => {
+    const banned: Array<[RegExp, string]> = [
+      [/spawnSync\(\s*['"](cp|ln|rm|mkdir|find|grep|sed|cat)['"]/, 'POSIX-only coreutil spawn'],
+      [/['"]\/tmp\//, 'hardcoded /tmp'],
+      [/['"]C:\\\\/, 'hardcoded Windows path'],
+      [/mkdir -p|rm -rf|ln -s/, 'shell file-op string'],
+    ];
+    for (const file of sources) {
+      const text = readFileSync(join(realpathSync(process.cwd()), file), 'utf8');
+      // Comments legitimately name these commands when explaining why they are
+      // not used; strip them before matching so the guard tests the code.
+      const code = text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+      for (const [pattern, label] of banned) {
+        expect(pattern.test(code), `${file}: ${label}`).toBe(false);
+      }
+    }
+  });
+
+  it('builds every path through node:path', () => {
+    for (const file of sources) {
+      const text = readFileSync(join(realpathSync(process.cwd()), file), 'utf8');
+      expect(text).toMatch(/from 'node:path'/);
+    }
+  });
+});

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -77,6 +77,11 @@ const commandLoaders: Record<string, CommandLoader> = {
   epic: () => import('./epic.js'),
   // Spec-Driven Development artifacts (Epic #1269)
   sdd: () => import('./sdd.js'),
+  worktree: () => import('./worktree.js'),
+  // Alias key, not just `aliases: ['wt']` on the command: lazy commands resolve
+  // through `commandLoaders` by name, and an alias declared only on the command
+  // object is unreachable until something has already loaded it.
+  wt: () => import('./worktree.js'),
   // GitHub Repository Setup
   github: () => import('./github.js'),
   // /flo run ledger + per-run token rollup (#1333).

--- a/src/cli/commands/worktree.ts
+++ b/src/cli/commands/worktree.ts
@@ -26,6 +26,7 @@ import {
   allocateIndex,
   computeWorktreePath,
   isInside,
+  isProvisionedPath,
   resolveForCompare,
   provisionWorktree,
   readWorktreeState,
@@ -338,15 +339,12 @@ function userChanges(porcelain: string): string[] {
 function unprovisionedIgnoredPaths(worktreePath: string, config?: WorktreeConfig): string[] {
   const status = git(['status', '--porcelain', '--ignored=matching', '-uall'], worktreePath);
   if (!status.ok) return [];
-  const provisioned = [...(config?.copy ?? []), ...(config?.link ?? [])].map(entry =>
-    entry.split(/[\\/]/).filter(Boolean).join('/'),
-  );
   return status.stdout
     .split(/\r?\n/)
     .filter(line => line.startsWith('!! '))
     .map(line => line.slice(3).trim().replace(/^"|"$/g, ''))
     .filter(target => target !== WORKTREE_STATE_FILE_POSIX)
-    .filter(target => !provisioned.some(p => target === p || target.startsWith(`${p}/`)));
+    .filter(target => !isProvisionedPath(target, config));
 }
 
 async function cmdRemove(ctx: CommandContext): Promise<CommandResult> {

--- a/src/cli/commands/worktree.ts
+++ b/src/cli/commands/worktree.ts
@@ -20,17 +20,17 @@ import { findProjectRoot } from '../services/project-root.js';
 import { loadMofloConfig } from '../config/moflo-config.js';
 import {
   type ProvisionStep,
+  type WorktreeConfig,
   type WorktreeState,
+  WORKTREE_STATE_FILE_POSIX,
   allocateIndex,
   computeWorktreePath,
   isInside,
+  resolveForCompare,
   provisionWorktree,
   readWorktreeState,
   writeWorktreeState,
 } from '../services/worktree-provision.js';
-
-/** moflo's own per-worktree bookkeeping directory, as git reports it. */
-const MOFLO_DIR = '.moflo';
 
 interface WorktreeEntry {
   path: string;
@@ -95,6 +95,12 @@ function listWorktrees(repoRoot: string): WorktreeEntry[] {
  * already assumes) and finally to whichever of `origin/main`/`origin/master`
  * exists. Returns null when none resolve — better a clear error than silently
  * branching off the wrong ref.
+ *
+ * Deliberately NOT shared with `getDefaultBranch` in `commands/github.ts`: that
+ * one returns a bare branch name and falls back to the literal `'main'`, which
+ * is right for generating a CI workflow and wrong here — silently branching a
+ * user's work off a guessed ref is the failure this returns null to avoid. It
+ * also tries `gh` first, where this prefers git (faster, and works offline).
  */
 function resolveDefaultBase(repoRoot: string): string | null {
   const head = git(['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'], repoRoot);
@@ -142,7 +148,10 @@ async function cmdAdd(ctx: CommandContext): Promise<CommandResult> {
   const target = computeWorktreePath(repoRoot, branch, worktreeConfig?.dir);
 
   const existing = listWorktrees(repoRoot);
-  const alreadyRegistered = existing.find(entry => isInside(entry.path, target) && isInside(target, entry.path));
+  // Resolve the needle once, then compare resolved strings — realpathing both
+  // sides inside the scan costs 4 walks per worktree for the same answer.
+  const resolvedTarget = resolveForCompare(target);
+  const alreadyRegistered = existing.find(entry => resolveForCompare(entry.path) === resolvedTarget);
 
   // Reuse rather than recreate: a prior run may have left work in this tree, and
   // deleting a directory we did not just create is never this command's call.
@@ -154,7 +163,8 @@ async function cmdAdd(ctx: CommandContext): Promise<CommandResult> {
         exitCode: 1,
       };
     }
-    const base = typeof ctx.flags.from === 'string' ? ctx.flags.from : resolveDefaultBase(repoRoot);
+    const explicitFrom = typeof ctx.flags.from === 'string';
+    const base = explicitFrom ? (ctx.flags.from as string) : resolveDefaultBase(repoRoot);
     if (!base) {
       return {
         success: false,
@@ -162,18 +172,28 @@ async function cmdAdd(ctx: CommandContext): Promise<CommandResult> {
         exitCode: 1,
       };
     }
-    // Fetch so the base ref is current; a failure here is not fatal (the ref may
-    // already be local, and an offline machine should still get its worktree).
-    git(['fetch', 'origin'], repoRoot);
+    // Fetch so the DEFAULT base is current — branching a ticket off a stale
+    // origin/main is the failure this guards. An explicit `--from` that already
+    // resolves locally (a tag, another branch) is the user naming a specific
+    // commit, so skip the network round trip there. A fetch failure is never
+    // fatal: an offline machine should still get its worktree.
+    const baseIsLocal = git(['rev-parse', '--verify', '--quiet', base], repoRoot).ok;
+    if (!(explicitFrom && baseIsLocal)) git(['fetch', 'origin'], repoRoot);
     const created = git(['worktree', 'add', '-b', branch, target, base], repoRoot);
     if (!created.ok) {
       return { success: false, message: `git worktree add failed: ${created.stderr}`, exitCode: 1 };
     }
   }
 
-  const index = allocateIndex(
-    existing.map(entry => entry.state?.index).filter((n): n is number => typeof n === 'number'),
-  );
+  // Re-adding an existing worktree MUST keep its index. `existing` includes that
+  // worktree, so allocating afresh would hand it a new number and rewrite
+  // worktree.json — silently shifting every port a consumer derived from
+  // MOFLO_WORKTREE_INDEX in a tree they are already working in.
+  const index =
+    alreadyRegistered?.state?.index ??
+    allocateIndex(
+      existing.map(entry => entry.state?.index).filter((n): n is number => typeof n === 'number'),
+    );
 
   let provisioned = true;
   // Distinct from `!provisioned`: skipping provisioning by request is not a
@@ -273,23 +293,61 @@ async function cmdList(ctx: CommandContext): Promise<CommandResult> {
  * make `remove` demand `--force` on every worktree this command produced, which
  * trains the user to always pass it and defeats the guard entirely.
  *
+ * Only that ONE file is excused, never the whole `.moflo/` directory: a worktree
+ * may also hold un-pushed SDD specs and plans under `.moflo/specs/`, and those
+ * are user-authored work that must still block removal. Reaching that precision
+ * requires `-uall` at the call site — porcelain otherwise collapses an untracked
+ * directory to a single `?? .moflo/` line, which cannot be told apart from spec
+ * work living inside it.
+ *
  * Each line is `XY <path>`; a rename is `XY <old> -> <new>`, and a path with
- * unusual characters is quoted. Only the leading two status columns are fixed
- * width, so the path starts at index 3.
+ * unusual characters is quoted with C-style escapes. Only the leading two
+ * status columns are fixed width, so the path starts at index 3. A filename
+ * containing a literal ` -> ` inside quotes would mis-split — harmless, because
+ * the mis-split value simply fails to equal the state file and the line counts
+ * as user work, which is the safe direction (refuse removal, never delete).
  */
 function userChanges(porcelain: string): string[] {
-  const mofloPrefix = `${MOFLO_DIR}/`;
+  const stateFile = WORKTREE_STATE_FILE_POSIX;
   return porcelain
     .split(/\r?\n/)
     .filter(line => line.trim().length > 0)
     .filter(line => {
       const entry = line.slice(3).trim();
       const target = (entry.includes(' -> ') ? entry.split(' -> ')[1] : entry).replace(/^"|"$/g, '');
-      // git always reports forward slashes here, on every platform.
-      return target !== MOFLO_DIR && target !== mofloPrefix && !target.startsWith(mofloPrefix);
+      return target !== stateFile;
     });
 }
 
+
+/**
+ * Gitignored paths in the worktree that `remove` is about to destroy and that
+ * provisioning did not put there.
+ *
+ * `git status --porcelain` never lists ignored files, so the dirty gate above
+ * cannot see them — yet removing the worktree deletes them (stock
+ * `git worktree remove` does the same; this is inherent to worktree removal,
+ * not something --force introduces). Anything `copy:` or `link:` created is
+ * excluded: it either still exists in the primary checkout or is a symlink
+ * whose target is untouched, so naming it would be noise on every removal.
+ *
+ * Warns; never blocks. A project whose `setup:` ran `npm ci` has a legitimate
+ * `node_modules` here on every single removal, and blocking on that would just
+ * teach the user to always pass --force.
+ */
+function unprovisionedIgnoredPaths(worktreePath: string, config?: WorktreeConfig): string[] {
+  const status = git(['status', '--porcelain', '--ignored=matching', '-uall'], worktreePath);
+  if (!status.ok) return [];
+  const provisioned = [...(config?.copy ?? []), ...(config?.link ?? [])].map(entry =>
+    entry.split(/[\\/]/).filter(Boolean).join('/'),
+  );
+  return status.stdout
+    .split(/\r?\n/)
+    .filter(line => line.startsWith('!! '))
+    .map(line => line.slice(3).trim().replace(/^"|"$/g, ''))
+    .filter(target => target !== WORKTREE_STATE_FILE_POSIX)
+    .filter(target => !provisioned.some(p => target === p || target.startsWith(`${p}/`)));
+}
 
 async function cmdRemove(ctx: CommandContext): Promise<CommandResult> {
   const which = ctx.args?.[1];
@@ -300,12 +358,11 @@ async function cmdRemove(ctx: CommandContext): Promise<CommandResult> {
 
   const repoRoot = findProjectRoot({ cwd: ctx.cwd });
   const entries = listWorktrees(repoRoot);
-  const candidate = path.resolve(ctx.cwd, which);
-
-  // Match by branch first, then by path. The path comparison realpaths both
-  // sides (inside `isInside`), so a symlinked tempdir on macOS still matches.
+  // Match by branch first, then by path. The path comparison is realpath-based,
+  // so a symlinked tempdir on macOS still matches; the needle resolves once.
+  const resolvedCandidate = resolveForCompare(path.resolve(ctx.cwd, which));
   const match = entries.find(
-    entry => entry.branch === which || (isInside(entry.path, candidate) && isInside(candidate, entry.path)),
+    entry => entry.branch === which || resolveForCompare(entry.path) === resolvedCandidate,
   );
   if (!match) {
     return { success: false, message: `Not a registered worktree of this repo: ${which}`, exitCode: 1 };
@@ -315,7 +372,8 @@ async function cmdRemove(ctx: CommandContext): Promise<CommandResult> {
   }
 
   if (!force) {
-    const status = git(['status', '--porcelain'], match.path);
+    // `-uall` so an untracked directory is not collapsed to one line — see userChanges().
+    const status = git(['status', '--porcelain', '-uall'], match.path);
     const dirty = status.ok ? userChanges(status.stdout) : [];
     if (dirty.length > 0) {
       return {
@@ -330,16 +388,23 @@ async function cmdRemove(ctx: CommandContext): Promise<CommandResult> {
   // has already refused anything the user would miss; git's own check cannot tell
   // moflo's untracked `.moflo/worktree.json` from user work, so without this every
   // worktree this command created would be unremovable without `--force`.
+  const doomed = unprovisionedIgnoredPaths(match.path, loadMofloConfig(repoRoot).worktree);
   const removed = git(['worktree', 'remove', '--force', match.path], repoRoot);
   if (!removed.ok) {
     return { success: false, message: `git worktree remove failed: ${removed.stderr}`, exitCode: 1 };
   }
 
   if (ctx.flags.json === true) {
-    console.log(JSON.stringify({ removed: match.path, branch: match.branch }));
+    console.log(JSON.stringify({ removed: match.path, branch: match.branch, discardedIgnored: doomed }));
     return { success: true, exitCode: 0 };
   }
   console.log(`Removed worktree: ${match.path}`);
+  if (doomed.length > 0) {
+    console.log(
+      `  also discarded ${doomed.length} gitignored path(s) that were not provisioned: ` +
+        `${doomed.slice(0, 5).join(', ')}${doomed.length > 5 ? ', …' : ''}`,
+    );
+  }
   return { success: true, exitCode: 0 };
 }
 

--- a/src/cli/commands/worktree.ts
+++ b/src/cli/commands/worktree.ts
@@ -1,0 +1,400 @@
+/**
+ * MoFlo Worktree Command — #1481.
+ *
+ * Lifecycle + provisioning for git worktrees, so `/flo -wt` produces a RUNNABLE
+ * workspace instead of a bare checkout. This file owns git invocation and output
+ * formatting only; every platform-sensitive filesystem decision lives in
+ * `../services/worktree-provision.ts` where a unit test can reach it (Rule #1).
+ *
+ * Usage:
+ *   flo worktree add <branch> [--from <ref>] [--no-provision] [--json]
+ *   flo worktree list [--json]
+ *   flo worktree remove <branch|path> [--force] [--json]
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import type { Command, CommandContext, CommandResult } from '../types.js';
+import { findProjectRoot } from '../services/project-root.js';
+import { loadMofloConfig } from '../config/moflo-config.js';
+import {
+  type ProvisionStep,
+  type WorktreeState,
+  allocateIndex,
+  computeWorktreePath,
+  isInside,
+  provisionWorktree,
+  readWorktreeState,
+  writeWorktreeState,
+} from '../services/worktree-provision.js';
+
+/** moflo's own per-worktree bookkeeping directory, as git reports it. */
+const MOFLO_DIR = '.moflo';
+
+interface WorktreeEntry {
+  path: string;
+  branch: string | null;
+  /** moflo state, or null for a worktree moflo did not create. */
+  state: WorktreeState | null;
+  /** True for the primary working tree (the one that is not a linked worktree). */
+  primary: boolean;
+}
+
+/**
+ * Run a git command. Never `shell: true` — args are passed as an array so a
+ * branch name containing shell metacharacters cannot be reinterpreted, and so
+ * the same call works identically on all three platforms.
+ */
+function git(args: string[], cwd: string): { ok: boolean; stdout: string; stderr: string } {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  return {
+    ok: !result.error && result.status === 0,
+    stdout: (result.stdout ?? '').trim(),
+    stderr: (result.stderr ?? result.error?.message ?? '').trim(),
+  };
+}
+
+/**
+ * Parse `git worktree list --porcelain`. The first record is always the primary
+ * working tree; linked worktrees follow. Records are blank-line separated, and
+ * `branch` is a full ref (`refs/heads/x`) or absent when detached.
+ */
+function listWorktrees(repoRoot: string): WorktreeEntry[] {
+  const result = git(['worktree', 'list', '--porcelain'], repoRoot);
+  if (!result.ok) return [];
+  const entries: WorktreeEntry[] = [];
+  let current: { path?: string; branch?: string } = {};
+  const flush = (): void => {
+    if (!current.path) return;
+    entries.push({
+      path: current.path,
+      branch: current.branch ? current.branch.replace(/^refs\/heads\//, '') : null,
+      state: readWorktreeState(current.path),
+      primary: entries.length === 0,
+    });
+    current = {};
+  };
+  for (const line of result.stdout.split(/\r?\n/)) {
+    if (line.startsWith('worktree ')) {
+      flush();
+      current.path = line.slice('worktree '.length).trim();
+    } else if (line.startsWith('branch ')) {
+      current.branch = line.slice('branch '.length).trim();
+    }
+  }
+  flush();
+  return entries;
+}
+
+/**
+ * The ref a new worktree branches from when `--from` is not given.
+ *
+ * `origin/HEAD` is the authoritative answer but is not always configured in a
+ * fresh clone, so fall back to `gh` (which the rest of this repo's tooling
+ * already assumes) and finally to whichever of `origin/main`/`origin/master`
+ * exists. Returns null when none resolve — better a clear error than silently
+ * branching off the wrong ref.
+ */
+function resolveDefaultBase(repoRoot: string): string | null {
+  const head = git(['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'], repoRoot);
+  if (head.ok && head.stdout) return head.stdout.replace(/^refs\/remotes\//, '');
+
+  const gh = spawnSync('gh', ['repo', 'view', '--json', 'defaultBranchRef', '--jq', '.defaultBranchRef.name'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  if (!gh.error && gh.status === 0) {
+    const name = (gh.stdout ?? '').trim();
+    if (name) return `origin/${name}`;
+  }
+
+  for (const candidate of ['origin/main', 'origin/master']) {
+    if (git(['rev-parse', '--verify', '--quiet', candidate], repoRoot).ok) return candidate;
+  }
+  return null;
+}
+
+function renderSteps(steps: readonly ProvisionStep[]): string {
+  return steps
+    .map(step => {
+      const mark = step.status === 'done' ? '✓' : step.status === 'skipped' ? '·' : '✗';
+      const detail = step.detail ? ` (${step.detail})` : '';
+      return `  ${mark} ${step.kind} ${step.target}${detail}`;
+    })
+    .join('\n');
+}
+
+// =============================================================================
+// add
+// =============================================================================
+
+async function cmdAdd(ctx: CommandContext): Promise<CommandResult> {
+  const branch = ctx.args?.[1];
+  const json = ctx.flags.json === true;
+  if (!branch) {
+    return { success: false, message: 'Usage: flo worktree add <branch> [--from <ref>]', exitCode: 1 };
+  }
+
+  const repoRoot = findProjectRoot({ cwd: ctx.cwd });
+  const config = loadMofloConfig(repoRoot);
+  const worktreeConfig = config.worktree;
+  const target = computeWorktreePath(repoRoot, branch, worktreeConfig?.dir);
+
+  const existing = listWorktrees(repoRoot);
+  const alreadyRegistered = existing.find(entry => isInside(entry.path, target) && isInside(target, entry.path));
+
+  // Reuse rather than recreate: a prior run may have left work in this tree, and
+  // deleting a directory we did not just create is never this command's call.
+  if (!alreadyRegistered) {
+    if (existsSync(target)) {
+      return {
+        success: false,
+        message: `Path already exists but is not a registered worktree: ${target}\nRemove it by hand, or pass a different branch name.`,
+        exitCode: 1,
+      };
+    }
+    const base = typeof ctx.flags.from === 'string' ? ctx.flags.from : resolveDefaultBase(repoRoot);
+    if (!base) {
+      return {
+        success: false,
+        message: 'Could not resolve a default base ref (no origin/HEAD, no gh, no origin/main or origin/master). Pass --from <ref>.',
+        exitCode: 1,
+      };
+    }
+    // Fetch so the base ref is current; a failure here is not fatal (the ref may
+    // already be local, and an offline machine should still get its worktree).
+    git(['fetch', 'origin'], repoRoot);
+    const created = git(['worktree', 'add', '-b', branch, target, base], repoRoot);
+    if (!created.ok) {
+      return { success: false, message: `git worktree add failed: ${created.stderr}`, exitCode: 1 };
+    }
+  }
+
+  const index = allocateIndex(
+    existing.map(entry => entry.state?.index).filter((n): n is number => typeof n === 'number'),
+  );
+
+  let provisioned = true;
+  // Distinct from `!provisioned`: skipping provisioning by request is not a
+  // failure, so it must not colour the exit code.
+  let provisionFailed = false;
+  let steps: readonly ProvisionStep[] = [];
+  // Positive name, negative read (#1474): the parser turns `--no-provision`
+  // into `flags.provision = false`; an option DECLARED `no-provision` would be
+  // an unreachable no-op.
+  if (ctx.flags.provision === false) {
+    // Still record state so `list` reports the tree as moflo-created and the
+    // index stays allocated against it.
+    writeWorktreeState(target, { branch, index, primaryRoot: repoRoot, provisioned: false });
+    provisioned = false;
+  } else {
+    const result = provisionWorktree({
+      primaryRoot: repoRoot,
+      worktreePath: target,
+      branch,
+      index,
+      config: worktreeConfig,
+      jsonMode: json,
+    });
+    provisioned = result.provisioned;
+    provisionFailed = !result.provisioned;
+    steps = result.steps;
+  }
+
+  if (json) {
+    console.log(JSON.stringify({ path: target, branch, index, provisioned, steps }));
+    return { success: !provisionFailed, exitCode: provisionFailed ? 1 : 0 };
+  }
+
+  const lines = [`Worktree: ${target}`, `Branch:   ${branch}`, `Index:    ${index}`];
+  if (steps.length > 0) lines.push('Provisioning:', renderSteps(steps));
+  else if (ctx.flags.provision === false) lines.push('Provisioning: skipped (--no-provision)');
+  else if (!worktreeConfig) {
+    lines.push('Provisioning: none configured (add a `worktree:` block to moflo.yaml)');
+  }
+  lines.push(`Remove with: flo worktree remove ${branch}`);
+  console.log(lines.join('\n'));
+  return { success: !provisionFailed, exitCode: provisionFailed ? 1 : 0 };
+}
+
+// =============================================================================
+// list
+// =============================================================================
+
+async function cmdList(ctx: CommandContext): Promise<CommandResult> {
+  const repoRoot = findProjectRoot({ cwd: ctx.cwd });
+  const entries = listWorktrees(repoRoot);
+
+  if (ctx.flags.json === true) {
+    console.log(
+      JSON.stringify(
+        entries.map(entry => ({
+          path: entry.path,
+          branch: entry.branch,
+          primary: entry.primary,
+          provisioned: entry.state?.provisioned ?? false,
+          managed: entry.state !== null,
+          index: entry.state?.index ?? null,
+        })),
+      ),
+    );
+    return { success: true, exitCode: 0 };
+  }
+
+  if (entries.length === 0) {
+    console.log('No worktrees.');
+    return { success: true, exitCode: 0 };
+  }
+  const lines = entries.map(entry => {
+    const tag = entry.primary
+      ? 'primary'
+      : entry.state === null
+        ? 'unmanaged'
+        : entry.state.provisioned
+          ? `provisioned #${entry.state.index}`
+          : `unprovisioned #${entry.state.index}`;
+    return `  ${entry.branch ?? '(detached)'}  [${tag}]\n    ${entry.path}`;
+  });
+  console.log(lines.join('\n'));
+  return { success: true, exitCode: 0 };
+}
+
+// =============================================================================
+// remove
+// =============================================================================
+
+/**
+ * Porcelain status lines that represent the USER's work.
+ *
+ * `flo worktree add` writes `.moflo/worktree.json` into the tree it creates, and
+ * `.moflo/` is not gitignored in every project — so a freshly created, untouched
+ * worktree reports as dirty. Counting moflo's own bookkeeping as user work would
+ * make `remove` demand `--force` on every worktree this command produced, which
+ * trains the user to always pass it and defeats the guard entirely.
+ *
+ * Each line is `XY <path>`; a rename is `XY <old> -> <new>`, and a path with
+ * unusual characters is quoted. Only the leading two status columns are fixed
+ * width, so the path starts at index 3.
+ */
+function userChanges(porcelain: string): string[] {
+  const mofloPrefix = `${MOFLO_DIR}/`;
+  return porcelain
+    .split(/\r?\n/)
+    .filter(line => line.trim().length > 0)
+    .filter(line => {
+      const entry = line.slice(3).trim();
+      const target = (entry.includes(' -> ') ? entry.split(' -> ')[1] : entry).replace(/^"|"$/g, '');
+      // git always reports forward slashes here, on every platform.
+      return target !== MOFLO_DIR && target !== mofloPrefix && !target.startsWith(mofloPrefix);
+    });
+}
+
+
+async function cmdRemove(ctx: CommandContext): Promise<CommandResult> {
+  const which = ctx.args?.[1];
+  const force = ctx.flags.force === true;
+  if (!which) {
+    return { success: false, message: 'Usage: flo worktree remove <branch|path> [--force]', exitCode: 1 };
+  }
+
+  const repoRoot = findProjectRoot({ cwd: ctx.cwd });
+  const entries = listWorktrees(repoRoot);
+  const candidate = path.resolve(ctx.cwd, which);
+
+  // Match by branch first, then by path. The path comparison realpaths both
+  // sides (inside `isInside`), so a symlinked tempdir on macOS still matches.
+  const match = entries.find(
+    entry => entry.branch === which || (isInside(entry.path, candidate) && isInside(candidate, entry.path)),
+  );
+  if (!match) {
+    return { success: false, message: `Not a registered worktree of this repo: ${which}`, exitCode: 1 };
+  }
+  if (match.primary) {
+    return { success: false, message: 'Refusing to remove the primary working tree.', exitCode: 1 };
+  }
+
+  if (!force) {
+    const status = git(['status', '--porcelain'], match.path);
+    const dirty = status.ok ? userChanges(status.stdout) : [];
+    if (dirty.length > 0) {
+      return {
+        success: false,
+        message: `Worktree has uncommitted changes: ${match.path}\n  ${dirty.slice(0, 5).join('\n  ')}\nCommit them, or re-run with --force.`,
+        exitCode: 1,
+      };
+    }
+  }
+
+  // Always `--force` at the git layer. `userChanges()` above is the real gate and
+  // has already refused anything the user would miss; git's own check cannot tell
+  // moflo's untracked `.moflo/worktree.json` from user work, so without this every
+  // worktree this command created would be unremovable without `--force`.
+  const removed = git(['worktree', 'remove', '--force', match.path], repoRoot);
+  if (!removed.ok) {
+    return { success: false, message: `git worktree remove failed: ${removed.stderr}`, exitCode: 1 };
+  }
+
+  if (ctx.flags.json === true) {
+    console.log(JSON.stringify({ removed: match.path, branch: match.branch }));
+    return { success: true, exitCode: 0 };
+  }
+  console.log(`Removed worktree: ${match.path}`);
+  return { success: true, exitCode: 0 };
+}
+
+// =============================================================================
+// Command definition
+// =============================================================================
+
+const HELP = `Usage: flo worktree <command>
+
+Git worktrees as provisioned workspaces (moflo.yaml \`worktree:\` block):
+  add <branch> [--from <ref>] [--no-provision] [--json]
+                           Create a worktree at <repo-parent>/<repo>-worktrees/<branch>
+                           and provision it (copy / link / setup)
+  list [--json]            List this repo's worktrees and their provisioning state
+  remove <branch|path> [--force] [--json]
+                           Remove a worktree (refuses a dirty tree without --force)
+
+With no \`worktree:\` block in moflo.yaml, \`add\` creates the worktree and
+provisions nothing.`;
+
+const worktreeCommand: Command = {
+  name: 'worktree',
+  description: 'Create, list, and remove provisioned git worktrees',
+  aliases: ['wt'],
+  options: [
+    { name: 'from', description: 'Base ref for the new branch (default: origin/HEAD)', type: 'string' },
+    {
+      name: 'provision',
+      description: 'Run copy/link/setup after creating the worktree (--no-provision to skip)',
+      type: 'boolean',
+      default: true,
+    },
+    { name: 'force', description: 'Remove even with uncommitted changes', type: 'boolean' },
+    { name: 'json', description: 'Emit machine-readable JSON', type: 'boolean' },
+  ],
+  examples: [
+    { command: 'flo worktree add feature/1481-provisioning', description: 'Create + provision a worktree' },
+    { command: 'flo worktree list', description: 'Show every worktree and its state' },
+    { command: 'flo worktree remove feature/1481-provisioning', description: 'Clean up when the PR is merged' },
+  ],
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    const sub = ctx.args?.[0];
+    switch (sub) {
+      case 'add':
+        return cmdAdd(ctx);
+      case 'list':
+        return cmdList(ctx);
+      case 'remove':
+        return cmdRemove(ctx);
+      default:
+        console.log(HELP);
+        return { success: !sub, exitCode: sub ? 1 : 0 };
+    }
+  },
+};
+
+export default worktreeCommand;
+export { worktreeCommand };

--- a/src/cli/config/moflo-config.ts
+++ b/src/cli/config/moflo-config.ts
@@ -4,6 +4,8 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
+// Type-only: adds no runtime edge to this module's import closure.
+import type { WorktreeConfig } from '../services/worktree-provision.js';
 let yaml: any;
 try {
   yaml = await import('js-yaml');
@@ -162,39 +164,11 @@ export interface MofloConfig {
    * optional; unknown sub-keys are ignored rather than fatal, so a consumer's
    * `moflo.yaml` never fails to parse on an unrecognised entry.
    *
-   * See `src/cli/services/worktree-provision.ts`.
+   * The shape is owned by `src/cli/services/worktree-provision.ts`, which is
+   * what consumes it — declaring it twice would let the parser and the
+   * provisioner drift apart silently.
    */
-  worktree?: {
-    /**
-     * Override the computed worktree parent directory
-     * (`<repo-parent>/<repo-basename>-worktrees`). Relative → project root.
-     */
-    dir?: string;
-    /**
-     * Gitignored files/directories copied from the primary checkout into a new
-     * worktree — typically `.env` material a fresh checkout lacks. Sources must
-     * resolve **inside** the primary checkout (realpath-checked on both sides);
-     * a missing source is skipped, not fatal. Accepts a string or an array; a
-     * single trailing `*` within one directory level is supported.
-     */
-    copy?: string[];
-    /**
-     * Paths symlinked (junctioned on Windows) from the primary checkout into a
-     * new worktree — typically `node_modules`. Opt-in with no default: a
-     * symlinked root `node_modules` is fragile under npm workspaces, so whether
-     * to link or to run `setup` is a per-project call. Accepts a string or an
-     * array. An existing destination is never clobbered.
-     */
-    link?: string[];
-    /**
-     * Command run inside the new worktree after copy/link — e.g. `npm ci`. Runs
-     * with `MOFLO_WORKTREE_INDEX` in its environment (a small integer, unique
-     * among live worktrees) so a project whose dev servers bind fixed ports can
-     * offset them per workspace. A non-zero exit marks the provision failed but
-     * leaves the worktree in place — it is a valid checkout either way.
-     */
-    setup?: string;
-  };
+  worktree?: WorktreeConfig;
 
   hooks: {
     pre_edit: boolean;

--- a/src/cli/config/moflo-config.ts
+++ b/src/cli/config/moflo-config.ts
@@ -155,6 +155,47 @@ export interface MofloConfig {
     snapshot_to?: string;
   };
 
+  /**
+   * Optional worktree provisioning (#1481). Absent = off, and `flo worktree add`
+   * then behaves exactly like the inline `git worktree add` recipe it replaced:
+   * the worktree is created and nothing is copied, linked, or run. Every key is
+   * optional; unknown sub-keys are ignored rather than fatal, so a consumer's
+   * `moflo.yaml` never fails to parse on an unrecognised entry.
+   *
+   * See `src/cli/services/worktree-provision.ts`.
+   */
+  worktree?: {
+    /**
+     * Override the computed worktree parent directory
+     * (`<repo-parent>/<repo-basename>-worktrees`). Relative → project root.
+     */
+    dir?: string;
+    /**
+     * Gitignored files/directories copied from the primary checkout into a new
+     * worktree — typically `.env` material a fresh checkout lacks. Sources must
+     * resolve **inside** the primary checkout (realpath-checked on both sides);
+     * a missing source is skipped, not fatal. Accepts a string or an array; a
+     * single trailing `*` within one directory level is supported.
+     */
+    copy?: string[];
+    /**
+     * Paths symlinked (junctioned on Windows) from the primary checkout into a
+     * new worktree — typically `node_modules`. Opt-in with no default: a
+     * symlinked root `node_modules` is fragile under npm workspaces, so whether
+     * to link or to run `setup` is a per-project call. Accepts a string or an
+     * array. An existing destination is never clobbered.
+     */
+    link?: string[];
+    /**
+     * Command run inside the new worktree after copy/link — e.g. `npm ci`. Runs
+     * with `MOFLO_WORKTREE_INDEX` in its environment (a small integer, unique
+     * among live worktrees) so a project whose dev servers bind fixed ports can
+     * offset them per workspace. A non-zero exit marks the provision failed but
+     * leaves the worktree in place — it is a valid checkout either way.
+     */
+    setup?: string;
+  };
+
   hooks: {
     pre_edit: boolean;
     post_edit: boolean;
@@ -461,6 +502,39 @@ function coerceMemoryBackend(raw: unknown): MofloMemoryBackend {
 }
 
 /**
+ * Coerce a `worktree.copy` / `worktree.link` entry to a string array (#1481).
+ * Both keys accept a bare string for the common single-entry case; anything
+ * that is neither a string nor an array of strings is dropped rather than
+ * throwing — a malformed entry must never stop a consumer's config loading.
+ */
+function coercePathList(raw: unknown): string[] | undefined {
+  const list = typeof raw === 'string' ? [raw] : Array.isArray(raw) ? raw : undefined;
+  if (!list) return undefined;
+  const cleaned = list
+    .filter((v): v is string => typeof v === 'string')
+    .map(v => v.trim())
+    .filter(v => v.length > 0);
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
+/**
+ * Parse the optional `worktree:` block (#1481). Returns `undefined` when the
+ * block is absent or contains nothing usable, so "not configured" stays
+ * distinguishable from "configured empty". Unknown sub-keys are ignored.
+ */
+function parseWorktreeConfig(raw: unknown): MofloConfig['worktree'] {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const block = raw as Record<string, unknown>;
+  const dir = typeof block.dir === 'string' && block.dir.trim().length > 0 ? block.dir.trim() : undefined;
+  const copy = coercePathList(block.copy);
+  const link = coercePathList(block.link);
+  const setup =
+    typeof block.setup === 'string' && block.setup.trim().length > 0 ? block.setup.trim() : undefined;
+  if (!dir && !copy && !link && !setup) return undefined;
+  return { ...(dir && { dir }), ...(copy && { copy }), ...(link && { link }), ...(setup && { setup }) };
+}
+
+/**
  * Parse raw config object into typed config, merging with defaults.
  */
 function mergeConfig(raw: Record<string, any>, root: string): MofloConfig {
@@ -535,6 +609,10 @@ function mergeConfig(raw: Record<string, any>, root: string): MofloConfig {
         return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
       })(),
     },
+    // #1481 — optional worktree provisioning. The whole block stays `undefined`
+    // when absent so an existing consumer `moflo.yaml` is unaffected, and so
+    // `flo worktree add` can distinguish "not configured" from "configured empty".
+    worktree: parseWorktreeConfig(raw.worktree),
     hooks: {
       pre_edit: raw.hooks?.pre_edit ?? raw.hooks?.preEdit ?? DEFAULT_CONFIG.hooks.pre_edit,
       post_edit: raw.hooks?.post_edit ?? raw.hooks?.postEdit ?? DEFAULT_CONFIG.hooks.post_edit,
@@ -791,6 +869,26 @@ memory:
   #   worktrees / Conductor workspaces always hydrate from a current seed. Linked
   #   worktrees never produce. Conductor recipe: set hydrate_from AND snapshot_to
   #   to the SAME absolute path. Overridable per-process via MOFLO_SNAPSHOT_TO.
+
+# Worktree provisioning (#1481) — makes "flo worktree add" (and "/flo -wt")
+# produce a RUNNABLE workspace, not just a valid checkout. Entirely optional:
+# with this block absent, a new worktree is created and nothing is provisioned.
+# worktree:
+#   dir: ../myrepo-worktrees
+#     Where worktrees are created. Defaults to <repo-parent>/<repo>-worktrees.
+#   copy: [".env", ".env.*"]
+#     Gitignored files a fresh checkout lacks, copied from the primary checkout.
+#     Sources must live inside the primary checkout. NOTE: this relocates secret
+#     material to a directory OUTSIDE the repo and outside its .gitignore — keep
+#     the worktree dir out of any repo you commit.
+#   link: ["node_modules"]
+#     Symlinked (junctioned on Windows) from the primary checkout. Opt-in with no
+#     default: a symlinked root node_modules is fragile under npm workspaces —
+#     prefer "setup: npm ci" if your project uses them.
+#   setup: "npm ci"
+#     Run inside the new worktree after copy/link, with MOFLO_WORKTREE_INDEX in
+#     its environment (a small integer unique among live worktrees) so a project
+#     with fixed dev-server ports can offset them per workspace.
 
 # Hook toggles (all on by default — disable to slim down)
 hooks:

--- a/src/cli/services/worktree-provision.ts
+++ b/src/cli/services/worktree-provision.ts
@@ -32,6 +32,7 @@ import {
 } from 'node:fs';
 import path from 'node:path';
 import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
+import { globToRegExp } from '../guidance/retriever.js';
 
 /** The `worktree:` block from `moflo.yaml`. Every key optional. */
 export interface WorktreeConfig {
@@ -64,6 +65,13 @@ export interface ProvisionResult {
 
 /** Relative path of the per-worktree state file, from the worktree root. */
 export const WORKTREE_STATE_FILE = path.join('.moflo', 'worktree.json');
+
+/**
+ * The same path in git's spelling. `git status --porcelain` reports forward
+ * slashes on every platform, so a caller comparing against porcelain output
+ * needs this form rather than the host-separator one above.
+ */
+export const WORKTREE_STATE_FILE_POSIX = '.moflo/worktree.json';
 
 /**
  * Turn a branch name into a single flat directory name. Both separators are
@@ -127,16 +135,44 @@ function realpathBestEffort(target: string): string {
 }
 
 /**
- * Is `candidate` inside `root`? Both sides are realpath'd first — the #1145
- * shape, where an unresolved `/var/folders/...` compared against a resolved
+ * A canonical key for path identity: realpath'd, and case-folded on the two
+ * platforms whose filesystems are case-insensitive by default.
+ *
+ * Exported so a caller scanning a list resolves its needle ONCE and compares
+ * keys, rather than realpathing both sides on every iteration. Case-folding is
+ * what makes plain string equality safe here — `C:\Repo` and `C:\repo` are the
+ * same directory on Windows, and `/Users/x/Repo` and `/Users/x/repo` are the
+ * same directory on stock APFS.
+ */
+export function resolveForCompare(target: string): string {
+  const resolved = realpathBestEffort(target);
+  return process.platform === 'win32' || process.platform === 'darwin'
+    ? resolved.toLowerCase()
+    : resolved;
+}
+
+/**
+ * Do two paths name the same location? Realpaths both sides — the #1145 shape,
+ * where an unresolved `/var/folders/...` compared against a resolved
  * `/private/var/folders/...` on macOS made two identical paths look different.
  */
+export function samePath(a: string, b: string): boolean {
+  return resolveForCompare(a) === resolveForCompare(b);
+}
+
+/**
+ * Is `candidate` inside `root`? Both sides are realpath'd first, for the same
+ * reason as {@link samePath}.
+ */
 export function isInside(root: string, candidate: string): boolean {
-  const resolvedRoot = realpathBestEffort(root);
-  const resolvedCandidate = realpathBestEffort(candidate);
+  const resolvedRoot = resolveForCompare(root);
+  const resolvedCandidate = resolveForCompare(candidate);
   if (resolvedCandidate === resolvedRoot) return true;
   const rel = path.relative(resolvedRoot, resolvedCandidate);
-  return rel.length > 0 && !rel.startsWith('..') && !path.isAbsolute(rel);
+  // No `rel.length > 0` guard: `path.relative` returns '' for two spellings of
+  // the SAME directory that the equality check above missed, and treating that
+  // as "not inside" would break every identity test built on this.
+  return !rel.startsWith('..') && !path.isAbsolute(rel);
 }
 
 /**
@@ -158,17 +194,31 @@ function expandCopyEntry(primaryRoot: string, entry: string): string[] {
   }
   const dir = path.join(primaryRoot, ...normalized.slice(0, -1));
   if (!existsSync(dir)) return [];
-  // Anchor both ends so `.env.*` cannot match `my.env.backup`, and escape every
-  // regex metacharacter except the `*` we are translating.
-  const pattern = new RegExp(`^${last.split('*').map(escapeRegExp).join('[^\\\\/]*')}$`);
+  // Reuse the guidance retriever's translator rather than hand-rolling one: it
+  // is anchored, escapes every metacharacter, and was already hardened for the
+  // `docs/*.md` matching `docsXmd` bug. Its `*` becomes `[^/]*`, which is exact
+  // here because these patterns match bare readdir NAMES, never a path.
+  const pattern = globToRegExp(last);
   return readdirSync(dir)
     .filter(name => pattern.test(name))
     .sort()
     .map(name => path.join(dir, name));
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+/**
+ * Does a config entry escape `root` before any symlink resolution?
+ *
+ * Deliberately LEXICAL, unlike {@link isInside}. "Did the user write a path that
+ * climbs out of the tree" is a property of the string they wrote, and resolving
+ * it first gets the answer wrong in the normal case: on a re-add, the worktree's
+ * `node_modules` is already a symlink into the primary checkout, so realpathing
+ * the destination reports it as outside the worktree and rejects a link that is
+ * exactly the one provisioning just made. A primary checkout whose own
+ * `node_modules` is a symlink (pnpm, a shared store) fails the same way.
+ */
+function escapesRoot(root: string, entry: string): boolean {
+  const rel = path.relative(root, path.resolve(root, entry));
+  return rel.startsWith('..') || path.isAbsolute(rel);
 }
 
 /**
@@ -246,7 +296,19 @@ function runLink(
   const linkType = linkTypeForPlatform(process.platform);
   for (const entry of entries) {
     const source = path.resolve(primaryRoot, entry);
-    const dest = path.join(worktreePath, entry);
+    const dest = path.resolve(worktreePath, entry);
+    // Guard BOTH ends against an escaping entry: `link: ["../x"]` would
+    // otherwise source from outside the checkout and write the link outside the
+    // worktree. Lexical on purpose — see escapesRoot().
+    if (escapesRoot(primaryRoot, entry) || escapesRoot(worktreePath, entry)) {
+      steps.push({
+        kind: 'link',
+        target: entry,
+        status: 'failed',
+        detail: 'resolves outside the primary checkout or the worktree',
+      });
+      continue;
+    }
     if (!existsSync(source)) {
       steps.push({ kind: 'link', target: entry, status: 'skipped', detail: 'no such path' });
       continue;

--- a/src/cli/services/worktree-provision.ts
+++ b/src/cli/services/worktree-provision.ts
@@ -1,0 +1,382 @@
+/**
+ * Worktree provisioning (#1481).
+ *
+ * `/flo -wt` and `flo worktree add` create a git worktree; on its own that is a
+ * valid checkout and an unrunnable workspace — no `node_modules`, none of the
+ * gitignored `.env` files, and no notion that a second worktree's dev servers
+ * will collide with the first on fixed ports. This service closes that gap,
+ * driven by the optional `worktree:` block in `moflo.yaml`.
+ *
+ * Every platform-sensitive decision lives here rather than in the command, so
+ * the Windows-vs-POSIX branches are reachable from a unit test (Rule #1):
+ *   - paths built with `path.*`, never separator concatenation
+ *   - directory links are junctions on Windows (no admin/developer mode needed,
+ *     and the target must be absolute), plain symlinks on POSIX
+ *   - copies via `fs.cpSync`; no `cp`/`ln -s`/`mkdir -p`/`find` shell-outs
+ *   - `setup` runs through a shell on both platforms (it is a user-authored
+ *     command string, not an argv array) — see `runSetup`
+ *   - containment checks realpath BOTH sides before comparing (#1145: macOS
+ *     `/var/folders` vs `/private/var/folders` otherwise false-positives)
+ */
+
+import { spawnSync } from 'node:child_process';
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  symlinkSync,
+} from 'node:fs';
+import path from 'node:path';
+import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
+
+/** The `worktree:` block from `moflo.yaml`. Every key optional. */
+export interface WorktreeConfig {
+  dir?: string;
+  copy?: string[];
+  link?: string[];
+  setup?: string;
+}
+
+/** Contents of `.moflo/worktree.json` inside a moflo-created worktree. */
+export interface WorktreeState {
+  branch: string;
+  index: number;
+  primaryRoot: string;
+  provisioned: boolean;
+}
+
+/** One thing provisioning did (or declined to do), for human + `--json` output. */
+export interface ProvisionStep {
+  kind: 'copy' | 'link' | 'setup';
+  target: string;
+  status: 'done' | 'skipped' | 'failed';
+  detail?: string;
+}
+
+export interface ProvisionResult {
+  provisioned: boolean;
+  steps: ProvisionStep[];
+}
+
+/** Relative path of the per-worktree state file, from the worktree root. */
+export const WORKTREE_STATE_FILE = path.join('.moflo', 'worktree.json');
+
+/**
+ * Turn a branch name into a single flat directory name. Both separators are
+ * replaced: a branch is always `/`-delimited, but a caller may hand us a
+ * Windows-style string, and `\` is invalid in an NTFS directory name anyway.
+ */
+export function slugifyBranch(branch: string): string {
+  return branch.replace(/[\\/]/g, '-');
+}
+
+/**
+ * Resolve where a worktree for `branch` belongs.
+ *
+ * Default: `<repo-parent>/<repo-basename>-worktrees/<slugged-branch>` — a
+ * sibling of the checkout, so it is never inside the repo (and so never picked
+ * up by the repo's own tooling). `configuredDir` overrides the parent directory
+ * and is resolved relative to `repoRoot` when relative.
+ */
+export function computeWorktreePath(
+  repoRoot: string,
+  branch: string,
+  configuredDir?: string,
+): string {
+  const parent = configuredDir
+    ? path.resolve(repoRoot, configuredDir)
+    : path.join(path.dirname(repoRoot), `${path.basename(repoRoot)}-worktrees`);
+  return path.join(parent, slugifyBranch(branch));
+}
+
+/**
+ * Smallest non-negative integer not already taken. Reusing a freed slot (rather
+ * than incrementing a counter) keeps the index small and stable, which matters
+ * because consumers offset fixed ports from it — an unbounded counter would
+ * eventually push a derived port out of range.
+ */
+export function allocateIndex(existing: readonly number[]): number {
+  const taken = new Set(existing.filter(n => Number.isInteger(n) && n >= 0));
+  let candidate = 0;
+  while (taken.has(candidate)) candidate++;
+  return candidate;
+}
+
+/**
+ * Resolve a path as far as it exists. `realpathSync` throws on a missing path,
+ * but a containment check must still work for a destination that has not been
+ * created yet — so walk up to the nearest existing ancestor, resolve that, and
+ * re-append the remainder.
+ */
+function realpathBestEffort(target: string): string {
+  let current = path.resolve(target);
+  const trailing: string[] = [];
+  // Bounded by the path depth: each iteration removes one segment, and
+  // `path.dirname` is a fixed point at the filesystem root.
+  for (;;) {
+    if (existsSync(current)) return path.join(realpathSync(current), ...trailing.reverse());
+    const parent = path.dirname(current);
+    if (parent === current) return path.resolve(target);
+    trailing.push(path.basename(current));
+    current = parent;
+  }
+}
+
+/**
+ * Is `candidate` inside `root`? Both sides are realpath'd first — the #1145
+ * shape, where an unresolved `/var/folders/...` compared against a resolved
+ * `/private/var/folders/...` on macOS made two identical paths look different.
+ */
+export function isInside(root: string, candidate: string): boolean {
+  const resolvedRoot = realpathBestEffort(root);
+  const resolvedCandidate = realpathBestEffort(candidate);
+  if (resolvedCandidate === resolvedRoot) return true;
+  const rel = path.relative(resolvedRoot, resolvedCandidate);
+  return rel.length > 0 && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+/**
+ * Expand one `copy:` entry against the primary checkout.
+ *
+ * Glob support is deliberately narrow — a single `*` in the final segment, so
+ * `.env.*` works — because the alternative is either a shell-out (`find` does
+ * not exist on Windows) or a full tree walk on a pattern the user thought was
+ * cheap. A pattern needing more than this returns nothing rather than silently
+ * matching a subset; the caller reports it as skipped.
+ */
+function expandCopyEntry(primaryRoot: string, entry: string): string[] {
+  const normalized = entry.split(/[\\/]/).filter(Boolean);
+  if (normalized.length === 0) return [];
+  const last = normalized[normalized.length - 1];
+  if (!last.includes('*')) {
+    const full = path.join(primaryRoot, ...normalized);
+    return existsSync(full) ? [full] : [];
+  }
+  const dir = path.join(primaryRoot, ...normalized.slice(0, -1));
+  if (!existsSync(dir)) return [];
+  // Anchor both ends so `.env.*` cannot match `my.env.backup`, and escape every
+  // regex metacharacter except the `*` we are translating.
+  const pattern = new RegExp(`^${last.split('*').map(escapeRegExp).join('[^\\\\/]*')}$`);
+  return readdirSync(dir)
+    .filter(name => pattern.test(name))
+    .sort()
+    .map(name => path.join(dir, name));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Copy the configured gitignored material into the new worktree.
+ *
+ * Sources are guarded on both ends: each must resolve inside the primary
+ * checkout (so `../secrets` is rejected), and the destination is always the
+ * worktree we just created. A missing source is skipped rather than fatal —
+ * `.env.local` legitimately does not exist on every machine.
+ */
+function runCopy(
+  primaryRoot: string,
+  worktreePath: string,
+  entries: readonly string[],
+): ProvisionStep[] {
+  const steps: ProvisionStep[] = [];
+  for (const entry of entries) {
+    if (!isInside(primaryRoot, path.resolve(primaryRoot, entry))) {
+      steps.push({
+        kind: 'copy',
+        target: entry,
+        status: 'failed',
+        detail: 'resolves outside the primary checkout',
+      });
+      continue;
+    }
+    const matches = expandCopyEntry(primaryRoot, entry);
+    if (matches.length === 0) {
+      steps.push({ kind: 'copy', target: entry, status: 'skipped', detail: 'no match' });
+      continue;
+    }
+    for (const source of matches) {
+      const dest = path.join(worktreePath, path.relative(primaryRoot, source));
+      try {
+        mkdirSync(path.dirname(dest), { recursive: true });
+        cpSync(source, dest, { recursive: true });
+        steps.push({ kind: 'copy', target: path.relative(primaryRoot, source), status: 'done' });
+      } catch (error) {
+        steps.push({
+          kind: 'copy',
+          target: path.relative(primaryRoot, source),
+          status: 'failed',
+          detail: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+  return steps;
+}
+
+/**
+ * The `fs.symlinkSync` type argument for a directory link on this platform.
+ *
+ * Windows gets a junction: unlike a `'dir'` symlink it needs no admin rights or
+ * developer mode. Exported and pure so the Windows branch is assertable from a
+ * unit test on any host — the alternative, spying on an ESM `fs` export, is not
+ * possible, and gating the assertion on a Windows runner would leave the branch
+ * unverified on the two CI legs that run most often.
+ */
+export function linkTypeForPlatform(platform: NodeJS.Platform): 'junction' | undefined {
+  return platform === 'win32' ? 'junction' : undefined;
+}
+
+/**
+ * Link the configured paths from the primary checkout into the new worktree.
+ * The target is resolved to an ABSOLUTE path before the call on every platform:
+ * a relative target silently produces a broken junction on Windows.
+ */
+function runLink(
+  primaryRoot: string,
+  worktreePath: string,
+  entries: readonly string[],
+): ProvisionStep[] {
+  const steps: ProvisionStep[] = [];
+  const linkType = linkTypeForPlatform(process.platform);
+  for (const entry of entries) {
+    const source = path.resolve(primaryRoot, entry);
+    const dest = path.join(worktreePath, entry);
+    if (!existsSync(source)) {
+      steps.push({ kind: 'link', target: entry, status: 'skipped', detail: 'no such path' });
+      continue;
+    }
+    // lstat, not existsSync: a broken symlink left by an earlier run still
+    // occupies the name, and clobbering it is not ours to decide.
+    let occupied = false;
+    try {
+      lstatSync(dest);
+      occupied = true;
+    } catch {
+      occupied = false;
+    }
+    if (occupied) {
+      steps.push({ kind: 'link', target: entry, status: 'skipped', detail: 'already exists' });
+      continue;
+    }
+    try {
+      mkdirSync(path.dirname(dest), { recursive: true });
+      symlinkSync(source, dest, linkType);
+      steps.push({ kind: 'link', target: entry, status: 'done' });
+    } catch (error) {
+      steps.push({
+        kind: 'link',
+        target: entry,
+        status: 'failed',
+        detail: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return steps;
+}
+
+/**
+ * Run the configured `setup` command inside the new worktree.
+ *
+ * `shell: true` on BOTH platforms, unlike the daemon-spawning code this repo
+ * models elsewhere. That rule ("shell on Windows, detached on POSIX") is about
+ * spawning a known binary with an argv array; `setup` is a user-authored shell
+ * command *string* from `moflo.yaml` — `npm ci && npm run build` is a legitimate
+ * value, and it needs `cmd.exe` or `/bin/sh` to mean anything. Running it
+ * without a shell would exec a file literally named `npm ci && npm run build`.
+ * On Windows a shell is required regardless, since `npm` there is `npm.cmd`.
+ * Trust boundary: the same as a `package.json` script — the project's own config.
+ *
+ * `jsonMode` sends the child's stdout to our stderr so a `--json` caller still
+ * gets parseable JSON on stdout.
+ */
+function runSetup(
+  worktreePath: string,
+  command: string,
+  index: number,
+  jsonMode: boolean,
+): ProvisionStep {
+  const result = spawnSync(command, {
+    cwd: worktreePath,
+    shell: true,
+    stdio: jsonMode ? ['ignore', 2, 2] : 'inherit',
+    env: { ...process.env, MOFLO_WORKTREE_INDEX: String(index) },
+  });
+  if (result.error) {
+    return { kind: 'setup', target: command, status: 'failed', detail: result.error.message };
+  }
+  if (result.status !== 0) {
+    return {
+      kind: 'setup',
+      target: command,
+      status: 'failed',
+      detail: `exited with code ${result.status ?? 'null'}`,
+    };
+  }
+  return { kind: 'setup', target: command, status: 'done' };
+}
+
+/**
+ * Provision a freshly created worktree: copy, then link, then setup.
+ *
+ * Order matters — `setup` (typically `npm ci`) may depend on the `.env` files
+ * `copy` brings in, and must not race the `link` that would otherwise supply
+ * `node_modules`. A failed step never unwinds the worktree: it is a valid
+ * checkout either way, and deleting a tree the user may have started working in
+ * is far worse than leaving it under-provisioned.
+ */
+export function provisionWorktree(opts: {
+  primaryRoot: string;
+  worktreePath: string;
+  branch: string;
+  index: number;
+  config?: WorktreeConfig;
+  /** Send `setup` output to stderr so stdout stays parseable JSON. */
+  jsonMode?: boolean;
+}): ProvisionResult {
+  const { primaryRoot, worktreePath, branch, index, config, jsonMode = false } = opts;
+  const steps: ProvisionStep[] = [];
+
+  if (config?.copy?.length) steps.push(...runCopy(primaryRoot, worktreePath, config.copy));
+  if (config?.link?.length) steps.push(...runLink(primaryRoot, worktreePath, config.link));
+  if (config?.setup) steps.push(runSetup(worktreePath, config.setup, index, jsonMode));
+
+  const provisioned = steps.every(step => step.status !== 'failed');
+  writeWorktreeState(worktreePath, { branch, index, primaryRoot, provisioned });
+  return { provisioned, steps };
+}
+
+/** Write `.moflo/worktree.json` into a worktree. Atomic — the daemon may read it. */
+export function writeWorktreeState(worktreePath: string, state: WorktreeState): void {
+  const statePath = path.join(worktreePath, WORKTREE_STATE_FILE);
+  mkdirSync(path.dirname(statePath), { recursive: true });
+  atomicWriteFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+/**
+ * Read a worktree's moflo state. `null` means moflo did not create this tree —
+ * which is exactly how `flo worktree list` reports an externally-created
+ * worktree as unprovisioned, so a malformed file is treated the same as a
+ * missing one rather than failing the listing.
+ */
+export function readWorktreeState(worktreePath: string): WorktreeState | null {
+  const statePath = path.join(worktreePath, WORKTREE_STATE_FILE);
+  if (!existsSync(statePath)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(statePath, 'utf8')) as Partial<WorktreeState>;
+    if (typeof parsed.branch !== 'string' || !Number.isInteger(parsed.index)) return null;
+    return {
+      branch: parsed.branch,
+      index: parsed.index as number,
+      primaryRoot: typeof parsed.primaryRoot === 'string' ? parsed.primaryRoot : '',
+      provisioned: parsed.provisioned === true,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/cli/services/worktree-provision.ts
+++ b/src/cli/services/worktree-provision.ts
@@ -152,17 +152,10 @@ export function resolveForCompare(target: string): string {
 }
 
 /**
- * Do two paths name the same location? Realpaths both sides — the #1145 shape,
- * where an unresolved `/var/folders/...` compared against a resolved
- * `/private/var/folders/...` on macOS made two identical paths look different.
- */
-export function samePath(a: string, b: string): boolean {
-  return resolveForCompare(a) === resolveForCompare(b);
-}
-
-/**
- * Is `candidate` inside `root`? Both sides are realpath'd first, for the same
- * reason as {@link samePath}.
+ * Is `candidate` inside `root`? Both sides go through
+ * {@link resolveForCompare} first — the #1145 shape, where an unresolved
+ * `/var/folders/...` compared against a resolved `/private/var/folders/...` on
+ * macOS made two identical paths look different.
  */
 export function isInside(root: string, candidate: string): boolean {
   const resolvedRoot = resolveForCompare(root);
@@ -411,6 +404,36 @@ export function provisionWorktree(opts: {
   const provisioned = steps.every(step => step.status !== 'failed');
   writeWorktreeState(worktreePath, { branch, index, primaryRoot, provisioned });
   return { provisioned, steps };
+}
+
+/**
+ * Did `copy:`/`link:` put this worktree-relative path there?
+ *
+ * Lives here, next to {@link provisionWorktree}, because answering it needs the
+ * same glob translation provisioning used: a raw config entry is not a filename.
+ * Comparing `.env.*` literally against the `.env.local` git reports never
+ * matches, which would blame provisioning's own files on the user.
+ *
+ * Every ancestor prefix is tested, so a directory entry (glob or literal) also
+ * claims the files inside it — `git status -uall` reports those individually.
+ *
+ * @param target a path in git's spelling (forward slashes), relative to the worktree
+ */
+export function isProvisionedPath(target: string, config?: WorktreeConfig): boolean {
+  const entries = [...(config?.copy ?? []), ...(config?.link ?? [])]
+    .map(entry => entry.split(/[\\/]/).filter(Boolean).join('/'))
+    .filter(Boolean);
+  if (entries.length === 0) return false;
+
+  const segments = target.split('/').filter(Boolean);
+  for (const entry of entries) {
+    const matcher = entry.includes('*') ? globToRegExp(entry) : null;
+    for (let depth = 1; depth <= segments.length; depth++) {
+      const prefix = segments.slice(0, depth).join('/');
+      if (matcher ? matcher.test(prefix) : prefix === entry) return true;
+    }
+  }
+  return false;
 }
 
 /** Write `.moflo/worktree.json` into a worktree. Atomic — the daemon may read it. */

--- a/tests/guards/worktree-skill-wiring-1481.test.ts
+++ b/tests/guards/worktree-skill-wiring-1481.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Guard: the `/flo -wt` skill drives `flo worktree add`, not a hand-rolled
+ * `git worktree add` (#1481).
+ *
+ * `.claude/skills/fl/phases.md` ships to every consumer (`.claude/skills/**` is
+ * in the package `files` list, and `fl` is in `ALWAYS_INSTALLED_SKILLS`), so the
+ * recipe it carries runs on Linux, macOS and Windows dev boxes alike. The inline
+ * version it replaced computed the worktree path with an embedded `node -e` one-
+ * liner and shelled `git worktree add` — unlinted, untypechecked, untestable
+ * string logic on the exact axis Rule #1 governs, and it provisioned nothing, so
+ * the resulting tree had no `node_modules` and none of the gitignored `.env`
+ * files.
+ *
+ * Reverting to the inline form would be invisible in review (the markdown reads
+ * plausibly either way) and would silently drop provisioning for every consumer.
+ * This guard makes that regression loud.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const PHASES = join(process.cwd(), '.claude', 'skills', 'fl', 'phases.md');
+
+describe('#1481 /flo -wt drives the worktree command', () => {
+  const text = readFileSync(PHASES, 'utf8');
+
+  it('instructs the agent to run `flo worktree add`', () => {
+    expect(text).toMatch(/flo worktree add/);
+  });
+
+  it('carries no raw `git worktree add -b` recipe', () => {
+    // The command owns branch creation now; a raw recipe here bypasses
+    // provisioning and the tested path computation.
+    expect(text).not.toMatch(/git worktree add\s+-b/);
+  });
+
+  it('computes no worktree path inline', () => {
+    // The `-worktrees` sibling-directory convention lives in
+    // computeWorktreePath(); a second copy in markdown will drift from it.
+    expect(text).not.toMatch(/node -e[^\n]*worktrees/);
+  });
+
+  it('documents `flo worktree remove` as the cleanup path', () => {
+    expect(text).toMatch(/flo worktree remove/);
+  });
+
+  it('tells the agent to read the JSON `path` rather than guess the location', () => {
+    expect(text).toMatch(/flo worktree add[^\n]*--json/);
+    expect(text).toMatch(/`path`/);
+  });
+});

--- a/tests/guards/worktree-skill-wiring-1481.test.ts
+++ b/tests/guards/worktree-skill-wiring-1481.test.ts
@@ -29,16 +29,47 @@ describe('#1481 /flo -wt drives the worktree command', () => {
     expect(text).toMatch(/flo worktree add/);
   });
 
-  it('carries no raw `git worktree add -b` recipe', () => {
-    // The command owns branch creation now; a raw recipe here bypasses
-    // provisioning and the tested path computation.
-    expect(text).not.toMatch(/git worktree add\s+-b/);
+  it('reaches for the command BEFORE any raw git recipe', () => {
+    // The command owns branch creation. A raw `git worktree add -b` is allowed
+    // only as the documented fallback for a `flo` older than these skills — so
+    // what matters is ordering: the command must be the primary path.
+    const command = text.indexOf('flo worktree add');
+    const raw = text.search(/git worktree add\s+-b/);
+    expect(command).toBeGreaterThan(-1);
+    if (raw !== -1) expect(command).toBeLessThan(raw);
   });
 
-  it('computes no worktree path inline', () => {
-    // The `-worktrees` sibling-directory convention lives in
-    // computeWorktreePath(); a second copy in markdown will drift from it.
-    expect(text).not.toMatch(/node -e[^\n]*worktrees/);
+  it('confines any raw recipe to the fallback section', () => {
+    const raw = text.search(/git worktree add\s+-b/);
+    if (raw === -1) return;
+    const fallback = text.indexOf('**Fallback');
+    // A raw recipe outside the fallback is the regression this guards: it
+    // bypasses provisioning and the tested path computation silently.
+    expect(fallback).toBeGreaterThan(-1);
+    expect(raw).toBeGreaterThan(fallback);
+  });
+
+  it('tells the agent the fallback leaves the tree unprovisioned', () => {
+    // Without this the agent silently continues into a run whose tests fail for
+    // want of node_modules, with no idea why.
+    expect(text).toMatch(/Unknown command: worktree/);
+    expect(text).toMatch(/no `node_modules`/);
+  });
+
+  it('binds the repo root to the worktree call itself', () => {
+    // `flo worktree` resolves the repo from cwd. Run from the wrong directory
+    // it targets a different repository entirely — and the cwd reset makes that
+    // the DEFAULT outcome in Claude Code, not an edge case.
+    expect(text).toMatch(/cd "<repo-root>" && flo worktree add/);
+  });
+
+  it('warns that a bare cd does not persist between Bash calls', () => {
+    // Claude Code resets the Bash cwd to the project root after every call, so
+    // `cd <path>` then `npm test` runs in the PRIMARY checkout and the run looks
+    // green while producing an empty PR. The skill must bind the directory to
+    // each command instead.
+    expect(text).toMatch(/bare `cd` does not stick/i);
+    expect(text).toMatch(/git -C/);
   });
 
   it('documents `flo worktree remove` as the cleanup path', () => {


### PR DESCRIPTION
Closes #1481.

## Why

`/flo -wt` and Conductor are the same primitive — git worktrees plus Claude Code — and moflo already matched it on memory: durable learnings converge across a repo's worktrees automatically, and `memory.hydrate_from` / `snapshot_to` cover the structural cold-start with a documented recipe. **The memory half was already done.**

The gap was **provisioning**. `phases.md` §3.2 computed a path with an inline `node -e` and shelled `git worktree add`; the result is a valid checkout and an unrunnable workspace — no `node_modules`, none of the gitignored `.env` files, and dev servers that collide with the primary checkout on fixed ports. That is what Conductor's per-workspace setup script buys, and it is a gap moflo can close in its own CLI.

## What

`flo worktree add | list | remove` (alias `wt`), driven by an optional `worktree:` block in `moflo.yaml`:

```yaml
worktree:
  dir: ../myrepo-worktrees   # default: <repo-parent>/<repo>-worktrees
  copy: [".env", ".env.*"]   # gitignored files copied from the primary checkout
  link: ["node_modules"]     # symlinked (junctioned on Windows) from the primary
  setup: "npm ci"            # run in the new worktree, MOFLO_WORKTREE_INDEX in env
```

`/flo -wt` now drives `flo worktree add --json` instead of the inline recipe.

**Ports.** moflo cannot rewrite a project's hardcoded ports, so it does not pretend to. Each worktree gets a small stable integer — unique among live worktrees, reused when one is removed, preserved across a re-add — exposed as `MOFLO_WORKTREE_INDEX` to the `setup` command. Offsetting from it is the consumer's call.

## Consumer impact (Rule #2)

**Surface touched:** a new lazy-loaded CLI command; a new optional `MofloConfig` key plus its `moflo.yaml` template comment; `.claude/skills/fl/phases.md`, which ships to every consumer.

**Failure mode for someone upgrading: none by design.** `worktree:` is optional, an existing `moflo.yaml` parses unchanged, and with the block absent `add` creates the worktree and provisions nothing — behaviourally identical to the recipe it replaced. No migration, no `.moflo/` format change. That is AC5, and it has four dedicated tests rather than being a side-assertion.

**Round-trip:** publish + reinstall. Both surfaces run from `node_modules/moflo/`, and the session-start launcher re-syncs `.claude/skills/` from the installed package. Everything below was exercised against the source tree via `bin/cli.js`; the installed path is not yet proven.

## Deliberate deviation from the reviewed plan

The plan specified `shell: true` on Windows only for `setup`. That would be a bug: `setup` is a user-authored shell command *string* (`npm ci && npm run build`), not an argv array, so it needs a shell on both platforms — without one, Node execs a file literally named `npm ci && npm run build`. The repo's "shell on Windows, detached on POSIX" rule governs spawning a known binary with an argv array, which this is not. Implemented as `shell: true` on both, documented at the call site.

## Explicitly out of scope

- Rewriting a consumer's hardcoded ports — moflo cannot know which files hold which ports.
- Choosing a `node_modules` strategy. `link:` and `setup:` are both offered; neither is a default, because a symlinked root `node_modules` is fragile under npm workspaces.
- A workspace dashboard. `/luminarium` exists; the gap was provisioning, not observability.

## Review findings fixed

A DEEP three-agent pass ran on the first commit. Bugs it caught, all mine, all fixed with a pinning test:

- **Index reassignment on re-add** — the allocator was fed a list that included the worktree being re-added, so a second `add` handed it a *new* index and rewrote `worktree.json`, silently shifting every port a consumer had derived from it.
- **`isInside(x, x)` could return false** — a `rel.length > 0` guard rejected the case where `path.relative` returns `''` for two spellings of the same directory (case differences on win32/APFS), breaking every identity check built on it. `resolveForCompare` now case-folds on win32/darwin so the hoisted string comparison is correct there.
- **The link guard rejected the normal case** — my own first version realpathed the destination, so a re-add (whose `node_modules` is already a symlink into the primary) and a primary using pnpm both read as escapes. The escape check is now lexical; identity checks keep realpath.
- **`--no-provision` was a silent no-op** — declared as a `no-`prefixed option name, which this repo's #1474 guard forbids for exactly that reason. Now the positive-name / `default: true` pattern.
- **Every managed worktree looked dirty** — its own untracked `.moflo/worktree.json` made `remove` always demand `--force`. Fixed; the first fix excused the whole `.moflo/` directory, which would have silently deleted un-pushed SDD specs under `.moflo/specs/`, so it now uses `-uall` and matches the one exact path.
- **`remove` destroyed gitignored files silently** — now names the ignored paths it discarded that provisioning did not create. Warns, never blocks: a project whose `setup` ran `npm ci` would otherwise be blocked on every removal.

A single-agent validation pass then reviewed those fixes and caught two more:

- **Glob attribution was broken in the new warning** — it compared raw config entries against the concrete filenames git reports, so `copy: [".env.*"]` never matched `.env.local` and blamed provisioning's own file on the user on every removal. Attribution now lives in `isProvisionedPath()` beside the provisioner, where the same glob translation is in scope, and tests every ancestor prefix so a directory entry claims the files inside it.
- **`samePath` was exported with no production caller** — the efficiency fix had replaced both comparisons with a hoisted key. Removed rather than shipped as dead weight.

Reuse and efficiency findings applied: `expandCopyEntry` now calls the already-hardened `globToRegExp` instead of a hand-rolled translator; `WorktreeConfig` is declared once, in the service that consumes it; `add`/`remove` resolve their needle once rather than realpathing both sides per worktree; the fetch is skipped when an explicit `--from` already resolves locally, while the default path still fetches, since a stale base is the real hazard.

## Caught by re-checking the standing considerations at the simplify gate

Three defects that were all in the shipped skill and docs, not the code — the surfaces that are
easiest to review as "just prose" and hardest to notice when wrong:

- **The dogfood window breaks `/flo -wt`.** The `flo` on PATH is 4.12.12 and has no `worktree`
  command, while the committed `phases.md` now tells the agent to run it — so between merge and
  publish, and for any consumer whose `flo` binary lags their synced `.claude/skills`, the flag
  would simply fail. The skill now falls back to a plain `git worktree add` and says provisioning
  was skipped, rather than dying.
- **`cd` does not persist between Bash calls in Claude Code.** The instruction to "cd to the
  worktree and run every remaining phase from there" — which the *original* text also carried —
  silently ran every later phase in the primary checkout: green tests, empty PR. The skill now binds
  the directory to each command (`cd X && cmd`, `git -C X`, absolute paths for edits), including to
  the `flo worktree` call itself, which resolves its repo from cwd.
- **README had no coverage.** Adds a Provisioned worktrees section (config table, the port-index
  contract, the secret caveat), a Worktrees block in the command list, and a subsection on driving
  it from inside a Claude session.

## Testing

92 tests across three files — unit (path/index/copy/link/config/platform), integration against real temporary git repos, and a guard that `phases.md` cannot regress to the inline recipe.

Full suite **11,382 passed / 0 failed**; lint clean.

Beyond the suites, the command was driven end-to-end from inside a live Claude session against
temporary git repositories: create-and-provision, work committed in the worktree and confirmed
absent from the primary checkout, dirty-tree refusal, forced removal, index reuse after free, and
index preservation across a re-add. The README's port-offset example was executed verbatim and
produced non-colliding ports (3000 and 3020) across two worktrees, and every `flo worktree`
invocation in the README, the skill and the CLI reference was cross-checked against the command's
declared subcommands and options.

**Not yet verified, and not claimed:** the Windows and macOS CI legs have not run — the junction branch is asserted through a pure exported function on Linux rather than executed on a Windows host, which is the honest limit of a unit test here. Per Rule #1 these need reading before merge. The installed-package path needs publish + reinstall.
<details>
<summary>📋 SDD spec &amp; plan</summary>

### Spec — Make moflo worktrees provisioned workspaces (reviewed)

# Spec: Make moflo worktrees provisioned workspaces

## Problem

`/flo -wt` and Conductor are the same primitive — git worktrees plus Claude Code. moflo already
matches Conductor on capability and on memory: durable learnings converge across a repo's worktrees
automatically via `<git-common-dir>/moflo/durable.db`, and `memory.hydrate_from` + `memory.snapshot_to`
(#1244, epic #1231) already cover the structural cold-start with a documented Conductor recipe.

What moflo does not do is **provision**. `.claude/skills/fl/phases.md` § 3.2 computes a sibling path
with an inline `node -e` and shells `git worktree add`. The result is a valid checkout and an
unrunnable workspace: no `node_modules`, none of the gitignored `.env*` files, and no notion that a
second worktree running dev servers will collide with the first on hardcoded ports. A developer who
reaches for `-wt` on anything beyond a typecheck-only ticket hits that wall immediately and does the
setup by hand, every time.

Felt by: anyone running two or more tickets concurrently in one repo. Why now: #1481 asked whether
Conductor buys anything `-wt` lacks; the answer is "per-workspace setup", and that is a gap moflo
can close in its own CLI rather than by adopting another tool.

## Goal & non-goals

- **Goal:** a first-class `flo worktree` command that owns worktree lifecycle *and* provisioning,
  driven by an optional `worktree:` block in `moflo.yaml`, so that a worktree created by `/flo -wt`
  is runnable without manual setup.
- **Non-goals:**
  - Rewriting a consumer's hardcoded ports. moflo cannot know which files hold which ports; the
    contract stops at handing the workspace a stable index the consumer's own setup command offsets from.
  - Choosing a `node_modules` strategy on the consumer's behalf. `link:` and `setup:` are both
    offered; neither is a default. A symlinked root `node_modules` is known-fragile under npm
    workspaces — that is a per-project call.
  - A workspace dashboard or UI. `/luminarium` exists; the gap is provisioning, not observability.
  - Changing anything about memory sharing across worktrees. Already shipped and out of scope.

## Scope

- **MVP:**
  1. `src/cli/services/worktree-provision.ts` — path computation, index allocation, copy, link, setup.
  2. `src/cli/commands/worktree.ts` — `add` / `list` / `remove`, registered in `commands/index.ts`.
  3. Optional `worktree?: { dir?, copy?, link?, setup? }` on `MofloConfig`, parsed absent-tolerantly,
     documented in the generated `moflo.yaml` template.
  4. `.claude/skills/fl/phases.md` § 3.2 rewritten to drive `flo worktree add --json`.
  5. Tests: unit (path/index/copy/link/config), plus a guard that the skill no longer carries the raw
     `git worktree add -b` recipe.
- **Out of scope:** everything under Non-goals; also `flo worktree` support for bare/detached
  worktrees and for repos with no `origin` remote beyond a clear error.

## Constraints

**Rule #1 — cross-platform.** This feature is almost entirely platform-sensitive filesystem work:

- Sibling worktree dir via `path.join`/`path.dirname`/`path.basename` — never separator concatenation.
  Branch `/` slugged to `-` so the directory is flat and valid on NTFS.
- Directory links: `fs.symlinkSync(absoluteTarget, linkPath, 'junction')` on Windows (junctions need
  an absolute target and, unlike `'dir'` symlinks, no admin/developer mode); default type on POSIX.
- File/dir copies via `fs.cpSync(..., { recursive: true })`. No `cp`, `ln -s`, `mkdir -p`, `find`.
- Any containment check ("is this copy source inside the primary checkout?", "is this path a
  registered worktree?") must `fs.realpathSync` **both** sides before comparing — the #1145 shape,
  where macOS `/var/folders` vs `/private/var/folders` false-positived an identity check.
- `setup` spawned with `spawn`, `shell: true` **only** on Windows (Node 24 DEP0190 requires quoted
  string args there); POSIX passes argv without a shell.
- Tests use `os.tmpdir()`; any port used in a test stays in 40000–44999.
- No `Foo.ts` beside `foo.ts`.

**Rule #2 — consumer blast radius.** Consumer surface touched: a new CLI command (reachable in every
consumer via `flo`), a new optional `MofloConfig` key plus its `moflo.yaml` template comment, and
`.claude/skills/fl/phases.md`, which `flo init` writes and the session-start launcher re-syncs into
every consumer's `.claude/skills/`. Failure mode for a consumer upgrading from the current version:
**none by design** — `worktree:` is optional, an existing `moflo.yaml` parses unchanged, and with the
block absent `flo worktree add` reproduces today's inline behaviour exactly (worktree created,
nothing provisioned). No migration; no `.moflo/` state format change. The new `.moflo/worktree.json`
is written only inside newly created worktrees, never into an existing checkout.

**Dogfooding.** Both the command and the skill markdown run from `node_modules/moflo/`. `flo worktree`
cannot be exercised in this repo until publish + reinstall, and a local edit to `phases.md` is
reverted by the session-start re-sync from the installed package. Source-tree tests alone do not
prove the shipped path; the round-trip is required before claiming it works end-to-end.

**Security.** `copy:` moves gitignored material — `.env` files hold secrets — into a directory
*outside* the repo. Two guards: copy sources must resolve (realpath, both sides) to inside the
primary checkout, so `../secrets` is rejected; and the destination is the worktree the command just
created, never an arbitrary `--path`.

## Acceptance Criteria

- [ ] **AC1** `flo worktree add <branch>` creates a worktree at
      `<repo-parent>/<repo-basename>-worktrees/<slugged-branch>`, branching off `origin/<default-branch>`
      by default or `--from <ref>` when given, and prints the resolved absolute path. `--json` emits
      `{ path, branch, index, provisioned }`.
- [ ] **AC2** `flo worktree list` enumerates the repo's worktrees with branch, path, and whether moflo
      provisioned them (an externally-created worktree shows as unprovisioned). `--json` emits the same
      as structured data.
- [ ] **AC3** `flo worktree remove <branch-or-path>` removes the worktree; refuses a dirty tree without
      `--force`; refuses any path that does not resolve back to a registered worktree of this repo.
- [ ] **AC4** An optional `moflo.yaml worktree:` block is honored on `add`, every key optional:
      `dir`, `copy`, `link`, `setup`. `copy` and `link` accept a string or an array; unknown keys are
      ignored rather than fatal.
- [ ] **AC5** A `moflo.yaml` with **no** `worktree:` block loads unchanged, and `flo worktree add` then
      creates the worktree and provisions nothing — behaviourally identical to today's inline recipe.
- [ ] **AC6** `add` writes `.moflo/worktree.json` in the new tree recording
      `{ branch, index, primaryRoot, provisioned }`, and exports `MOFLO_WORKTREE_INDEX` into the
      `setup` command's environment. The index is unique among live worktrees and reuses a freed slot
      rather than growing unbounded.
- [ ] **AC7** A `copy` source that resolves outside the primary checkout is rejected; a `copy` source
      that does not exist is skipped without failing the run; `link` does not clobber an existing path
      in the new tree.
- [ ] **AC8** Rule #1 holds throughout, verified by test: Windows link creation requests `'junction'`,
      POSIX does not; no `cp`/`ln`/`mkdir -p` shell-outs; every path built with `path.*`; both sides
      realpath'd on containment checks.
- [ ] **AC9** `.claude/skills/fl/phases.md` § 3.2 drives `-wt` through `flo worktree add --json` and
      documents `flo worktree remove` as cleanup; a guard test asserts the raw `git worktree add -b`
      recipe is gone from that file.
- [ ] **AC10** `flo worktree --help` and the generated `moflo.yaml` template document the new surface.

## Constitution
Invariants this work must respect live in the project's constitution layer, by
reference — do not restate them here:
- `CLAUDE.md` (root + nearest directory-scoped)
- `.claude/guidance/`

### Plan (reviewed)

# Plan: Make moflo worktrees provisioned workspaces

## Approach

Split the work along the repo's existing seam: a **pure service** holding every platform-sensitive
decision, and a **thin command** that parses flags, calls the service, and formats output. This is the
`sdd.ts` / `src/cli/sdd/` shape already in the tree, and it is what makes Rule #1 testable — the
Windows-vs-POSIX branches live in functions a unit test can call directly, rather than inside a
command action that needs a real git repo and a real `flo` invocation to reach.

- `src/cli/services/worktree-provision.ts` — `computeWorktreePath`, `allocateIndex`, `provision`
  (copy → link → setup), `readWorktreeState`, plus the containment guard. No `Command` types, no
  output formatting, no `process.exit`.
- `src/cli/commands/worktree.ts` — `add` / `list` / `remove` subcommands; owns `git` invocations via
  `spawnSync` and `--json` rendering.

**Alternatives considered.** (a) Put provisioning in the `/flo -wt` skill markdown as inline `node -e`:
rejected — Rule #1 logic in an unlinted, untestable, un-typechecked string is exactly the fragility the
rule exists to prevent, and the user chose the full command. (b) Reuse `flo init`'s file-writing
machinery for copy/link: rejected — `init` writes *generated* content into a project it owns; this
copies *existing* user files between two checkouts, a different trust boundary with a different guard
(the realpath containment check). Sharing the code would couple two unrelated blast radii.

**Registration.** Mirror `sdd`: an entry in `commandLoaders` in `src/cli/commands/index.ts`
(lazy-loaded, not in the synchronous `commands` array) so CLI startup cost is unchanged.

## Steps

1. **Config surface.** Add optional `worktree?: { dir?: string; copy?: string[]; link?: string[];
   setup?: string }` to `MofloConfig` in `src/cli/config/moflo-config.ts`. Parse absent-tolerantly in
   the loader: block missing → key stays `undefined`; `copy`/`link` given as a bare string → coerced to
   a one-element array; unknown sub-keys ignored. Add the documented comment block to the generated
   `moflo.yaml` template alongside the existing `memory:` block. **(AC4, AC5)**

2. **Service: path + index.** `computeWorktreePath(repoRoot, branch, cfgDir?)` →
   `path.join(cfgDir ?? path.join(path.dirname(repoRoot), path.basename(repoRoot) + '-worktrees'),
   branch.replace(/[\\/]/g, '-'))`. `allocateIndex(existingIndices)` → smallest non-negative integer not
   in use, so a removed worktree's slot is reused. Both pure, both trivially testable on either
   separator convention. **(AC1, AC6)**

3. **Service: containment guard.** `assertInsidePrimary(primaryRoot, candidate)` — `fs.realpathSync`
   **both** sides, then compare with `path.relative` (`!rel.startsWith('..') && !path.isAbsolute(rel)`).
   Used for every `copy` source. This is the #1145 shape; the test must cover a symlinked tempdir so
   macOS `/var/folders` → `/private/var/folders` is exercised, not just Linux. **(AC7, AC8)**

4. **Service: provision.** In order — copy, link, setup:
   - **copy**: expand each entry (literal path, or a glob resolved with the existing Glob machinery /
     `fs.readdirSync` filter — *not* a shell `find`), guard each source with step 3, skip missing
     sources with a warning, `fs.cpSync(src, dest, { recursive: true })`.
   - **link**: skip if the destination already exists; otherwise `fs.symlinkSync(absoluteTarget,
     linkPath, process.platform === 'win32' ? 'junction' : undefined)`.
   - **setup**: `spawn` with `cwd` = new worktree, `env` = `{ ...process.env, MOFLO_WORKTREE_INDEX:
     String(index) }`, and `shell: true` **only** on `win32`. Non-zero exit → `provisioned: false` in the
     result, worktree left in place (it is a valid checkout regardless). **(AC6, AC7, AC8)**

5. **Service: state file.** Write `.moflo/worktree.json` (`{ branch, index, primaryRoot, provisioned }`)
   into the new tree via the existing `atomicWriteFileSync`, creating `.moflo/` with
   `fs.mkdirSync(..., { recursive: true })`. `readWorktreeState(dir)` returns `null` for a worktree moflo
   did not create — that is how `list` reports "unprovisioned". **(AC2, AC6)**

6. **Command: `add`.** Resolve repo root (`findProjectRoot`), resolve the base ref (`--from`, else
   `origin/<default branch>` via `git symbolic-ref refs/remotes/origin/HEAD` with a `gh repo view`
   fallback — the pattern already in `commands/github.ts:120`), `git fetch origin <branch>`,
   `git worktree add -b <branch> <path> <base>`, then `provision`. Print the path; `--json` emits
   `{ path, branch, index, provisioned }`. Existing-path case reuses the tree rather than deleting it
   (today's skill behaviour). **(AC1)**

7. **Command: `list` / `remove`.** `list` parses `git worktree list --porcelain` and annotates each
   entry with `readWorktreeState`. `remove` resolves the argument as a branch *or* a path, matches it
   against the porcelain listing (realpath both sides), refuses anything unmatched, checks
   `git status --porcelain` in the target and refuses non-empty without `--force`, then
   `git worktree remove [--force]`. **(AC2, AC3)**

8. **Register.** `worktree: () => import('./worktree.js')` in `commandLoaders`; confirm
   `flo worktree --help` renders and `hasCommand('worktree')` is true. **(AC10)**

9. **Skill wiring.** Rewrite `.claude/skills/fl/phases.md` § 3.2 to call `flo worktree add "<branch>"
   --json`, read `path` from the JSON, `cd` there, and document `flo worktree remove` as cleanup.
   Delete the inline `node -e` path computation and the raw `git worktree add -b` line. **(AC9)**

10. **Tests** under `src/cli/__tests__/` (unit, mirroring `sdd/`) plus a guard test for the skill file.
    Every test uses `os.tmpdir()` and real temp git repos; the Windows link branch is asserted by
    spying on the `symlinkSync` type argument rather than by requiring a Windows host, so the
    assertion is meaningful on the Linux/macOS CI legs too.

11. **Docs.** `flo worktree --help` examples; the `moflo.yaml` template comment; a short section in the
    guidance doc that already covers worktree workspaces, pointing at provisioning. **(AC10)**

## Verification

- **AC1** (add / path / `--from` / `--json`) → unit test on `computeWorktreePath` for both separator
  conventions and the `dir` override, plus an integration test creating a real temp git repo and
  running the `add` action, asserting the worktree exists at the computed path and the JSON shape.
- **AC2** (list) → integration test: create one worktree via `flo worktree add` and one via raw
  `git worktree add`; assert `list --json` marks the first provisioned and the second not.
- **AC3** (remove) → integration test: remove by branch and by path both succeed; a dirty tree is
  refused without `--force` and removed with it; an unrelated path is refused.
- **AC4** (config honored) → unit test on the loader with a `worktree:` block using a string for `copy`
  and an array for `link`, plus an unknown sub-key; assert the parsed shape and that no throw occurs.
- **AC5** (no-block parity) → unit test loading a `moflo.yaml` with no `worktree:` block (assert
  `config.worktree === undefined`), plus an integration `add` against it asserting the worktree is
  created and nothing was copied, linked, or run. This is the consumer-upgrade case — it is the AC that
  proves the change is non-breaking, so it gets its own explicit test, not a side-assertion.
- **AC6** (state file + index) → unit test on `allocateIndex` (fresh, sequential, reuse-after-free);
  integration test asserting `.moflo/worktree.json` contents and that the `setup` command observes
  `MOFLO_WORKTREE_INDEX` in its env (setup command is `node -e` writing its env value to a file).
- **AC7** (copy guards) → unit tests: `../secrets` rejected, missing source skipped without throwing,
  existing link destination not clobbered.
- **AC8** (Rule #1) → unit test spying on `symlinkSync` asserting `'junction'` under a mocked
  `process.platform === 'win32'` and no type arg otherwise; a static guard test grepping the two new
  source files for `cp `, `ln -s`, `mkdir -p`, `rm -rf`, and hardcoded `/tmp`; the realpath test from
  AC7 run through a symlinked tempdir.
- **AC9** (skill wiring) → guard test asserting `phases.md` § 3.2 contains `flo worktree add` and does
  **not** contain `git worktree add -b`.
- **AC10** (docs) → assert `flo worktree --help` exits 0 and lists all three subcommands; assert the
  generated `moflo.yaml` template contains the `worktree:` comment block.
- **Whole change** → `npm run build`, `npm run lint`, `node scripts/test-runner.mjs`, and the
  cross-platform smoke harness result on the **macOS and Ubuntu** CI legs, not just the local Linux run.

## Risks

- **Dogfood round-trip masks breakage.** `flo worktree` runs from `node_modules/moflo/`, so nothing in
  this repo exercises the shipped command until publish + reinstall, and a local `phases.md` edit is
  reverted by the session-start re-sync from the installed package. *Mitigation:* verify against the
  source tree via the CLI entry (`node bin/cli.js worktree …`) rather than the installed `flo`, state
  plainly in the PR that the installed-path check is post-publish, and do not claim end-to-end
  verification of the `-wt` skill flow before that round-trip.
- **`copy:` relocates secrets.** `.env` material lands in a directory outside the repo, which is not
  covered by the repo's `.gitignore`. *Mitigation:* the containment guard limits *sources*; the
  destination is always the just-created worktree; document plainly in the template comment that
  `copy:` moves secrets and that the worktree dir should not itself be a git repo the user commits.
  Not mitigated: a user pointing `dir:` somewhere shared. Documented, not prevented.
- **Symlinked `node_modules` under npm workspaces is fragile.** *Mitigation:* `link:` is opt-in with no
  default, and the template comment says so. Out of scope to solve.
- **Glob expansion without shelling out.** Needs care to stay cross-platform and to not walk the whole
  tree on a pattern like `.env.*`. *Mitigation:* restrict glob support to a single trailing `*` within
  one directory level for the MVP; a pattern needing more is a follow-up, not a silent partial match.
- **Windows junction target must be absolute.** A relative target silently produces a broken junction.
  *Mitigation:* resolve to absolute before the call and assert it in the AC8 test.

</details>
